### PR TITLE
Qt EditorAreaPane: Change linux next/prev tab keybinding to Ctrl+PgUp/Dow

### DIFF
--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -44,8 +44,15 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
         self.control.installEventFilter(self._filter)
 
         # Add shortcuts for scrolling through tabs.
-        next_seq = 'Ctrl+}' if sys.platform == 'darwin' else 'Alt+n'
-        prev_seq = 'Ctrl+{' if sys.platform == 'darwin' else 'Alt+p' 
+        if sys.platform == 'darwin':
+            next_seq = 'Ctrl+}'
+            prev_seq = 'Ctrl+{'
+        elif sys.platform.startswith('linux'):
+            next_seq = 'Ctrl+PgDown'
+            prev_seq = 'Ctrl+PgUp'
+        else:
+            next_seq = 'Alt+n'
+            prev_seq = 'Alt+p'
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(next_seq), self.control)
         shortcut.activated.connect(self._next_tab)
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(prev_seq), self.control)

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -44,8 +44,15 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         control.tabCloseRequested.connect(self._close_requested)
 
         # Add shortcuts for scrolling through tabs.
-        next_seq = 'Ctrl+}' if sys.platform == 'darwin' else 'Alt+n'
-        prev_seq = 'Ctrl+{' if sys.platform == 'darwin' else 'Alt+p' 
+        if sys.platform == 'darwin':
+            next_seq = 'Ctrl+}'
+            prev_seq = 'Ctrl+{'
+        elif sys.platform.startswith('linux'):
+            next_seq = 'Ctrl+PgDown'
+            prev_seq = 'Ctrl+PgUp'
+        else:
+            next_seq = 'Alt+n'
+            prev_seq = 'Alt+p'
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(next_seq), self.control)
         shortcut.activated.connect(self._next_tab)
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(prev_seq), self.control)


### PR DESCRIPTION
Qt EditorAreaPane: Change linux next/prev tab keybinding to Ctrl+PgUp/Down
This is the most common default on most linux applications: gnome-terminal,
gedit, nautilus, firefox, eclipse etc.
