### PR TITLE
BUG: FileDialog wildcard seems to have redundant text in filter.

### DIFF
--- a/pyface/ui/qt4/file_dialog.py
+++ b/pyface/ui/qt4/file_dialog.py
@@ -68,7 +68,7 @@ class FileDialog(MFileDialog, Dialog):
         else:
             pattern = ' '.join(extension)
 
-        return "%s (%s)|%s|" % (description, pattern, pattern)
+        return "%s (%s)" % (description, pattern)
 
     ###########################################################################
     # Protected 'IDialog' interface.


### PR DESCRIPTION
The file-extensions are to be enclosed in parenthesis.  Additionally,
they seem to be enclosed in pipe characters which seems to be
redundant.

A quick look at the documentation (and a search) doesn't tell me anything about what the pipe characters are doing.  Removing them seems to work for me.  Someone more familiar with this, could look into it. 
