### PR TITLE
BUG: Work around broken enums in PySide 1.0.8

### DIFF
--- a/pyface/ui/qt4/dialog.py
+++ b/pyface/ui/qt4/dialog.py
@@ -25,12 +25,12 @@ from window import Window
 
 # Map PyQt dialog related constants to the pyface equivalents.
 _RESULT_MAP = {
-    QtGui.QDialog.Accepted:     OK,
-    QtGui.QDialog.Rejected:     CANCEL,
-    QtGui.QMessageBox.Ok:       OK,
-    QtGui.QMessageBox.Cancel:   CANCEL,
-    QtGui.QMessageBox.Yes:      YES,
-    QtGui.QMessageBox.No:       NO
+    int(QtGui.QDialog.Accepted):     OK,
+    int(QtGui.QDialog.Rejected):     CANCEL,
+    int(QtGui.QMessageBox.Ok):       OK,
+    int(QtGui.QMessageBox.Cancel):   CANCEL,
+    int(QtGui.QMessageBox.Yes):      YES,
+    int(QtGui.QMessageBox.No):       NO
 }
 
 

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -18,7 +18,7 @@ AREA_MAP = { 'left'   : QtCore.Qt.LeftDockWidgetArea,
              'right'  : QtCore.Qt.RightDockWidgetArea,
              'top'    : QtCore.Qt.TopDockWidgetArea,
              'bottom' : QtCore.Qt.BottomDockWidgetArea }
-INVERSE_AREA_MAP = dict((v, k) for k, v in AREA_MAP.iteritems())
+INVERSE_AREA_MAP = dict((int(v), k) for k, v in AREA_MAP.iteritems())
 
 
 class DockPane(TaskPane, MDockPane):
@@ -150,7 +150,7 @@ class DockPane(TaskPane, MDockPane):
 
     def _receive_dock_area(self, area):
         with self._signal_context():
-            self.dock_area = INVERSE_AREA_MAP[area]
+            self.dock_area = INVERSE_AREA_MAP[int(area)]
 
     def _receive_floating(self, floating):
         with self._signal_context():

--- a/pyface/ui/qt4/tasks/task_window_backend.py
+++ b/pyface/ui/qt4/tasks/task_window_backend.py
@@ -86,7 +86,7 @@ class TaskWindowBackend(MTaskWindowBackend):
 
         # Extract the window's corner configuration.
         for name, corner in CORNER_MAP.iteritems():
-            area = INVERSE_AREA_MAP[self.control.corner(corner)]
+            area = INVERSE_AREA_MAP[int(self.control.corner(corner))]
             setattr(layout, name + '_corner', area)
             
         return layout


### PR DESCRIPTION
A change was introduced in PySide 1.0.8 which makes enums basically unusable as dictionary keys: http://bugs.pyside.org/show_bug.cgi?id=1033
