### PR TITLE
BUG: Windows qt wildcard for all files should be *

### DIFF
--- a/pyface/ui/qt4/file_dialog.py
+++ b/pyface/ui/qt4/file_dialog.py
@@ -58,6 +58,9 @@ class FileDialog(MFileDialog, Dialog):
     # 'MFileDialog' *CLASS* interface.
     ###########################################################################
 
+    # In Windows, Qt needs only a * while wx needs a *.*
+    WILDCARD_ALL = "All files (*)|*"
+
     @classmethod
     def create_wildcard(cls, description, extension):
         """ Creates a wildcard for a given extension. """


### PR DESCRIPTION
wx requires _._ to be the wildcard for all files on Windows, but Qt
needs it to be just a *.
