### PR TITLE
BF: Handle view being closed through close button

### DIFF
--- a/pyface/ui/qt4/workbench/workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/workbench_window_layout.py
@@ -459,6 +459,8 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
             dw.setObjectName(view.id)
             dw.connect(dw.toggleViewAction(), QtCore.SIGNAL('toggled(bool)'),
                     self._qt4_handle_dock_visibility)
+            dw.connect(dw, QtCore.SIGNAL('visibilityChanged(bool)'),
+                    self._qt4_handle_dock_visibility)
 
             # Save the dock window.
             view._qt4_dock = dw
@@ -512,7 +514,11 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
             except AttributeError:
                 continue
 
-            if dw.toggleViewAction() is dw.sender():
+            sender = dw.sender()
+            if (sender is dw.toggleViewAction() or
+                sender in dw.children()):
+                # Toggling the action or pressing the close button on
+                # the view
                 v.visible = checked
 
     def _qt4_monitor(self, control):


### PR DESCRIPTION
I'm not sure of the best way of capturing the visibility change when the user closes the view using the close button. This seems to work without any side-effects - I'm open to suggestions for better implementations. The main issue is the visibilityChanged signal seems to be fired for a lot more than just showing/hiding the dockwidget - namely docking/undocking and focus changes also trigger it (see http://doc.qt.nokia.com/latest/qdockwidget.html#visibilityChanged)
