### PR TITLE
ENH: Added size_state trait to Window for maximized information.

### DIFF
--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -291,7 +291,8 @@ class TaskWindow(ApplicationWindow):
     def get_window_layout(self):
         """ Returns a TaskWindowLayout for the current state of the window.
         """
-        result = TaskWindowLayout(position=self.position, size=self.size)
+        result = TaskWindowLayout(position=self.position, size=self.size,
+                                  size_state=self.size_state)
         for state in self._states:
             if state == self._active_state:
                 result.active_task = state.task.id
@@ -308,6 +309,7 @@ class TaskWindow(ApplicationWindow):
         # Set window size before laying it out.
         self.position = window_layout.position
         self.size = window_layout.size
+        self.size_state = window_layout.size_state
 
         # Store layouts for the tasks, including the active task.
         for layout in window_layout.items:
@@ -318,7 +320,7 @@ class TaskWindow(ApplicationWindow):
                 state.layout = layout
             else:
                 logger.warn("Cannot apply layout for task %r: task does not "
-                            "belong to the window." % task)
+                            "belong to the window." % layout.id)
 
         # Attempt to activate the requested task.
         state = self._get_state(window_layout.get_active_task())

--- a/pyface/tasks/task_window_layout.py
+++ b/pyface/tasks/task_window_layout.py
@@ -1,5 +1,5 @@
 # Enthought library imports.
-from traits.api import Either, List, Str, Tuple
+from traits.api import Either, List, Str, Tuple, Enum
 
 # Local imports.
 from task_layout import LayoutContainer, TaskLayout
@@ -21,6 +21,8 @@ class TaskWindowLayout(LayoutContainer):
 
     # The size of the window.
     size = Tuple(800, 600)
+
+    size_state = Enum('normal', 'maximized')
 
     def get_active_task(self):
         """ Returns the ID of the active task in the layout, or None if there is

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -125,18 +125,11 @@ class ApplicationWindow(MApplicationWindow, Window):
         self._create_trim_widgets(self.control)
 
     def _create_control(self, parent):
-        control = QtGui.QMainWindow(parent)
+        control = super(ApplicationWindow, self)._create_control(parent)
         control.setObjectName('ApplicationWindow')
-
-        if self.position != (-1, -1):
-            control.move(*self.position)
-
-        if self.size != (-1, -1):
-            control.resize(*self.size)
 
         control.setAnimated(False)
         control.setDockNestingEnabled(True)
-        control.setWindowTitle(self.title)
 
         return control
 


### PR DESCRIPTION
Window now has `size_state` trait which is synced to the window's
maximized state and also stored in the task's persistent layout.

Also added a default _create_control() method to Window (which is close
to the implementation of ApplicationWindow's _create_control) to make it
easier to create window without needing an application and which can
set the window's size_state correctly.
