### PR TITLE
No control fix

### DIFF
--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -491,7 +491,7 @@ class EditorAreaWidget(QtGui.QMainWindow):
         """ Assign focus to the active editor, if possible.
         """
         active_editor = self.editor_area.active_editor
-        if active_editor:
+        if active_editor and active_editor.control:
             set_focus(active_editor.control)
 
     ###########################################################################


### PR DESCRIPTION
Don't explode if the active editor doesn't have a control.
