### PR TITLE
BUG: Only pass the minimum size if it is valid.

### DIFF
--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -68,7 +68,9 @@ class DockPane(TaskPane, MDockPane):
 
         # For some reason the QDockWidget doesn't respect the minimum size
         # of its widgets
-        control.setMinimumSize(contents.minimumSize())
+        minsize = contents.minimumSize()
+        if minsize.isValid():
+            control.setMinimumSize(minsize)
 
         # Hide the control by default. Otherwise, the widget will visible in its
         # parent immediately!


### PR DESCRIPTION
Qt will print annoying error messages if it is not. This shows up frequently when undocking and redocking `DockPanes` because often the widget contents have not been laid out yet and do not have a minimum size.
