### PR TITLE
BUG: Fix the minimum size handling for QDockWidgets.

### DIFF
--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -540,6 +540,13 @@ class EditorWidget(QtGui.QDockWidget):
         self.setWidget(editor.control)
         self.update_title()
 
+        # Update the minimum size.
+        contents_minsize = editor.control.minimumSize()
+        style = self.style()
+        contents_minsize.setHeight(contents_minsize.height()
+            + style.pixelMetric(style.PM_DockWidgetHandleExtent))
+        self.setMinimumSize(contents_minsize)
+
         self.dockLocationChanged.connect(self.update_title_bar)
         self.visibilityChanged.connect(self.update_title_bar)
 

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -68,7 +68,11 @@ class DockPane(TaskPane, MDockPane):
 
         # For some reason the QDockWidget doesn't respect the minimum size
         # of its widgets
-        control.setMinimumSize(contents.minimumSize())
+        contents_minsize = contents.minimumSize()
+        style = control.style()
+        contents_minsize.setHeight(contents_minsize.height()
+            + style.pixelMetric(style.PM_DockWidgetHandleExtent))
+        control.setMinimumSize(contents_minsize)
 
         # Hide the control by default. Otherwise, the widget will visible in its
         # parent immediately!


### PR DESCRIPTION
This helps pass through the minimum size information from `QDockWidget` contents to the `QDockWidget` itself. It will help avoid passing bad size information to the `QMainWindow` layout and noisy warnings.
