### PR TITLE
BUG: Set the active editor to None when all of the editors are removed.

### DIFF
--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -109,6 +109,8 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
         self.editors.remove(editor)
         self.control.remove_editor_widget(editor_widget)
         editor.editor_area = None
+        if not self.editors:
+            self.active_editor = None
 
     ###########################################################################
     # 'IAdvancedEditorAreaPane' interface.

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -111,6 +111,8 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         editor.destroy()
         editor.editor_area = None
         self._update_tab_bar()
+        if not self.editors:
+            self.active_editor = None
 
     ###########################################################################
     # Protected interface.


### PR DESCRIPTION
When the last editor is removed, the `active_editor` attribute still held a reference. This fix removes that.
