### PR TITLE
[Delivers 37296157] CLN: Clean-up of drag/drop logic

### DIFF
--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -125,6 +125,7 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
         requested
         """
         menu = Menu()
+        splitter = None
 
         for tabwidget in self.tabwidgets():
             # obtain tabwidget's bounding rectangle in global coordinates


### PR DESCRIPTION
- Added a `drop_handler` Callable trait to AdvancedEditorAreaPane which decides if the file can be handled, if yes, returns a handler, else None.
- File drop handling using `file_drop_extensions` is provided merely as a backwards compatibility option - the recommended way is to use `drop_handler`.
- Drag now carries a `PyMimeData` constructed on a `TabDragObject`, instead of the previous global `drag_info` implementation.

Works only with the following PR on traitsui: https://github.com/enthought/traitsui/pull/83 
