### PR TITLE
[Delivers 37472681] FIX: Shows tab tooltip correctly.

### DIFF
--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -81,8 +81,9 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
         """
         editor.editor_area = self
         editor.create(self.active_tabwidget)
-        index = self.active_tabwidget.addTab(editor.control, 
-                                            self._get_label(editor))
+        self.active_tabwidget.addTab(editor.control, 
+                                    self._get_label(editor))
+        index = self.active_tabwidget.indexOf(editor.control)
         self.active_tabwidget.setTabToolTip(index, editor.tooltip)
         self.editors.append(editor)
 


### PR DESCRIPTION
Tab tooltip was not showing correctly since the index value was goofed up in the presence of an empty widget.
