### PR TITLE
BUG: Task window set_layout causes dock panes unresizable.

### DIFF
--- a/pyface/ui/qt4/tasks/main_window_layout.py
+++ b/pyface/ui/qt4/tasks/main_window_layout.py
@@ -285,7 +285,13 @@ class MainWindowLayout(HasTraits):
         QWIDGETSIZE_MAX = (1 << 24) - 1 # Not exposed by Qt bindings.
         for child in self.control.children():
             if isinstance(child, QtGui.QDockWidget):
-                child.widget().setFixedSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
+                child.widget().setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
+                child.widget().setMinimumSize(0, 0)
+                # QDockWidget somehow manages to set its own
+                # min/max sizes and hence that too needs to be reset.
+                child.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
+                child.setMinimumSize(0, 0)
+
 
 
 class MainWindowLayoutError(ValueError):


### PR DESCRIPTION
set_layout would set the dock to really large fixed size which
would make the dock panes' non resizable to any smaller value
than set in the layout. QDockWidget unfortunately inherits
the minimumSize from its child widget and hence _reset_fixed_sizes()
must also reset it on the QDockWidget too.
