### PR TITLE
New design of empty pane + Cleaned up drag/drop

### DIFF
--- a/pyface/i_drop_handler.py
+++ b/pyface/i_drop_handler.py
@@ -1,4 +1,4 @@
-from traits.api import Interface, Instance
+from traits.api import Interface
 
 class IDropHandler(Interface):
 	""" Interface for a drop event handler, which provides API to check if the drop can

--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -5,7 +5,7 @@ import sys
 from pyface.tasks.i_editor_area_pane import IEditorAreaPane, \
     MEditorAreaPane
 from traits.api import implements, on_trait_change, Instance, Tuple, Callable, \
-    Property, Dict, Str, List, HasTraits
+    Property, Dict, Str, List, HasTraits, cached_property
 from pyface.qt import QtCore, QtGui
 from pyface.action.api import Action, Group
 from pyface.tasks.task_layout import PaneItem, Tabbed, Splitter
@@ -64,6 +64,7 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
         return [TabDropHandler(), 
                 FileDropHandler(extensions=self.file_drop_extensions)]
 
+    @cached_property
     def _get__all_drop_handlers(self):
         return self.drop_handlers + self._pvt_drop_handlers
 
@@ -846,7 +847,7 @@ class DraggableTabBar(QtGui.QTabBar):
         return super(DraggableTabBar, self).mouseReleaseEvent(event)        
 
 
-class TabDragObject:
+class TabDragObject(object):
     """ Class to hold information related to tab dragging/dropping
     """
 


### PR DESCRIPTION
This PR modifies the design of empty pane (that comes up when you create a split) based on UX inputs from Sri, and the following API clean-up:
- Adds a trait `drop_handlers` which accepts a list of handlers of the type `IDropHandler`. By default, two drop handlers - TabDropHandler, and FileDropHandler (for backwards compatibility) are provided.
- A `callbacks` trait provides a communication channel between the editor area pane and the editor.
- Option to create the empty widget by custom applications.
