### PR TITLE
contextMenuEvent is unneeded on the QTabBar - it's handled correctly by

### DIFF
--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -800,14 +800,6 @@ class DraggableTabBar(QtGui.QTabBar):
         self.setContextMenuPolicy(QtCore.Qt.DefaultContextMenu)
         self.drag_obj = None
 
-    def contextMenuEvent(self, event):
-        """ Re-implemented to provide split/collapse context menu on the tab bar. 
-        """
-        global_pos = self.mapToGlobal(event.pos())
-        menu = self.editor_area.get_context_menu(pos=global_pos)
-        qmenu = menu.create_menu(self)
-        qmenu.exec_(global_pos)
-
     def mousePressEvent(self, event):
         if event.button()==QtCore.Qt.LeftButton:
             index = self.tabAt(event.pos())


### PR DESCRIPTION
the QTabWidget
