### PR TITLE
REF: Refactor the drag-and-drop interface.

### DIFF
--- a/pyface/drop_handler.py
+++ b/pyface/drop_handler.py
@@ -6,16 +6,16 @@ class BaseDropHandler(HasTraits):
     """
     implements(IDropHandler)
 
-    # Returns True if the current drop handler can handle the given drag event 
+    ### BaseDropHandler interface #############################################
+
+    # Returns True if the current drop handler can handle the given drag event
     # occurring on the given target widget.
     on_can_handle = Callable
 
-    # Performs drop action when drop event occurs on target widget. Returns True 
-    # if it successfully handled the event, otherwise False. Does nothing if it 
-    # couldn't handle the event.
+    # Performs drop action when drop event occurs on target widget.
     on_handle = Callable
 
-    ### IDropHandler interface ##################################################
+    ### IDropHandler interface ################################################
 
     def can_handle_drop(self, event, target):
         return self.on_can_handle(event, target)
@@ -24,14 +24,20 @@ class BaseDropHandler(HasTraits):
         return self.on_handle(event, target)
 
 
-class FileDropHandler(BaseDropHandler):
+class FileDropHandler(HasTraits):
     """ Class to handle backward compatible file drop events
     """
+    implements(IDropHandler)
+
+    ### FileDropHandler interface #############################################
+
     # supported extensions
     extensions = List(Str)
 
     # Called when file is opened. Takes single argument: path of file
     open_file = Callable
+
+    ### IDropHandler interface ################################################
 
     def can_handle_drop(self, event, target):
         if event.mimeData().hasUrls():
@@ -42,11 +48,5 @@ class FileDropHandler(BaseDropHandler):
         return False
 
     def handle_drop(self, event, target):
-        if not self.can_handle_drop(event, target):
-            return False
-
-        accepted = False
         for url in event.mimeData().urls():
             self.open_file(url.toLocalFile())
-            accepted = True
-        return accepted

--- a/pyface/i_drop_handler.py
+++ b/pyface/i_drop_handler.py
@@ -1,17 +1,16 @@
 from traits.api import Interface
 
+
 class IDropHandler(Interface):
-	""" Interface for a drop event handler, which provides API to check if the drop can
-	be handled or not, and then handle it if possible.
-	"""
+    """ Interface for a drop event handler, which provides API to check if the
+    drop can be handled or not, and then handle it if possible.
+    """
 
-	def can_handle_drop(self, event, target):
-		""" Returns True if the current drop handler can handle the given drag event 
-		occurring on the given target widget.
-		"""
+    def can_handle_drop(self, event, target):
+        """ Returns True if the current drop handler can handle the given drag
+        event occurring on the given target widget.
+        """
 
-	def handle_drop(self, event, target):
-		""" Performs drop action when drop event occurs on target widget. Returns 
-		True if it successfully handled the event, otherwise False. Does nothing if 
-		it couldn't handle the event.
-		"""
+    def handle_drop(self, event, target):
+        """ Performs drop action when drop event occurs on target widget.
+        """


### PR DESCRIPTION
I'm doing this small step because it requires a change in
other applications.

Changes:
- `handle_drop` was calling can_handle_drop in every
  implementation, since it needed to check again that
  it can handle the drop event. Now use a more classical
  pattern:
  
  if handler.can_handle_drop(event):
      handler.handle_drop(event)
- dropEvent and dragEnterEvent do not return any value
  (PyQt4 complains)
- QTabBars are not pickle-able, set pickle=False in the
  PyMimeData definition
- clean up tab characters and line lengths in a couple
  of places
