### PR TITLE
BUG: active_tabwidget gets set to tabwidget of other editor areas.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -318,9 +318,11 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         """
         if new:
             if isinstance(new, DraggableTabWidget):
-                self.active_tabwidget = new
+                if new.editor_area == self:
+                    self.active_tabwidget = new
             elif isinstance(new, QtGui.QTabBar):
-                self.active_tabwidget = new.parent()
+                if new.parent().editor_area == self:
+                    self.active_tabwidget = new.parent()
             else:
                 # check if any of the editor widgets have focus.
                 # If yes, make it active


### PR DESCRIPTION
When there are multiple editor area panes being used, on focus change,
the active_tabwidget is sometimes set to a widget belonging to another
editor area.
