### PR TITLE
BUG: Checking for editor_area attribute of QTabBar instance crashes.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -321,7 +321,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
                 if new.editor_area == self:
                     self.active_tabwidget = new
             elif isinstance(new, QtGui.QTabBar):
-                if new.parent().editor_area == self:
+                if self.control.isAncestorOf(new):
                     self.active_tabwidget = new.parent()
             else:
                 # check if any of the editor widgets have focus.


### PR DESCRIPTION
When the widget in focus is not a DraggableTabBar, it won't have an
instance editor_area and the code in the previous commit crashes.
