### PR TITLE
FIX: Drag starting at the tab bar (not on any tab) created an invalid drag_obj.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -696,7 +696,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
 
         # generate label
         label = QtGui.QLabel(parent=frame)
-        label.setText("""<span style='font-size:14pt; color:#999999'>
+        label.setText("""<span style='font-size:14px; color:#999999'>
                         or
                         </span>""")
         layout.addWidget(label, alignment=QtCore.Qt.AlignHCenter)
@@ -714,7 +714,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
 
         # generate label
         label = QtGui.QLabel(parent=frame)
-        label.setText("""<span style='font-size:14pt; color:#999999'>
+        label.setText("""<span style='font-size:14px; color:#999999'>
                         Tip: You can also drag and drop files/tabs here.
                         </span>""")
         layout.addWidget(label, alignment=QtCore.Qt.AlignHCenter)


### PR DESCRIPTION
Instead, the drag_obj should be None, since this is not a valid drag.

This can cause applications to crash on the subsequent mousemove event.

Also, using px instead of pt for font-sizes. Using pt makes things look ugly on different screens.
