### PR TITLE
Destroy SplitEditorAreaPane empty_widget when removing.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -669,6 +669,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
         """
         index = self.indexOf(self.empty_widget)
         self.removeTab(index)
+        self.empty_widget.deleteLater()
         self.empty_widget = None
         self.setTabsClosable(True)
 


### PR DESCRIPTION
QTabWidget's removeTab only removes the tab from the tabs list,
so we need to explicitly destroy the empty_widget.
