### PR TITLE
TaskAction: Disconnect task dependent listeners for action.

### DIFF
--- a/pyface/tasks/action/task_action.py
+++ b/pyface/tasks/action/task_action.py
@@ -29,6 +29,11 @@ class TaskAction(ListeningAction):
     def _get_object(self):
         return self.task
 
+    def destroy(self):
+        # Disconnect listeners to task and dependent properties.
+        self.task = None
+        super(TaskAction, self).destroy()
+
 
 class TaskWindowAction(TaskAction):
     """ An Action that makes a callback to a Task's window.


### PR DESCRIPTION
This commit sets the TaskAction's task to None in .destroy() method,
so that task dependent trait listeners are disconnected.
Unless this is done, TraitChangeNotifyWrapper wrappers are
leaked on creating and deleting TaskAction instances which have
listeners on TaskAction dependent properties.
