### PR TITLE
Call event.Skip() in _wx_on_activate to allow Mac menubar to change

### DIFF
--- a/pyface/ui/wx/window.py
+++ b/pyface/ui/wx/window.py
@@ -143,6 +143,8 @@ class Window(MWindow, Widget):
         else:
             self.deactivated = self
 
+        event.Skip()
+
     def _wx_on_close(self, event):
         """ Called when the frame is being closed. """
 


### PR DESCRIPTION
The wx event handler for EVT_ACTIVATE needs the call to event.Skip() to allow the Mac menubar to be changed when switching among top level windows.

I have an example of the problem but it depends on the work I've been doing on adding wx support for tasks...

Anyway, for reference, see http://www.wxpython.org/docs/api/wx.ActivateEvent-class.html :

>Please note that usually you should call event.Skip() in your handlers for these events so the default handlers will still be called, as not doing so can result in strange effects.