### PR TITLE
keybindings update for other editor area classes

### DIFF
--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -47,12 +47,9 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         if sys.platform == 'darwin':
             next_seq = 'Ctrl+}'
             prev_seq = 'Ctrl+{'
-        elif sys.platform.startswith('linux'):
+        else:
             next_seq = 'Ctrl+PgDown'
             prev_seq = 'Ctrl+PgUp'
-        else:
-            next_seq = 'Alt+n'
-            prev_seq = 'Alt+p'
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(next_seq), self.control)
         shortcut.activated.connect(self._next_tab)
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(prev_seq), self.control)

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -253,12 +253,9 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         if sys.platform == 'darwin':
             next_seq = 'Ctrl+}'
             prev_seq = 'Ctrl+{'
-        elif sys.platform.startswith('linux'):
+        else:
             next_seq = 'Ctrl+PgDown'
             prev_seq = 'Ctrl+PgUp'
-        else:
-            next_seq = 'Alt+n'
-            prev_seq = 'Alt+p'
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(next_seq), self.control)
         shortcut.activated.connect(self._next_tab)
         shortcut = QtGui.QShortcut(QtGui.QKeySequence(prev_seq), self.control)


### PR DESCRIPTION
This PR changes other editor area classes to use Ctrl+PgUp/PgDown to match what was done in PR #99.
