### PR TITLE
Tab index bug fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ Fixes
 
 * Fixed wx 2.9 incompatibility bug in ProgressDialog (PR#106).
 
+* Tooltip for first editor of SplitEditorAreaPane was broken (PR#108)
+
+
 Release 4.4.0
 -------------
 

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -43,7 +43,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     #  'open': open file action (takes file_path as single argument)
     #  'open_dialog': show the open file dialog (responsibility of the callback,
     #     takes no argument), overrides 'open' callback
-    # They are used to create shortcut buttons for these actions in the empty 
+    # They are used to create shortcut buttons for these actions in the empty
     # pane that gets created when the user makes a split
     callbacks = Dict({}, key=Str, value=Callable)
 
@@ -59,14 +59,14 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     )
 
     def __private_drop_handlers_default(self):
-        """ By default, two private drop handlers are installed: 
+        """ By default, two private drop handlers are installed:
 
             1. For dropping of tabs from one pane to other
             2. For dropping of supported files from file-browser pane or outside
             the application
         """
-        return [TabDropHandler(), 
-                FileDropHandler(extensions=self.file_drop_extensions, 
+        return [TabDropHandler(),
+                FileDropHandler(extensions=self.file_drop_extensions,
                                 open_file=lambda path:self.trait_set(file_dropped=path))]
 
     @cached_property
@@ -96,8 +96,8 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
 
     def destroy(self):
         """ Destroy the toolkit-specific control that represents the pane.
-        """        
-        # disconnect application level focus change signals first, else it gives 
+        """
+        # disconnect application level focus change signals first, else it gives
         # weird runtime errors trying to access non-existent objects
         QtGui.QApplication.instance().focusChanged.disconnect(self._focus_changed)
 
@@ -134,6 +134,10 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         editor.create(self.active_tabwidget)
         index = self.active_tabwidget.addTab(editor.control,
                                              self._get_label(editor))
+        # There seem to be a bug in pyside or qt, where the index is set to 1
+        # when you create the first tab. This is a hack to fix it.
+        if self.active_tabwidget.count() == 1:
+            index = 0
         self.active_tabwidget.setTabToolTip(index, editor.tooltip)
         self.editors.append(editor)
 
@@ -154,7 +158,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     ##########################################################################
 
     def get_layout(self):
-        """ Returns a LayoutItem that reflects the current state of the 
+        """ Returns a LayoutItem that reflects the current state of the
         tabwidgets in the split framework.
         """
         return self.control.get_layout()
@@ -171,7 +175,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     def get_context_menu(self, pos):
         """ Returns a context menu containing split/collapse actions
 
-        pos : position (in global coordinates) where the context menu was 
+        pos : position (in global coordinates) where the context menu was
         requested
         """
         menu = Menu()
@@ -185,17 +189,17 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
             if global_rect.contains(pos):
                 splitter = tabwidget.parent()
 
-        # no split/collapse context menu for positions outside any tabwidget 
+        # no split/collapse context menu for positions outside any tabwidget
         # region
         if not splitter:
             return
 
         # add split actions (only show for non-empty tabwidgets)
         if not splitter.is_empty():
-            actions = [Action(id='split_hor', name='Create new pane to the right', 
+            actions = [Action(id='split_hor', name='Create new pane to the right',
                        on_perform=lambda : splitter.split(orientation=
                         QtCore.Qt.Horizontal)),
-                       Action(id='split_ver', name='Create new pane to the bottom', 
+                       Action(id='split_ver', name='Create new pane to the bottom',
                        on_perform=lambda : splitter.split(orientation=
                         QtCore.Qt.Vertical))]
 
@@ -214,7 +218,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
                     text = 'Merge with left pane'
                 else:
                     text = 'Merge with top pane'
-            actions = [Action(id='merge', name=text, 
+            actions = [Action(id='merge', name=text,
                         on_perform=lambda : splitter.collapse())]
 
             collapsegroup = Group(*actions, id='collapse')
@@ -295,7 +299,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         self._activate_tab(new_index)
 
     def tabwidgets(self):
-        """ Returns the list of tabwidgets associated with the current editor 
+        """ Returns the list of tabwidgets associated with the current editor
         area.
         """
         return self.control.tabwidgets()
@@ -353,10 +357,10 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
 ###############################################################################
 
 class EditorAreaWidget(QtGui.QSplitter):
-    """ Container widget to hold a QTabWidget which are separated by other 
-    QTabWidgets via splitters.  
-    
-    An EditorAreaWidget is essentially a Node object in the editor area layout 
+    """ Container widget to hold a QTabWidget which are separated by other
+    QTabWidgets via splitters.
+
+    An EditorAreaWidget is essentially a Node object in the editor area layout
     tree.
     """
 
@@ -370,37 +374,37 @@ class EditorAreaWidget(QtGui.QSplitter):
         """
         super(EditorAreaWidget, self).__init__(parent=parent)
         self.editor_area = editor_area
-        
+
         if not tabwidget:
-            tabwidget = DraggableTabWidget(editor_area=self.editor_area, 
+            tabwidget = DraggableTabWidget(editor_area=self.editor_area,
                                         parent=self)
 
         # add the tabwidget to the splitter
         self.addWidget(tabwidget)
         # showing the tabwidget after reparenting
         tabwidget.show()
-        
+
         # Initializes left and right children to None (since no initial splitter
-        # children are present) 
-        self.leftchild = None 
+        # children are present)
+        self.leftchild = None
         self.rightchild = None
 
     def get_layout(self):
-        """ Returns a LayoutItem that reflects the layout of the current 
+        """ Returns a LayoutItem that reflects the layout of the current
         splitter.
         """
-        ORIENTATION_MAP = {QtCore.Qt.Horizontal: 'horizontal', 
+        ORIENTATION_MAP = {QtCore.Qt.Horizontal: 'horizontal',
                            QtCore.Qt.Vertical: 'vertical'}
         # obtain layout based on children layouts
         if not self.is_leaf():
-            layout = Splitter(self.leftchild.get_layout(), 
+            layout = Splitter(self.leftchild.get_layout(),
                             self.rightchild.get_layout(),
                             orientation=ORIENTATION_MAP[self.orientation()])
         # obtain the Tabbed layout
         else:
             if self.is_empty():
-                layout = Tabbed(PaneItem(id=-1, 
-                                        width=self.width(), 
+                layout = Tabbed(PaneItem(id=-1,
+                                        width=self.width(),
                                         height=self.height()),
                                 active_tab=0)
             else:
@@ -412,8 +416,8 @@ class EditorAreaWidget(QtGui.QSplitter):
                     item_id = self.editor_area.editors.index(editor)
                     item_width = self.width()
                     item_height = self.height()
-                    items.append(PaneItem(id=item_id, 
-                                        width=item_width, 
+                    items.append(PaneItem(id=item_id,
+                                        width=item_width,
                                         height=item_height))
                 layout = Tabbed(*items, active_tab=self.tabwidget().currentIndex())
         return layout
@@ -421,7 +425,7 @@ class EditorAreaWidget(QtGui.QSplitter):
     def set_layout(self, layout):
         """ Applies the given LayoutItem to current splitter.
         """
-        ORIENTATION_MAP = {'horizontal': QtCore.Qt.Horizontal, 
+        ORIENTATION_MAP = {'horizontal': QtCore.Qt.Horizontal,
                            'vertical': QtCore.Qt.Vertical}
         # if not a leaf splitter
         if isinstance(layout, Splitter):
@@ -438,7 +442,7 @@ class EditorAreaWidget(QtGui.QSplitter):
                 self.resize(self.leftchild.width(), sum(sizes))
             self.setSizes(sizes)
 
-        # if it is a leaf splitter 
+        # if it is a leaf splitter
         elif isinstance(layout, Tabbed):
             # don't clear-out empty_widget's information if all it contains is an
             # empty_widget
@@ -448,13 +452,13 @@ class EditorAreaWidget(QtGui.QSplitter):
             for item in layout.items:
                 if not item.id==-1:
                     editor = self.editor_area.editors[item.id]
-                    self.tabwidget().addTab(editor.control, 
+                    self.tabwidget().addTab(editor.control,
                                             self.editor_area._get_label(editor))
                 self.resize(item.width, item.height)
             self.tabwidget().setCurrentIndex(layout.active_tab)
 
     def tabwidget(self):
-        """ Obtain the tabwidget associated with current EditorAreaWidget 
+        """ Obtain the tabwidget associated with current EditorAreaWidget
         (returns None for non-leaf splitters)
         """
         for child in self.children():
@@ -463,7 +467,7 @@ class EditorAreaWidget(QtGui.QSplitter):
         return None
 
     def tabwidgets(self):
-        """ Return a list of tabwidgets associated with current splitter or 
+        """ Return a list of tabwidgets associated with current splitter or
         any of its descendants.
         """
         tabwidgets = []
@@ -473,11 +477,11 @@ class EditorAreaWidget(QtGui.QSplitter):
         else:
             tabwidgets.extend(self.leftchild.tabwidgets())
             tabwidgets.extend(self.rightchild.tabwidgets())
-        
+
         return tabwidgets
 
     def sibling(self):
-        """ Returns another child of its parent. Returns None if it can't find 
+        """ Returns another child of its parent. Returns None if it can't find
         any sibling.
         """
         parent = self.parent()
@@ -500,7 +504,7 @@ class EditorAreaWidget(QtGui.QSplitter):
             return True
 
     def is_leaf(self):
-        """ Returns True if the current EditorAreaWidget is a leaf, i.e., it has 
+        """ Returns True if the current EditorAreaWidget is a leaf, i.e., it has
         a tabwidget as one of it's immediate child.
         """
         # a leaf has it's leftchild and rightchild None
@@ -509,33 +513,33 @@ class EditorAreaWidget(QtGui.QSplitter):
         return False
 
     def is_empty(self):
-        """ Returns True if the current splitter's tabwidget doesn't contain any 
+        """ Returns True if the current splitter's tabwidget doesn't contain any
         tab.
         """
         return bool(self.tabwidget().empty_widget)
 
     def is_collapsible(self):
-        """ Returns True if the current splitter can be collapsed to its sibling, 
+        """ Returns True if the current splitter can be collapsed to its sibling,
         i.e. if it is (a) either empty, or (b) it has a sibling which is a leaf.
         """
         if self.is_root():
             return False
-        
+
         if self.is_empty():
             return True
-        
+
         sibling = self.sibling()
-            
+
         if sibling.is_leaf():
             return True
         else:
             return False
 
     def split(self, orientation=QtCore.Qt.Horizontal):
-        """ Split the current splitter into two children splitters. The current 
-        splitter's tabwidget is moved to the left child while a new empty 
+        """ Split the current splitter into two children splitters. The current
+        splitter's tabwidget is moved to the left child while a new empty
         tabwidget is added to the right child.
-        
+
         orientation : whether to split horizontally or vertically
         """
         # set splitter orientation
@@ -554,23 +558,23 @@ class EditorAreaWidget(QtGui.QSplitter):
 
         # set equal sizes of splits
         self.setSizes([orig_size/2,orig_size/2])
-        
+
         # make the rightchild's tabwidget active & show its empty widget
         self.editor_area.active_tabwidget = self.rightchild.tabwidget()
 
     def collapse(self):
-        """ Collapses the current splitter and its sibling splitter to their 
-        parent splitter. Merges together the tabs of both's tabwidgets. 
+        """ Collapses the current splitter and its sibling splitter to their
+        parent splitter. Merges together the tabs of both's tabwidgets.
 
         Does nothing if the current splitter is not collapsible.
         """
         if not self.is_collapsible():
-            return 
+            return
 
         parent = self.parent()
         sibling = self.sibling()
 
-        # this will happen only if self is empty, else it will not be 
+        # this will happen only if self is empty, else it will not be
         # collapsible at all
         if sibling and (not sibling.is_leaf()):
             parent.setOrientation(sibling.orientation())
@@ -579,7 +583,7 @@ class EditorAreaWidget(QtGui.QSplitter):
             parent.addWidget(sibling.rightchild)
             parent.leftchild = sibling.leftchild
             parent.rightchild = sibling.rightchild
-            # blindly make the first tabwidget active as it is not clear which 
+            # blindly make the first tabwidget active as it is not clear which
             # tabwidget should get focus now (FIXME??)
             self.editor_area.active_tabwidget = parent.tabwidgets()[0]
             self.setParent(None)
@@ -599,20 +603,20 @@ class EditorAreaWidget(QtGui.QSplitter):
 
         # add tabs of left and right tabwidgets to target
         for source in (left, right):
-            # Note: addTab removes widgets from source tabwidget, so 
+            # Note: addTab removes widgets from source tabwidget, so
             # grabbing all the source widgets beforehand
             # (not grabbing empty_widget)
-            widgets = [source.widget(i) for i in range(source.count()) if not 
+            widgets = [source.widget(i) for i in range(source.count()) if not
                         source.widget(i) is source.empty_widget]
             for editor_widget in widgets:
                 editor = self.editor_area._get_editor(editor_widget)
-                target.addTab(editor_widget, 
-                            self.editor_area._get_label(editor))                    
+                target.addTab(editor_widget,
+                            self.editor_area._get_label(editor))
 
         # add target to parent
         parent.addWidget(target)
 
-        # make target the new active tabwidget and make the original focused 
+        # make target the new active tabwidget and make the original focused
         # widget active in the target too
         self.editor_area.active_tabwidget = target
         target.setCurrentWidget(orig_currentWidget)
@@ -622,14 +626,14 @@ class EditorAreaWidget(QtGui.QSplitter):
         parent.rightchild = None
         self.setParent(None)
         sibling.setParent(None)
-    
+
 
 class DraggableTabWidget(QtGui.QTabWidget):
     """ Implements a QTabWidget with event filters for tab drag and drop
     """
 
     def __init__(self, editor_area, parent):
-        """ 
+        """
         editor_area : global SplitEditorAreaPane instance
         parent : parent of the tabwidget
         """
@@ -657,7 +661,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
         self.show_empty_widget()
 
     def show_empty_widget(self):
-        """ Shows the empty widget (containing buttons to open new file, and 
+        """ Shows the empty widget (containing buttons to open new file, and
         collapse the split).
         """
         self.empty_widget = None
@@ -665,7 +669,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
 
         # callback to editor_area's public `create_empty_widget` Callable trait
         empty_widget = self.editor_area.create_empty_widget()
-        
+
         self.addTab(empty_widget, '')
         self.empty_widget = empty_widget
         self.setFocus()
@@ -673,11 +677,11 @@ class DraggableTabWidget(QtGui.QTabWidget):
         # don't allow tab closing if empty widget comes up on a root tabwidget
         if self.parent().is_root():
             self.setTabsClosable(False)
-            
+
         self.setTabText(0, '     ')
 
     def hide_empty_widget(self):
-        """ Hides the empty widget (containing buttons to open new file, and 
+        """ Hides the empty widget (containing buttons to open new file, and
         collapse the split) based on whether the tabwidget is empty or not.
         """
         index = self.indexOf(self.empty_widget)
@@ -687,7 +691,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
         self.setTabsClosable(True)
 
     def create_empty_widget(self):
-        """ Creates the QFrame object to be shown when the current tabwidget is 
+        """ Creates the QFrame object to be shown when the current tabwidget is
         empty.
         """
         frame = QtGui.QFrame(parent=self)
@@ -739,14 +743,14 @@ class DraggableTabWidget(QtGui.QTabWidget):
                         Tip: You can also drag and drop files/tabs here.
                         </span>""")
         layout.addWidget(label, alignment=QtCore.Qt.AlignHCenter)
-        
+
         layout.addStretch()
         frame.setLayout(layout)
 
         return frame
 
     def get_names(self):
-        """ Utility function to return names of all the editors open in the 
+        """ Utility function to return names of all the editors open in the
         current tabwidget.
         """
         names = []
@@ -764,7 +768,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
         """
         widget = self.widget(index)
 
-        # if close requested on empty_widget, collapse the pane and return 
+        # if close requested on empty_widget, collapse the pane and return
         if widget is self.empty_widget:
             self.parent().collapse()
             return
@@ -852,7 +856,7 @@ class DraggableTabBar(QtGui.QTabBar):
         return super(DraggableTabBar, self).mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
-        """ Re-implemented to create a drag event when the mouse is moved for a 
+        """ Re-implemented to create a drag event when the mouse is moved for a
         sufficient distance while holding down mouse button.
         """
         # go into the drag logic only if a drag_obj is active
@@ -877,11 +881,11 @@ class DraggableTabBar(QtGui.QTabBar):
         return super(DraggableTabBar, self).mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event):
-        """ Re-implemented to deactivate the drag when mouse button is 
+        """ Re-implemented to deactivate the drag when mouse button is
         released
         """
         self.drag_obj = None
-        return super(DraggableTabBar, self).mouseReleaseEvent(event)        
+        return super(DraggableTabBar, self).mouseReleaseEvent(event)
 
 
 class TabDragObject(object):
@@ -948,7 +952,7 @@ class TabDropHandler(BaseDropHandler):
 
     def can_handle_drop(self, event, target):
         if isinstance(event.mimeData(), PyMimeData) and \
-            isinstance(event.mimeData().instance(), TabDragObject):    
+            isinstance(event.mimeData().instance(), TabDragObject):
             if not self.allow_cross_window_drop:
                 drag_obj = event.mimeData().instance()
                 return drag_obj.from_editor_area == target.editor_area
@@ -973,14 +977,13 @@ class TabDropHandler(BaseDropHandler):
             target.insertTab(index, drag_obj.widget, label)
 
         else:
-            # if the drag initiated from the same tabwidget, put the tab 
+            # if the drag initiated from the same tabwidget, put the tab
             # back at the original index
             if target is drag_obj.from_tabbar.parent():
                 target.insertTab(drag_obj.from_index, drag_obj.widget, label)
             # else, just add it at the end
             else:
                 target.addTab(drag_obj.widget, label)
-        
+
         # make the dropped widget active
         target.setCurrentWidget(drag_obj.widget)
-

--- a/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
@@ -242,9 +242,18 @@ class TestEditorAreaWidget(unittest.TestCase):
         # adding the editors
         editor_area = SplitEditorAreaPane()
         editor_area.create(parent=None)
-        editor_area.add_editor(Editor(obj=file0))
-        editor_area.add_editor(Editor(obj=file1))
-        editor_area.add_editor(Editor(obj=file2))
+        editor_area.add_editor(Editor(obj=file0, tooltip="test_tooltip0"))
+        editor_area.add_editor(Editor(obj=file1, tooltip="test_tooltip1"))
+        editor_area.add_editor(Editor(obj=file2, tooltip="test_tooltip2"))
+
+        ######## test tooltips #############
+
+        self.assertEquals(editor_area.active_tabwidget.tabToolTip(0),
+                          "test_tooltip0")
+        self.assertEquals(editor_area.active_tabwidget.tabToolTip(1),
+                          "test_tooltip1")
+        self.assertEquals(editor_area.active_tabwidget.tabToolTip(2),
+                          "test_tooltip2")
 
         ######## test set_layout #############
 

--- a/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
@@ -111,14 +111,14 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         # does the right tabwidget contain nothing but the empty widget?
         self.assertEquals(root.rightchild.tabwidget().count(), 1)
-        self.assertEquals(root.rightchild.tabwidget().widget(0), 
+        self.assertEquals(root.rightchild.tabwidget().widget(0),
                           root.rightchild.tabwidget().empty_widget)
 
         # do we have an equally sized split?
         self.assertEquals(root.leftchild.width(), root.rightchild.width())
 
         # is the rightchild active?
-        self.assertEquals(root.editor_area.active_tabwidget, 
+        self.assertEquals(root.editor_area.active_tabwidget,
                           root.rightchild.tabwidget())
 
     def _setUp_collapse(self, parent=None):
@@ -137,7 +137,7 @@ class TestEditorAreaWidget(unittest.TestCase):
         tabwidget.addTab(btn0, '0')
         tabwidget.addTab(btn1, '1')
         tabwidget.setCurrentIndex(1)
-        
+
         # setup rightchild
         right = EditorAreaWidget(editor_area=left.editor_area, parent=None)
         btn2 = QtGui.QPushButton('btn2')
@@ -146,7 +146,7 @@ class TestEditorAreaWidget(unittest.TestCase):
         tabwidget.addTab(btn2, '2')
         tabwidget.addTab(btn3, '3')
         tabwidget.setCurrentIndex(0)
-        
+
         # setup root
         root = EditorAreaWidget(editor_area=left.editor_area, parent=parent)
         tabwidget = root.tabwidget()
@@ -183,7 +183,7 @@ class TestEditorAreaWidget(unittest.TestCase):
         self.assertEquals(root.tabwidget().currentWidget(), btn2)
 
     def test_collapse_empty(self):
-        """ Test for collapse function when the collapse origin is an empty 
+        """ Test for collapse function when the collapse origin is an empty
         tabwidget. It's sibling can have an arbitrary layout and the result
         would be such that this layout is transferred to the parent.
         """
@@ -247,7 +247,7 @@ class TestEditorAreaWidget(unittest.TestCase):
         editor_area.add_editor(Editor(obj=file2))
 
         ######## test set_layout #############
-        
+
         # set the layout
         editor_area.set_layout(layout)
 
@@ -255,26 +255,26 @@ class TestEditorAreaWidget(unittest.TestCase):
         left = editor_area.control.leftchild
         editor = editor_area._get_editor(left.tabwidget().widget(0))
         self.assertEquals(editor.obj, file0)
-        
+
         # right pane is a splitter made of two panes?
         right = editor_area.control.rightchild
         self.assertFalse(right.is_leaf())
-        
+
         # right pane is vertical splitter?
         self.assertEquals(right.orientation(), QtCore.Qt.Vertical)
-        
+
         # top pane of this vertical split is empty?
-        right_top = right.leftchild 
+        right_top = right.leftchild
         self.assertTrue(right_top.is_empty())
-        
+
         # bottom pane is not empty?
-        right_bottom = right.rightchild 
+        right_bottom = right.rightchild
         self.assertFalse(right_bottom.is_empty())
-        
+
         # file1 goes first on bottom pane?
         editor = editor_area._get_editor(right_bottom.tabwidget().widget(0))
         self.assertEquals(editor.obj, file1)
-        
+
         # file2 goes second on bottom pane?
         editor = editor_area._get_editor(right_bottom.tabwidget().widget(1))
         self.assertEquals(editor.obj, file2)
@@ -290,7 +290,7 @@ class TestEditorAreaWidget(unittest.TestCase):
         # is the top level a horizontal splitter?
         self.assertIsInstance(layout_new, Splitter)
         self.assertEquals(layout_new.orientation, 'horizontal')
-        
+
         # tests on left child
         left = layout_new.items[0]
         self.assertIsInstance(left, Tabbed)


### PR DESCRIPTION
[See line 137 of the split_editor_area_pane and line 245 of the unit test file for the important changes.]

When a tab is created with the splitEditorAreaPane, the index variable in the `add_editor` method was wrong only for the first editor. That led to the tooltip for that editor being lost. This is a hack to fix that. The real fix is probably down inside qt or pyside...

Thanks to @corranwebster for his help tracking this one!