### PR TITLE
Add keyboard shortcuts for toolbar actions

### DIFF
--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -274,6 +274,7 @@ class _Tool(HasTraits):
         self.control.setWhatsThis(action.description)
         self.control.setEnabled(action.enabled)
         self.control.setVisible(action.visible)
+        self.control.setShortcut(action.accelerator)
 
         if action.style == 'toggle':
             self.control.setCheckable(True)


### PR DESCRIPTION
[QMenu.addAction](http://qt-project.org/doc/qt-4.8/qmenu.html#addAction) has a key-sequence argument in it's signature, but [QToolBar.addAction](http://qt-project.org/doc/qt-4.8/qtoolbar.html#addAction) doesn't, so the initialization of keyboard shortcuts is a bit different.
