### PR TITLE
Deprecate wx toolkit default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,9 @@ The following GUI backends are supported:
 - PyQt
 - PySide
 
+**Warning:** In Pyface version 5.0 the default GUI backend will change from
+``wx`` to ``qt4``.
+
 Documentation
 -------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,9 @@ Currently, the supported GUI toolkits are wxPython, PySide and PyQt. While all
 toolkits funtion with Traits, integration with wxPython is currently more
 complete. All future development, however, will focus on supporting Qt.
 
+.. warning:: Currently the default toolkit if none is supplied is 'wx', but
+   this will change to `qt` in Pyface 5.0.
+
 NOTE: Although the code in this library is BSD licensed, when the PyQt backend
 is used the more restrictive terms of PyQt's GPL or proprietary licensing will
 likely apply to your code.

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -38,6 +38,10 @@ def _init_toolkit():
         be = import_toolkit(ETSConfig.toolkit)
     else:
         # Toolkits to check for if none is explicitly specified.
+        import warnings
+        warnings.warn(DeprecationWarning(
+            "Default toolkit will change to 'qt4' in PyFace 5.0"))
+
         known_toolkits = ('wx', 'qt4', 'null')
 
         for tk in known_toolkits:

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -39,8 +39,8 @@ def _init_toolkit():
     else:
         # Toolkits to check for if none is explicitly specified.
         import warnings
-        warnings.warn(DeprecationWarning(
-            "Default toolkit will change to 'qt4' in PyFace 5.0"))
+        warnings.warn("Default toolkit will change to 'qt4' in PyFace 5.0",
+                      DeprecationWarning)
 
         known_toolkits = ('wx', 'qt4', 'null')
 


### PR DESCRIPTION
Unfortunately, can't easily test this because `_init_toolkit()` pulls the ladder up after itself, so we can't reset the toolkit to test the code.