### PR TITLE
Fix task window layout running after control destroyed

### DIFF
--- a/pyface/ui/qt4/tasks/main_window_layout.py
+++ b/pyface/ui/qt4/tasks/main_window_layout.py
@@ -76,7 +76,7 @@ class MainWindowLayout(HasTraits):
         # Build the layout tree bottom-up, in multiple passes.
         while len(items) > 1:
             add, remove = set(), set()
-            
+
             for item1, item2 in combinations(items, 2):
                 if item1 not in remove and item2 not in remove:
                     rect1, rect2 = rects[item1], rects[item2]
@@ -96,7 +96,7 @@ class MainWindowLayout(HasTraits):
                     rects[item] = rect1.united(rect2)
                     add.add(item)
                     remove.update((item1, item2))
-                    
+
             if add or remove:
                 items.update(add)
                 items.difference_update(remove)
@@ -144,7 +144,7 @@ class MainWindowLayout(HasTraits):
                 if widget:
                     self.control.addDockWidget(q_dock_area, widget)
                     widget.show()
-        
+
         elif isinstance(layout, Tabbed):
             active_widget = first_widget = None
             for item in layout.items:
@@ -189,7 +189,7 @@ class MainWindowLayout(HasTraits):
             for i, item in enumerate(layout.items):
                 self.set_layout_for_area(item, q_dock_area,
                     _toplevel_added=True, _toplevel_call=False)
-                
+
         else:
             raise MainWindowLayoutError("Unknown layout item %r" % layout)
 
@@ -226,15 +226,15 @@ class MainWindowLayout(HasTraits):
             sep = self.control.style().pixelMetric(
                 QtGui.QStyle.PM_DockWidgetSeparatorExtent, None, self.control)
             united.adjust(0, 0, -sep, -sep)
-            
+
         if one.x() == two.x() and one.width() == two.width() and \
                united.height() == one.height() + two.height():
             return QtCore.Qt.Horizontal
-        
+
         elif one.y() == two.y() and one.height() == two.height() and \
                  united.width() == one.width() + two.width():
             return QtCore.Qt.Vertical
-        
+
         return 0
 
     def _get_tab_bar(self, dock_widget):
@@ -272,10 +272,10 @@ class MainWindowLayout(HasTraits):
                 if layout.height > 0:
                     dock_widget.widget().setFixedHeight(layout.height)
             return dock_widget
-        
+
         elif isinstance(layout, LayoutContainer):
             return self._prepare_toplevel_for_item(layout.items[0])
-        
+
         else:
             raise MainWindowLayoutError("Leaves of layout must be PaneItems")
 
@@ -283,14 +283,15 @@ class MainWindowLayout(HasTraits):
         """ Clears any fixed sizes assined to QDockWidgets.
         """
         QWIDGETSIZE_MAX = (1 << 24) - 1 # Not exposed by Qt bindings.
-        for child in self.control.children():
-            if isinstance(child, QtGui.QDockWidget):
-                child.widget().setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
-                child.widget().setMinimumSize(0, 0)
-                # QDockWidget somehow manages to set its own
-                # min/max sizes and hence that too needs to be reset.
-                child.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
-                child.setMinimumSize(0, 0)
+        if self.control is not None:
+            for child in self.control.children():
+                if isinstance(child, QtGui.QDockWidget):
+                    child.widget().setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
+                    child.widget().setMinimumSize(0, 0)
+                    # QDockWidget somehow manages to set its own
+                    # min/max sizes and hence that too needs to be reset.
+                    child.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
+                    child.setMinimumSize(0, 0)
 
 
 

--- a/pyface/ui/qt4/tasks/main_window_layout.py
+++ b/pyface/ui/qt4/tasks/main_window_layout.py
@@ -282,16 +282,17 @@ class MainWindowLayout(HasTraits):
     def _reset_fixed_sizes(self):
         """ Clears any fixed sizes assined to QDockWidgets.
         """
+        if self.control is None:
+            return
         QWIDGETSIZE_MAX = (1 << 24) - 1 # Not exposed by Qt bindings.
-        if self.control is not None:
-            for child in self.control.children():
-                if isinstance(child, QtGui.QDockWidget):
-                    child.widget().setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
-                    child.widget().setMinimumSize(0, 0)
-                    # QDockWidget somehow manages to set its own
-                    # min/max sizes and hence that too needs to be reset.
-                    child.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
-                    child.setMinimumSize(0, 0)
+        for child in self.control.children():
+            if isinstance(child, QtGui.QDockWidget):
+                child.widget().setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
+                child.widget().setMinimumSize(0, 0)
+                # QDockWidget somehow manages to set its own
+                # min/max sizes and hence that too needs to be reset.
+                child.setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX)
+                child.setMinimumSize(0, 0)
 
 
 

--- a/pyface/ui/qt4/tasks/task_window_backend.py
+++ b/pyface/ui/qt4/tasks/task_window_backend.py
@@ -43,6 +43,8 @@ class TaskWindowBackend(MTaskWindowBackend):
         """
         QtGui.QApplication.instance().focusChanged.disconnect(
             self._focus_changed_signal)
+        # signal to layout we don't need it any more
+        self._main_window_layout.control = None
 
     def hide_task(self, state):
         """ Assuming the specified TaskState is active, hide its controls.
@@ -88,7 +90,7 @@ class TaskWindowBackend(MTaskWindowBackend):
         for name, corner in CORNER_MAP.iteritems():
             area = INVERSE_AREA_MAP[int(self.control.corner(corner))]
             setattr(layout, name + '_corner', area)
-            
+
         return layout
 
     def set_layout(self, layout):


### PR DESCRIPTION
The layout callback run by the following code https://github.com/enthought/pyface/blob/master/pyface/ui/qt4/tasks/main_window_layout.py#L129 can run after the tasks control has been destroyed.

This PR resolves the issue by flagging that the control is about to be destroyed from the TaskWindow backend implementation by setting the control to `None`.  The layout can then check this and not do any further work.