### PR TITLE
Don't force a conversion to str when reading text from Qt clipboard

### DIFF
--- a/pyface/ui/qt4/clipboard.py
+++ b/pyface/ui/qt4/clipboard.py
@@ -79,7 +79,7 @@ class Clipboard(BaseClipboard):
     #---------------------------------------------------------------------------
 
     def _get_text_data(self):
-        return str(cb.text())
+        return cb.text()
 
     def _set_text_data(self, data):
         cb.setText(data)


### PR DESCRIPTION
The conversion was failing when the string had non-ASCII characters. Fixes #146 