### PR TITLE
Fix regression on traitsui branch used in CI

### DIFF
--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -1,6 +1,6 @@
 coverage
 pygments
 git+http://github.com/enthought/traits.git#egg=traits
-git+http://github.com/enthought/traitsui.git@feature/python3#egg=traitsui
+git+http://github.com/enthought/traitsui.git#egg=traitsui
 traits_enaml ; python_version == '2.7'
 enaml ; python_version == '2.7'


### PR DESCRIPTION
I think this happened in the move from `dev_requirements.txt` to `travis-ci-requirements.txt`.