### PR TITLE
Remove usage of logging.warn in favour of logger.warning.

### DIFF
--- a/pyface/grid/api.py
+++ b/pyface/grid/api.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.api import *

--- a/pyface/grid/api.py
+++ b/pyface/grid/api.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.api import *

--- a/pyface/grid/checkbox_image_renderer.py
+++ b/pyface/grid/checkbox_image_renderer.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.checkbox_image_renderer import *

--- a/pyface/grid/checkbox_image_renderer.py
+++ b/pyface/grid/checkbox_image_renderer.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.checkbox_image_renderer import *

--- a/pyface/grid/checkbox_renderer.py
+++ b/pyface/grid/checkbox_renderer.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.checkbox_renderer import *

--- a/pyface/grid/checkbox_renderer.py
+++ b/pyface/grid/checkbox_renderer.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.checkbox_renderer import *

--- a/pyface/grid/combobox_focus_handler.py
+++ b/pyface/grid/combobox_focus_handler.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.combobox_focus_handler import *

--- a/pyface/grid/combobox_focus_handler.py
+++ b/pyface/grid/combobox_focus_handler.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.combobox_focus_handler import *

--- a/pyface/grid/composite_grid_model.py
+++ b/pyface/grid/composite_grid_model.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.composite_grid_model import *

--- a/pyface/grid/composite_grid_model.py
+++ b/pyface/grid/composite_grid_model.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.composite_grid_model import *

--- a/pyface/grid/edit_image_renderer.py
+++ b/pyface/grid/edit_image_renderer.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.edit_image_renderer import *

--- a/pyface/grid/edit_image_renderer.py
+++ b/pyface/grid/edit_image_renderer.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.edit_image_renderer import *

--- a/pyface/grid/edit_renderer.py
+++ b/pyface/grid/edit_renderer.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.edit_renderer import *

--- a/pyface/grid/edit_renderer.py
+++ b/pyface/grid/edit_renderer.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.edit_renderer import *

--- a/pyface/grid/grid.py
+++ b/pyface/grid/grid.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid import *

--- a/pyface/grid/grid.py
+++ b/pyface/grid/grid.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid import *

--- a/pyface/grid/grid_cell_image_renderer.py
+++ b/pyface/grid/grid_cell_image_renderer.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid_cell_image_renderer import *

--- a/pyface/grid/grid_cell_image_renderer.py
+++ b/pyface/grid/grid_cell_image_renderer.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid_cell_image_renderer import *

--- a/pyface/grid/grid_cell_renderer.py
+++ b/pyface/grid/grid_cell_renderer.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid_cell_renderer import *

--- a/pyface/grid/grid_cell_renderer.py
+++ b/pyface/grid/grid_cell_renderer.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid_cell_renderer import *

--- a/pyface/grid/grid_model.py
+++ b/pyface/grid/grid_model.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid_model import *

--- a/pyface/grid/grid_model.py
+++ b/pyface/grid/grid_model.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.grid_model import *

--- a/pyface/grid/inverted_grid_model.py
+++ b/pyface/grid/inverted_grid_model.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.inverted_grid_model import *

--- a/pyface/grid/inverted_grid_model.py
+++ b/pyface/grid/inverted_grid_model.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.inverted_grid_model import *

--- a/pyface/grid/mapped_grid_cell_image_renderer.py
+++ b/pyface/grid/mapped_grid_cell_image_renderer.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.mapped_grid_cell_image_renderer import *

--- a/pyface/grid/mapped_grid_cell_image_renderer.py
+++ b/pyface/grid/mapped_grid_cell_image_renderer.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.mapped_grid_cell_image_renderer import *

--- a/pyface/grid/simple_grid_model.py
+++ b/pyface/grid/simple_grid_model.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.simple_grid_model import *

--- a/pyface/grid/simple_grid_model.py
+++ b/pyface/grid/simple_grid_model.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.simple_grid_model import *

--- a/pyface/grid/trait_grid_cell_adapter.py
+++ b/pyface/grid/trait_grid_cell_adapter.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.trait_grid_cell_adapter import *

--- a/pyface/grid/trait_grid_cell_adapter.py
+++ b/pyface/grid/trait_grid_cell_adapter.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.trait_grid_cell_adapter import *

--- a/pyface/grid/trait_grid_model.py
+++ b/pyface/grid/trait_grid_model.py
@@ -1,5 +1,6 @@
 import logging
-logging.warn('DEPRECATED: pyface.grid, '
-             'use pyface.ui.wx.grid instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.trait_grid_model import *

--- a/pyface/grid/trait_grid_model.py
+++ b/pyface/grid/trait_grid_model.py
@@ -1,6 +1,6 @@
 import logging
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 logger.warning('DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.')
 
 from pyface.ui.wx.grid.trait_grid_model import *

--- a/pyface/wx/clipboard.py
+++ b/pyface/wx/clipboard.py
@@ -11,8 +11,9 @@
 #------------------------------------------------------------------------------
 
 import logging
-logging.warn('DEPRECATED: pyface.wx.clipboard, '
-             'use pyface.api instead.')
+
+logger = logging.getLogger()
+logger.warning('DEPRECATED: pyface.wx.clipboard, use pyface.api instead.')
 
 from pyface.ui.wx.clipboard import Clipboard
 clipboard = Clipboard()


### PR DESCRIPTION
Fixes #165 

Global search-and-replace on untested, deprecated code.  Fun, hopefully it works :)