### PR TITLE
Make qt4 the default toolkit

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ The following GUI backends are supported:
 - PyQt
 - PySide
 
-**Warning:** In Pyface version 5.0 the default GUI backend will change from
-``wx`` to ``qt4``.
+**Warning:** The default toolkit if none is supplied is ``qt4``.
+   This changed from ``wx`` in Pyface 5.0..
 
 Documentation
 -------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,12 +24,18 @@ supported Python-based GUI toolkit and the appropriate toolkit-specific backend
 project. Conversely, if you wish to use Traits without a UI, a "null" backend
 is automatically used in the absence of a real backend.
 
-Currently, the supported GUI toolkits are wxPython, PySide and PyQt. While all
-toolkits funtion with Traits, integration with wxPython is currently more
-complete. All future development, however, will focus on supporting Qt.
+Currently, the supported GUI toolkits are
 
-.. warning:: Currently the default toolkit if none is supplied is 'wx', but
-   this will change to `qt` in Pyface 5.0.
+* wxPython (>= 2.8, including experimental support for WxPython 3.0)
+* PySide
+* PyQt (Qt4 only, but Qt5 support is in development)
+
+While all toolkits funtion with Pyface, integration with wxPython is currently
+more complete.  Future development, however, will be more focused on
+supporting Qt.
+
+.. warning:: The default toolkit if none is supplied is ``qt4``.
+   This changed from ``wx`` in Pyface 5.0.
 
 NOTE: Although the code in this library is BSD licensed, when the PyQt backend
 is used the more restrictive terms of PyQt's GPL or proprietary licensing will

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -42,7 +42,7 @@ def _init_toolkit():
         warnings.warn("Default toolkit will change to 'qt4' in PyFace 5.0",
                       DeprecationWarning)
 
-        known_toolkits = ('wx', 'qt4', 'null')
+        known_toolkits = ('qt4', 'wx', 'null')
 
         for tk in known_toolkits:
             try:

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -38,10 +38,6 @@ def _init_toolkit():
         be = import_toolkit(ETSConfig.toolkit)
     else:
         # Toolkits to check for if none is explicitly specified.
-        import warnings
-        warnings.warn("Default toolkit will change to 'qt4' in PyFace 5.0",
-                      DeprecationWarning)
-
         known_toolkits = ('qt4', 'wx', 'null')
 
         for tk in known_toolkits:


### PR DESCRIPTION
This switches the lookup order for 'wx' and 'qt4' when no toolkit has been explicitly specified.  This may affect users who have both libraries installed and who have not specified the toolkit to use via environment variables or other methods.