### PR TITLE
A small fix to ProgressDialog and a change to code_widget in order to enabe (auto_set=False) for traitsui Qt CodeEditor

### DIFF
--- a/pyface/ui/qt4/code_editor/code_widget.py
+++ b/pyface/ui/qt4/code_editor/code_widget.py
@@ -30,6 +30,7 @@ class CodeWidget(QtGui.QPlainTextEdit):
     ###########################################################################
     # CodeWidget interface
     ###########################################################################
+    focus_lost = QtCore.Signal()
 
     def __init__(self, parent, should_highlight_current_line=True, font=None,
                  lexer=None):
@@ -425,6 +426,11 @@ class CodeWidget(QtGui.QPlainTextEdit):
         self.status_widget.setGeometry(QtCore.QRect(right_pos,
             contents.top(), self.status_widget.sizeHint().width(),
             contents.height()))
+
+    def focusOutEvent(self, event):
+        QtGui.QPlainTextEdit.focusOutEvent(self, event)
+        self.focus_lost.emit()
+
 
     def sizeHint(self):
         # Suggest a size that is 80 characters wide and 40 lines tall.

--- a/pyface/ui/qt4/progress_dialog.py
+++ b/pyface/ui/qt4/progress_dialog.py
@@ -67,6 +67,8 @@ class ProgressDialog(MProgressDialog, Window):
 
     def change_message(self, message):
         self.message = message
+        if self._message_control is not None:
+            self._message_control.setText(message)
 
     def update(self, value):
         """
@@ -187,7 +189,7 @@ class ProgressDialog(MProgressDialog, Window):
         label = QtGui.QLabel(self.message, dialog)
         label.setAlignment(QtCore.Qt.AlignTop | QtCore.Qt.AlignLeft)
         layout.addWidget(label)
-
+        self._message_control = label
         return
 
     def _create_percent(self, dialog, layout):
@@ -214,6 +216,8 @@ class ProgressDialog(MProgressDialog, Window):
     def _create_contents(self, parent):
         dialog = parent
         layout  = QtGui.QVBoxLayout(dialog)
+        layout.setContentsMargins(self.margin, self.margin,
+                                  self.margin, self.margin)
 
         # The 'guts' of the dialog.
         self._create_message(dialog, layout)
@@ -233,3 +237,7 @@ class ProgressDialog(MProgressDialog, Window):
     def _min_changed(self, new):
         if self.progress_bar is not None:
             self.progress_bar.setMinimum(new)
+
+    def _message_changed(self, new):
+        if self._message_control is not None:
+            self._message_control.setText(new)

--- a/pyface/ui/wx/progress_dialog.py
+++ b/pyface/ui/wx/progress_dialog.py
@@ -124,9 +124,10 @@ class ProgressDialog(MProgressDialog, Window):
 
             msg_control_size = self._message_control.GetSize()
             self.dialog_size.x = max(self.dialog_size.x, msg_control_size.x + 2*self.margin)
-            self.control.SetClientSize(self.dialog_size)
+            if self.control is not None:
+                self.control.SetClientSize(self.dialog_size)
 
-            self.control.GetSizer().Layout()
+                self.control.GetSizer().Layout()
 
     def update(self, value):
         """


### PR DESCRIPTION
The first commit fixes QT and WX ProgressDialog to enable updates to the message which did not work.

The second commit adds a "focus_lost" signal in the QT CodeWidget that is emitted whenever focus goes out of the widget, thus enabling traitsui CodeEditor to behave properly for auto_set=False (see other pull request on traitsui)