### PR TITLE
Fix SyntaxError: from __future__ imports must occur at the beginning …

### DIFF
--- a/pyface/ipython_widget.py
+++ b/pyface/ipython_widget.py
@@ -13,6 +13,7 @@
 #------------------------------------------------------------------------------
 """ The implementation of an IPython shell. """
 
+from __future__ import absolute_import
 
 # Import the toolkit specific version.
 try:
@@ -23,8 +24,6 @@ ________________________________________________________________________________
 Could not load the Wx frontend for ipython.
 You need to have ipython >= 0.9 installed to use the ipython widget.'''
 
-
-from __future__ import absolute_import
 
 from .toolkit import toolkit_object
 IPythonWidget= toolkit_object('ipython_widget:IPythonWidget')


### PR DESCRIPTION
…of the file

I get the following build the Fedora package:
~~~~~
Bytecompiling .py files below /builddir/build/BUILDROOT/python-pyface-5.0.0-1.fc24.noarch/usr/lib/python2.7 using /usr/bin/python2.7
Compiling /builddir/build/BUILDROOT/python-pyface-5.0.0-1.fc24.noarch/usr/lib/python2.7/site-packages/pyface/ipython_widget.py ...
  File "/usr/lib/python2.7/site-packages/pyface/ipython_widget.py", line 27
SyntaxError: from __future__ imports must occur at the beginning of the file
~~~~~

This patch fixes.