### PR TITLE
FIX: bug in ProgressDialog timer labels

### DIFF
--- a/pyface/ui/qt4/progress_dialog.py
+++ b/pyface/ui/qt4/progress_dialog.py
@@ -162,7 +162,7 @@ class ProgressDialog(MProgressDialog, Window):
         seconds = value % 60
         label = "%1u:%02u:%02u" % (hours, minutes, seconds)
 
-        control.setText(control.text()[:-7] + label)
+        control.setText(label)
 
     def _create_buttons(self, dialog, layout):
         """ Creates the buttons. """


### PR DESCRIPTION
When the number of steps in the progress dialog loop is large, the label text for the estimated and remaining times get prepended by the trailing digits of the previous step's labels, leading to hilarious results such as this:
![progress_dialog_bug](https://cloud.githubusercontent.com/assets/8642896/11704945/b99c7c14-9eb1-11e5-9b8a-81f170666f41.png)

With this fix in place, the same example results in this:
![progress_dialog_fixed](https://cloud.githubusercontent.com/assets/8642896/11704947/bbe00e28-9eb1-11e5-9fff-9189eb3728b9.png)

A minimal working example to reproduce this bug is below, and is a small modification of the [progress_dialog.py](https://github.com/enthought/pyface/blob/master/examples/progress_dialog.py) example.
```
#
# simple example of its use
#
from __future__ import print_function

import time
from pyface.api import GUI, ApplicationWindow, ProgressDialog
from pyface.action.api import Action, MenuManager, MenuBarManager

def task_func(t):
    progress = ProgressDialog(title="progress", message="counting to %d"%t, max=t, show_time=True, can_cancel=True)
    progress.open()

    for i in range(0,t+1):
        time.sleep(.000001)
        print(i)
        (cont, skip) = progress.update(i)
        if not cont or skip:
            break

    progress.update(t)

def _main():
    task_func(10000000)

class MainWindow(ApplicationWindow):
    """ The main application window. """

    ######################################################################
    # 'object' interface.
    ######################################################################

    def __init__(self, **traits):
        """ Creates a new application window. """

        # Base class constructor.
        super(MainWindow, self).__init__(**traits)

        # Add a menu bar.
        self.menu_bar_manager = MenuBarManager(
            MenuManager(
                Action(name='E&xit', on_perform=self.close),
                Action(name='DoIt', on_perform=_main),
                name = '&File',
            )
        )

        return


if __name__ == "__main__":
    gui = GUI()

    # Create and open the main window.
    window = MainWindow()
    window.open()

    _main()

    # Start the GUI event loop!
    gui.start_event_loop()

```