### PR TITLE
Clarified the purpose of LayoutContainer construction args.

### DIFF
--- a/pyface/tasks/task_layout.py
+++ b/pyface/tasks/task_layout.py
@@ -73,9 +73,9 @@ class LayoutContainer(LayoutItem):
 
     items = List(pretty_skip=True)
 
-    def __init__(self, *items, **traits):
-        super(LayoutContainer, self).__init__(**traits)
-        self.items = list(items)
+    def __init__(self, *args, **kwargs):
+        super(LayoutContainer, self).__init__(**kwargs)
+        self.items = list(args)
 
     def iterleaves(self):
         for item in self.items:

--- a/pyface/tasks/task_layout.py
+++ b/pyface/tasks/task_layout.py
@@ -73,9 +73,16 @@ class LayoutContainer(LayoutItem):
 
     items = List(pretty_skip=True)
 
-    def __init__(self, *args, **kwargs):
-        super(LayoutContainer, self).__init__(**kwargs)
-        self.items = list(args)
+    def __init__(self, *items, **traits):
+        # Items may either be specified as a positional arg or a kwarg.
+        if items:
+            if 'items' in traits:
+                raise ValueError(
+                    "Received 'items' as positional and keyword argument."
+                )
+            else:
+                traits['items'] = list(items)
+        super(LayoutContainer, self).__init__(**traits)
 
     def iterleaves(self):
         for item in self.items:

--- a/pyface/tasks/tests/test_task_layout.py
+++ b/pyface/tasks/tests/test_task_layout.py
@@ -3,6 +3,7 @@ import unittest
 
 # Enthought library imports.
 from pyface.tasks.api import HSplitter, PaneItem, Tabbed, VSplitter
+from ..task_layout import LayoutContainer
 
 
 class LayoutItemsTestCase(unittest.TestCase):
@@ -29,6 +30,22 @@ class LayoutItemsTestCase(unittest.TestCase):
     def test_vsplitter_items(self):
         layout = VSplitter(*self.items)
         self.assertEqual(layout.items, self.items)
+
+    def test_layout_container_positional_items(self):
+        items = self.items
+        container = LayoutContainer(*items)
+        self.assertListEqual(items, container.items)
+
+    def test_layout_container_keyword_items(self):
+        items = self.items
+        container = LayoutContainer(items=items)
+        self.assertListEqual(items, container.items)
+
+    def test_layout_container_keyword_and_positional_items(self):
+        items = self.items
+        with self.assertRaises(ValueError):
+            LayoutContainer(*items, items=items)
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
LayoutContainer's __init__ accepts arguments *items and **traits. At first glance, the argument names make it seem as if one could initialize LayoutContainer.items by calling LayoutContainer(items=some_items). However, doing this would create a task layout with items=() and traits={'items': some_items}. 

This behavior is misleading. I ran into some code yesterday where a vsplitter had been constructed with VSplitter(items=list_of_items), and it took me a few looks to realize that {items: list_of_items} was being passed to **traits instead of items.

The current commit will not fix the above example, but I'm hoping it will make it clear that the above usage is incorrect. All of my ideas for making LayoutContainer(items=[...]) assign a value to items would break backwards compatibility. @dpinte any ideas?