### PR TITLE
Add modal dialog_was_opened flag

### DIFF
--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -36,6 +36,10 @@ class ModalDialogTester(object):
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         self.assertEqual(tester.result, <expected>)
 
+        # Even if the dialog was not opened upon calling `function`,
+        # `result` is assigned and the test may not fail.
+        # To test if the dialog was once opened:
+        self.assertTrue(tester.dialog_was_opened)
 
     .. note::
 

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -58,7 +58,7 @@ class ModalDialogTester(object):
         self._helper = EventLoopHelper(qt_app=self._qt_app, gui=self._gui)
         self._dialog_widget = None
         self.dialog_was_opened = False
-        
+
     @property
     def result(self):
         """ The return value of the provided function.

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -57,7 +57,8 @@ class ModalDialogTester(object):
         self._event_loop_error = []
         self._helper = EventLoopHelper(qt_app=self._qt_app, gui=self._gui)
         self._dialog_widget = None
-
+        self.dialog_was_opened = False
+        
     @property
     def result(self):
         """ The return value of the provided function.
@@ -105,6 +106,7 @@ class ModalDialogTester(object):
             """ Run the when_opened as soon as the dialog has opened. """
             if self.dialog_opened():
                 self._gui.invoke_later(when_opened, self)
+                self.dialog_was_opened = True
             else:
                 condition_timer.start()
 
@@ -158,6 +160,7 @@ class ModalDialogTester(object):
             if self.dialog_opened():
                 self._dialog_widget = self.get_dialog_widget()
                 self._gui.invoke_later(when_opened, self)
+                self.dialog_was_opened = True
             else:
                 condition_timer.start()
 

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -38,6 +38,9 @@ class MyClass(HasStrictTraits):
         else:
             return 'rejected'
 
+    def do_not_show_dialog(self):
+        return True
+
 
 class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
     """ Tests for the modal dialog tester. """
@@ -52,11 +55,13 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         self.assertTrue(tester.value_assigned())
         self.assertEqual(tester.result, OK)
+        self.assertTrue(tester.dialog_was_opened)
 
         # reject
         tester.open_and_run(when_opened=lambda x: x.close())
         self.assertTrue(tester.value_assigned())
         self.assertEqual(tester.result, CANCEL)
+        self.assertTrue(tester.dialog_was_opened)
 
     def test_on_traitsui_dialog(self):
         my_class = MyClass()
@@ -66,11 +71,13 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         self.assertTrue(tester.value_assigned())
         self.assertEqual(tester.result, 'accepted')
+        self.assertTrue(tester.dialog_was_opened)
 
         # reject
         tester.open_and_run(when_opened=lambda x: x.close())
         self.assertTrue(tester.value_assigned())
         self.assertEqual(tester.result, 'rejected')
+        self.assertTrue(tester.dialog_was_opened)
 
     def test_capture_errors_on_failure(self):
         dialog = MessageDialog()
@@ -142,6 +149,18 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                 tester.close()
 
         tester.open_and_run(when_opened=check_and_close)
+
+    def test_dialog_was_not_opened_on_traitsui_dialog(self):
+        my_class = MyClass()
+        tester = ModalDialogTester(my_class.do_not_show_dialog)
+
+        # it runs okay
+        tester.open_and_run(when_opened=lambda x: x.close(accept=True))
+        self.assertTrue(tester.value_assigned())
+        self.assertEqual(tester.result, True)
+
+        # but no dialog is opened
+        self.assertFalse(tester.dialog_was_opened)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I needed to test if a dialog is indeed opened in many occasions.   The flag would be a nice thing to have.

@corranwebster flag does solve the problem!
My previous attempt failed because of some stupid mistake which leads to non-modal dialog being opened.
