### PR TITLE
Qt4 Workbench should create UI with parent being the dock widget

### DIFF
--- a/pyface/ui/qt4/workbench/workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/workbench_window_layout.py
@@ -520,7 +520,7 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
             view.window = self.window
 
             try:
-                view.control = view.create_control(self.window.control)
+                view.control = view.create_control(dw.widget())
             except:
                 # Tidy up if the view couldn't be created.
                 delattr(view, '_qt4_dock')


### PR DESCRIPTION
The dock widget's ViewContainer instead of the main window should be passed for creating UI.
