### PR TITLE
fix: correct the extened trait change description

### DIFF
--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -125,7 +125,7 @@ class DockPane(TaskPane, MDockPane):
                 main_window.addDockWidget(AREA_MAP[self.dock_area],
                                           self.control)
 
-    @on_trait_change('closable', 'floatable', 'movable')
+    @on_trait_change('closable,floatable,movable')
     def _set_dock_features(self):
         if self.control is not None:
             features = QtGui.QDockWidget.NoDockWidgetFeatures


### PR DESCRIPTION
On of the change handlers was using the `on_trait_change` decorator providing three separate trait names. However, this signature is not supported since (https://github.com/enthought/traits/pull/207) and actually never properly worked. Older versions of traits would ignore the second trait (not covered in the tests) and the recent version raises an error.

This PR fixes the issue for both old and new versions of traits