### PR TITLE
Update SplitEditorAreaPane.active_editor on focus changes

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -113,8 +113,9 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     def activate_editor(self, editor):
         """ Activates the specified editor in the pane.
         """
-        self.active_tabwidget = editor.control.parent().parent()
-        self.active_tabwidget.setCurrentWidget(editor.control)
+        active_tabwidget = editor.control.parent().parent()
+        active_tabwidget.setCurrentWidget(editor.control)
+        self.active_tabwidget = active_tabwidget
         editor_widget = editor.control.parent()
         editor_widget.setVisible(True)
         editor_widget.raise_()
@@ -330,7 +331,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         """Set the active tabwidget after an application-level change in focus.
         """
 
-        if new:
+        if new is not None:
             if isinstance(new, DraggableTabWidget):
                 if new.editor_area == self:
                     self.active_tabwidget = new
@@ -344,13 +345,23 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
                 for editor in self.editors:
                     control = editor.control
                     if control is not None and control.isAncestorOf(new):
-                        self.active_tabwidget = \
+                        active_tabwidget = \
                             self._find_ancestor_draggable_tab_widget(control)
-                        self.active_tabwidget.setCurrentWidget(control)
-                        # Set active_editor at the end so that the notification
-                        # occurs when everything is ready.
-                        self.active_editor = editor
+                        active_tabwidget.setCurrentWidget(control)
+                        self.active_tabwidget = active_tabwidget
                         break
+
+    def _active_tabwidget_changed(self, new):
+        """Set the active editor whenever the active tabwidget updates.
+        """
+
+        if new is None or new.parent().is_empty():
+            active_editor = None
+        else:
+            active_editor = self._get_editor(new.currentWidget())
+
+        self.active_editor = active_editor
+
 
 ###############################################################################
 # Auxiliary classes.

--- a/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
@@ -355,5 +355,43 @@ class TestEditorAreaWidget(unittest.TestCase):
         with event_loop():
             window.close()
 
+    def test_active_editor_after_focus_change(self):
+        window = TaskWindow(size=(800, 600))
+
+        task = SplitEditorAreaPaneTestTask()
+        editor_area = task.editor_area
+        window.add_task(task)
+
+        # Show the window.
+        with event_loop():
+            window.open()
+
+        with event_loop():
+            app = get_app_qt4()
+            app.setActiveWindow(window.control)
+
+        # Add and activate an editor which contains tabs.
+        left_editor = ViewWithTabsEditor()
+        right_editor = ViewWithTabsEditor()
+
+        with event_loop():
+            editor_area.add_editor(left_editor)
+        with event_loop():
+            editor_area.control.split(orientation=QtCore.Qt.Horizontal)
+        with event_loop():
+            editor_area.add_editor(right_editor)
+
+        editor_area.activate_editor(right_editor)
+        self.assertEqual(editor_area.active_editor, right_editor)
+
+        with event_loop():
+            left_editor.control.setFocus()
+
+        self.assertIsNotNone(editor_area.active_editor)
+        self.assertEqual(editor_area.active_editor, left_editor)
+
+        with event_loop():
+            window.close()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This fixes #202. I've given up on writing a test, since I can't figure out how to set focus or set the active window from within a test method.