### PR TITLE
Fix workbench_window_layout in python3

### DIFF
--- a/pyface/ui/qt4/workbench/workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/workbench_window_layout.py
@@ -292,7 +292,7 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
         self._qt4_editor_area.restoreState(editor_layout, resolve_id)
 
     def get_toolkit_memento(self):
-        return (0, dict(geometry=self.window.control.saveGeometry()))
+        return (0, {'geometry' : self.window.control.saveGeometry()})
 
     def set_toolkit_memento(self, memento):
         if hasattr(memento, 'toolkit_data'):

--- a/pyface/ui/qt4/workbench/workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/workbench_window_layout.py
@@ -202,7 +202,7 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
         view_ids = [v.id for v in self.window.views if self.contains_view(v)]
 
         # Everything else is provided by QMainWindow.
-        state = str(self.window.control.saveState())
+        state = self.window.control.saveState()
 
         return (0, (view_ids, state))
 
@@ -292,7 +292,7 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
         self._qt4_editor_area.restoreState(editor_layout, resolve_id)
 
     def get_toolkit_memento(self):
-        return (0, dict(geometry=str(self.window.control.saveGeometry())))
+        return (0, dict(geometry=self.window.control.saveGeometry()))
 
     def set_toolkit_memento(self, memento):
         if hasattr(memento, 'toolkit_data'):


### PR DESCRIPTION
Without this patch, starting Mayavi2 in python3 environment gives you the following error:

```
Traceback (most recent call last):
  File "/Users/kit/Envs/mayavi-py3/bin/mayavi2", line 9, in <module>
    load_entry_point('mayavi', 'gui_scripts', 'mayavi2')()
  File "/Users/kit/ETS/mayavi/mayavi/scripts/mayavi2.py", line 650, in main
    mayavi.main(sys.argv[1:])
  File "/Users/kit/ETS/mayavi/mayavi/plugins/app.py", line 195, in main
    app.run()
  File "/Users/kit/ETS/mayavi/mayavi/plugins/mayavi_workbench_application.py", line 81, in run
    window.open()
  File "/Users/kit/ETS/pyface/build/lib/pyface/workbench/workbench_window.py", line 144, in open
    self._create()
  File "/Users/kit/ETS/pyface/build/lib/pyface/ui/qt4/application_window.py", line 121, in _create
    contents = self._create_contents(self.control)
  File "/Users/kit/ETS/pyface/build/lib/pyface/workbench/workbench_window.py", line 221, in _create_contents
    self._initial_layout = self.layout.get_view_memento()
  File "/Users/kit/ETS/pyface/build/lib/pyface/ui/qt4/workbench/workbench_window_layout.py", line 205, in get_view_memento
    state = str(self.window.control.saveState())
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 3: invalid start byte
```

Not sure how to write a test case for this.

