### PR TITLE
Fix restoring show_editor_area from saved perspective

### DIFF
--- a/pyface/ui/qt4/workbench/workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/workbench_window_layout.py
@@ -304,6 +304,8 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
                     if geometry is not None:
                         self.window.control.restoreGeometry(geometry)
 
+    def is_editor_area_visible(self):
+        return self._qt4_editor_area.isVisible()
 
     ###########################################################################
     # Private interface.

--- a/pyface/ui/wx/workbench/workbench_window_layout.py
+++ b/pyface/ui/wx/workbench/workbench_window_layout.py
@@ -248,6 +248,12 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
 
         return
 
+    def is_editor_area_visible(self):
+        dock_control = self._wx_view_dock_window.get_control(
+            self.editor_area_id, visible_only=False
+        )
+        return dock_control.visible
+        
     #### Methods for saving and restoring the layout ##########################
 
     def get_view_memento(self):

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -1,0 +1,51 @@
+import mock
+
+from traits.testing.unittest_tools import unittest, UnittestTools
+
+from pyface.workbench.perspective import Perspective
+from pyface.workbench.workbench_window import (WorkbenchWindow,
+                                               WorkbenchWindowLayout,
+                                               WorkbenchWindowMemento)
+
+
+class TestWindow(unittest.TestCase, UnittestTools):
+
+    def test_restore_perspective_editor_area(self):
+        # A perspective with show_editor_area switched on
+        with_editor = Perspective(show_editor_area=True,
+                                  id="test_id", name="test_name")
+
+        # A perspective with show_editor_area switched off
+        without_editor = Perspective(show_editor_area=False,
+                                     id="test_id2", name="test_name2")
+
+        # Set up the WorkbenchWindow
+        workbench_window = WorkbenchWindow(
+            perspectives=[with_editor, without_editor])
+
+        # mock a bunch of objects
+        workbench_window._memento = WorkbenchWindowMemento()
+        workbench_window._initial_layout = workbench_window._memento
+        workbench_window.layout = mock.Mock(spec=WorkbenchWindowLayout)
+
+        # There are the methods we want to test if they are called
+        workbench_window.show_editor_area = mock.MagicMock()
+        workbench_window.hide_editor_area = mock.MagicMock()
+
+        # Show a perspective with editor area
+        workbench_window._show_perspective(None, with_editor)
+
+        # show_editor_area should be called
+        # hide_editor_area should not be called when there was
+        # no old perspective
+        self.assertTrue(workbench_window.show_editor_area.called)
+        self.assertFalse(workbench_window.hide_editor_area.called)
+
+        # Show a perspective with editor area
+        workbench_window.show_editor_area.reset_mock()
+        workbench_window.hide_editor_area.reset_mock()
+        workbench_window._show_perspective(with_editor, without_editor)
+
+        # show_editor_area should not be called and hide_editor_area is called
+        self.assertFalse(workbench_window.show_editor_area.called)
+        self.assertTrue(workbench_window.hide_editor_area.called)

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -53,12 +53,13 @@ class TestWorkbenchWindowUserPerspective(unittest.TestCase, UnittestTools):
             return_value=perspective.show_editor_area)
     
     def test_editor_area_with_perspectives(self):
+        """ Test show_editor_area is respected while switching perspective"""
+
         # The workbench and workbench window with layout mocked
         workbench, workbench_window = self.get_workbench_with_window()
         workbench.active_window = workbench_window
 
         # Add perspectives
-        # This will write to the state file
         workbench.user_perspective_manager.add(self.with_editor)
         workbench.user_perspective_manager.add(self.without_editor)
         
@@ -91,6 +92,8 @@ class TestWorkbenchWindowUserPerspective(unittest.TestCase, UnittestTools):
         self.assertTrue(workbench_window.show_editor_area.called)
 
     def test_editor_area_restore_from_saved_state(self):
+        """ Test if show_editor_area is restored properly from saved state """
+
         # The workbench and workbench window with layout mocked
         workbench, workbench_window = self.get_workbench_with_window()
         workbench.active_window = workbench_window
@@ -104,6 +107,7 @@ class TestWorkbenchWindowUserPerspective(unittest.TestCase, UnittestTools):
         workbench_window._initial_layout = workbench_window._memento
 
         # Mock layout functions for pickling
+        # We only care about show_editor_area and not the layout in this test
         layout_functions = {"get_view_memento.return_value": (0, (None, None)),
                             "get_editor_memento.return_value": (0, (None, None)),
                             "get_toolkit_memento.return_value": (0, dict(geometry=""))}
@@ -122,7 +126,7 @@ class TestWorkbenchWindowUserPerspective(unittest.TestCase, UnittestTools):
         del workbench
         
         # We create another workbench which uses the state location
-        # and we test if we can retore them correctly
+        # and we test if we can retore the saved perspective correctly
         workbench, workbench_window = self.get_workbench_with_window()
 
         # Mock window factory since we already created a workbench window

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -33,18 +33,19 @@ class TestWindow(unittest.TestCase, UnittestTools):
         workbench_window.hide_editor_area = mock.MagicMock()
 
         # Show a perspective with editor area
-        workbench_window._show_perspective(None, with_editor)
+        workbench_window.active_perspective = with_editor
+        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=True)
 
         # show_editor_area should be called
-        # hide_editor_area should not be called when there was
-        # no old perspective
+        # hide_editor_area should not be called
         self.assertTrue(workbench_window.show_editor_area.called)
         self.assertFalse(workbench_window.hide_editor_area.called)
 
         # Show a perspective with editor area
         workbench_window.show_editor_area.reset_mock()
         workbench_window.hide_editor_area.reset_mock()
-        workbench_window._show_perspective(with_editor, without_editor)
+        workbench_window.active_perspective = without_editor
+        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=False)
 
         # show_editor_area should not be called and hide_editor_area is called
         self.assertFalse(workbench_window.show_editor_area.called)
@@ -53,10 +54,9 @@ class TestWindow(unittest.TestCase, UnittestTools):
         # The with_editor has been seen so this will read from the memento
         workbench_window.show_editor_area.reset_mock()
         workbench_window.hide_editor_area.reset_mock()
-        workbench_window._show_perspective(None, with_editor)
+        workbench_window.active_perspective = with_editor
+        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=True)
 
         # show_editor_area should be called
-        # hide_editor_area should not be called as we fake
-        # old perspective to be None
         self.assertTrue(workbench_window.show_editor_area.called)
         self.assertFalse(workbench_window.hide_editor_area.called)

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -61,3 +61,14 @@ class TestWindow(unittest.TestCase, UnittestTools):
         # show_editor_area should be called
         self.assertEqual(workbench_window.show_editor_area.call_count, 1)
         self.assertEqual(workbench_window.hide_editor_area.call_count, 0)
+
+        # The without_editor has been seen so this will read from the memento
+        workbench_window.show_editor_area.reset_mock()
+        workbench_window.hide_editor_area.reset_mock()
+        workbench_window.active_perspective = without_editor
+        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=False)
+
+        # hide_editor_area should be called
+        self.assertEqual(workbench_window.show_editor_area.call_count, 0)
+        self.assertEqual(workbench_window.hide_editor_area.call_count, 1)
+        

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -49,3 +49,14 @@ class TestWindow(unittest.TestCase, UnittestTools):
         # show_editor_area should not be called and hide_editor_area is called
         self.assertFalse(workbench_window.show_editor_area.called)
         self.assertTrue(workbench_window.hide_editor_area.called)
+
+        # The with_editor has been seen so this will read from the memento
+        workbench_window.show_editor_area.reset_mock()
+        workbench_window.hide_editor_area.reset_mock()
+        workbench_window._show_perspective(None, with_editor)
+
+        # show_editor_area should be called
+        # hide_editor_area should not be called as we fake
+        # old perspective to be None
+        self.assertTrue(workbench_window.show_editor_area.called)
+        self.assertFalse(workbench_window.hide_editor_area.called)

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -1,74 +1,161 @@
 import mock
+import tempfile
+import shutil
+import os
 
 from traits.testing.unittest_tools import unittest, UnittestTools
 
 from pyface.workbench.perspective import Perspective
+from pyface.workbench.api import Workbench
+from pyface.workbench.user_perspective_manager import UserPerspectiveManager
 from pyface.workbench.workbench_window import (WorkbenchWindow,
                                                WorkbenchWindowLayout,
                                                WorkbenchWindowMemento)
 
 
-class TestWindow(unittest.TestCase, UnittestTools):
+class TestWorkbenchWindowUserPerspective(unittest.TestCase, UnittestTools):
 
-    def test_restore_perspective_editor_area(self):
+    def setUp(self):
         # A perspective with show_editor_area switched on
-        with_editor = Perspective(show_editor_area=True,
-                                  id="test_id", name="test_name")
+        self.with_editor = Perspective(show_editor_area=True,
+                                       id="test_id", name="test_name")
 
         # A perspective with show_editor_area switched off
-        without_editor = Perspective(show_editor_area=False,
-                                     id="test_id2", name="test_name2")
+        self.without_editor = Perspective(show_editor_area=False,
+                                          id="test_id2", name="test_name2")
 
-        # Set up the WorkbenchWindow
-        workbench_window = WorkbenchWindow(
-            perspectives=[with_editor, without_editor])
+        # Where the state file should be saved
+        self.state_location = tempfile.mkdtemp(dir="./")
 
-        # mock a bunch of objects
-        workbench_window._memento = WorkbenchWindowMemento()
-        workbench_window._initial_layout = workbench_window._memento
-        workbench_window.layout = mock.Mock(spec=WorkbenchWindowLayout)
+        # Make sure the temporary directory is removed
+        self.addCleanup(self.rm_tempdir)
+
+    def rm_tempdir(self):
+        shutil.rmtree(self.state_location)
+
+    def get_workbench_with_window(self):
+        workbench = Workbench()
+        workbench_window = WorkbenchWindow()
+        workbench.windows = [workbench_window]
+
+        # Saved perspectives should go to the temporary directory
+        workbench.state_location = self.state_location
+
+        # Mock the layout for the workbench window
+        workbench_window.layout = mock.MagicMock(spec=WorkbenchWindowLayout)
+        workbench_window.layout.window = workbench_window
+
+        return workbench, workbench_window
+
+    def show_perspective(self, workbench_window, perspective):
+        workbench_window.active_perspective = perspective
+        workbench_window.layout.is_editor_area_visible = mock.MagicMock(
+            return_value=perspective.show_editor_area)
+    
+    def test_editor_area_with_perspectives(self):
+        # The workbench and workbench window with layout mocked
+        workbench, workbench_window = self.get_workbench_with_window()
+        workbench.active_window = workbench_window
+
+        # Add perspectives
+        # This will write to the state file
+        workbench.user_perspective_manager.add(self.with_editor)
+        workbench.user_perspective_manager.add(self.without_editor)
         
         # There are the methods we want to test if they are called
         workbench_window.show_editor_area = mock.MagicMock()
         workbench_window.hide_editor_area = mock.MagicMock()
 
-        # Show a perspective with editor area
-        workbench_window.active_perspective = with_editor
-        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=True)
+        # Mock more things for initialing the Workbench Window
+        workbench_window._memento = WorkbenchWindowMemento()
+        workbench_window._initial_layout = workbench_window._memento
 
-        # show_editor_area should be called
-        # hide_editor_area should not be called
-        self.assertEqual(workbench_window.show_editor_area.call_count, 1)
-        self.assertEqual(workbench_window.hide_editor_area.call_count, 0)
-
-        # Show a perspective with editor area
-        workbench_window.show_editor_area.reset_mock()
-        workbench_window.hide_editor_area.reset_mock()        
-        workbench_window.active_perspective = without_editor
-        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=False)
-
-        # show_editor_area should not be called
-        # hide_editor_area should be called
-        self.assertEqual(workbench_window.show_editor_area.call_count, 0)
-        self.assertEqual(workbench_window.hide_editor_area.call_count, 1)
-
-        # The with_editor has been seen so this will read from the memento
-        workbench_window.show_editor_area.reset_mock()
-        workbench_window.hide_editor_area.reset_mock()
-        workbench_window.active_perspective = with_editor
-        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=True)
-
-        # show_editor_area should be called
-        self.assertEqual(workbench_window.show_editor_area.call_count, 1)
-        self.assertEqual(workbench_window.hide_editor_area.call_count, 0)
-
-        # The without_editor has been seen so this will read from the memento
-        workbench_window.show_editor_area.reset_mock()
-        workbench_window.hide_editor_area.reset_mock()
-        workbench_window.active_perspective = without_editor
-        workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=False)
-
-        # hide_editor_area should be called
-        self.assertEqual(workbench_window.show_editor_area.call_count, 0)
-        self.assertEqual(workbench_window.hide_editor_area.call_count, 1)
+        # Show a perspective with an editor area
+        self.show_perspective(workbench_window, self.with_editor)
         
+        # show_editor_area should be called
+        self.assertTrue(workbench_window.show_editor_area.called)
+
+        # Show a perspective withOUT an editor area
+        workbench_window.hide_editor_area.reset_mock()        
+        self.show_perspective(workbench_window, self.without_editor)
+
+        # hide_editor_area should be called
+        self.assertTrue(workbench_window.hide_editor_area.called)
+
+        # The with_editor has been seen so this will be restored from the memento
+        workbench_window.show_editor_area.reset_mock()
+        self.show_perspective(workbench_window, self.with_editor)
+
+        # show_editor_area should be called
+        self.assertTrue(workbench_window.show_editor_area.called)
+
+    def test_editor_area_restore_from_saved_state(self):
+        # The workbench and workbench window with layout mocked
+        workbench, workbench_window = self.get_workbench_with_window()
+        workbench.active_window = workbench_window
+
+        # Add perspectives
+        workbench.user_perspective_manager.add(self.with_editor)
+        workbench.user_perspective_manager.add(self.without_editor)
+
+        # Mock for initialising the workbench window
+        workbench_window._memento = WorkbenchWindowMemento()
+        workbench_window._initial_layout = workbench_window._memento
+
+        # Mock layout functions for pickling
+        layout_functions = {"get_view_memento.return_value": (0, (None, None)),
+                            "get_editor_memento.return_value": (0, (None, None)),
+                            "get_toolkit_memento.return_value": (0, dict(geometry=""))}
+
+        workbench_window.layout.configure_mock(**layout_functions)
+        
+        # The following records perspective mementos to workbench_window._memento
+        self.show_perspective(workbench_window, self.without_editor)
+        self.show_perspective(workbench_window, self.with_editor)
+
+        # Save the window layout to a state file
+        workbench._save_window_layout(workbench_window)
+        
+        # We only needed the state file for this test
+        del workbench_window
+        del workbench
+        
+        # We create another workbench which uses the state location
+        # and we test if we can retore them correctly
+        workbench, workbench_window = self.get_workbench_with_window()
+
+        # Mock window factory since we already created a workbench window
+        workbench.window_factory = mock.MagicMock(return_value=workbench_window)
+
+        # There are the methods we want to test if they are called
+        workbench_window.show_editor_area = mock.MagicMock()
+        workbench_window.hide_editor_area = mock.MagicMock()
+        
+        # This restores the perspectives and mementos
+        workbench.create_window()
+
+        # Create contents
+        workbench_window._create_contents(mock.Mock())
+
+        # Perspective mementos should be restored
+        self.assertIn(self.with_editor.id, workbench_window._memento.perspective_mementos)
+        self.assertIn(self.without_editor.id, workbench_window._memento.perspective_mementos)
+        
+        # Since the with_editor perspective is used last,
+        # it should be used as initial perspective
+        self.assertTrue(workbench_window.show_editor_area.called)
+
+        # Try restoring the perspective without editor
+        # The restored perspectives are not the same instance as before
+        # We need to get them using their id
+        perspective_without_editor = workbench_window.get_perspective_by_id(
+            self.without_editor.id)
+        
+        # Show the perspective with editor area
+        workbench_window.hide_editor_area.reset_mock()        
+        self.show_perspective(workbench_window, perspective_without_editor)
+
+        # make sure hide_editor_area is called
+        self.assertTrue(workbench_window.hide_editor_area.called)
+

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -27,7 +27,7 @@ class TestWindow(unittest.TestCase, UnittestTools):
         workbench_window._memento = WorkbenchWindowMemento()
         workbench_window._initial_layout = workbench_window._memento
         workbench_window.layout = mock.Mock(spec=WorkbenchWindowLayout)
-
+        
         # There are the methods we want to test if they are called
         workbench_window.show_editor_area = mock.MagicMock()
         workbench_window.hide_editor_area = mock.MagicMock()
@@ -38,18 +38,19 @@ class TestWindow(unittest.TestCase, UnittestTools):
 
         # show_editor_area should be called
         # hide_editor_area should not be called
-        self.assertTrue(workbench_window.show_editor_area.called)
-        self.assertFalse(workbench_window.hide_editor_area.called)
+        self.assertEqual(workbench_window.show_editor_area.call_count, 1)
+        self.assertEqual(workbench_window.hide_editor_area.call_count, 0)
 
         # Show a perspective with editor area
         workbench_window.show_editor_area.reset_mock()
-        workbench_window.hide_editor_area.reset_mock()
+        workbench_window.hide_editor_area.reset_mock()        
         workbench_window.active_perspective = without_editor
         workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=False)
 
-        # show_editor_area should not be called and hide_editor_area is called
-        self.assertFalse(workbench_window.show_editor_area.called)
-        self.assertTrue(workbench_window.hide_editor_area.called)
+        # show_editor_area should not be called
+        # hide_editor_area should be called
+        self.assertEqual(workbench_window.show_editor_area.call_count, 0)
+        self.assertEqual(workbench_window.hide_editor_area.call_count, 1)
 
         # The with_editor has been seen so this will read from the memento
         workbench_window.show_editor_area.reset_mock()
@@ -58,5 +59,5 @@ class TestWindow(unittest.TestCase, UnittestTools):
         workbench_window.layout.is_editor_area_visible = mock.MagicMock(return_value=True)
 
         # show_editor_area should be called
-        self.assertTrue(workbench_window.show_editor_area.called)
-        self.assertFalse(workbench_window.hide_editor_area.called)
+        self.assertEqual(workbench_window.show_editor_area.call_count, 1)
+        self.assertEqual(workbench_window.hide_editor_area.call_count, 0)

--- a/pyface/workbench/user_perspective_manager.py
+++ b/pyface/workbench/user_perspective_manager.py
@@ -131,7 +131,8 @@ class UserPerspectiveManager(HasTraits):
         # fixme: This needs to be pushed into the window API!!!!!!!
         window._memento.perspective_mementos[clone.id] = (
             window.layout.get_view_memento(),
-            window.active_view and window.active_view.id or None
+            window.active_view and window.active_view.id or None,
+            window.layout.get_editor_memento()
         )
 
         # Update the persistent file information.

--- a/pyface/workbench/user_perspective_manager.py
+++ b/pyface/workbench/user_perspective_manager.py
@@ -132,7 +132,7 @@ class UserPerspectiveManager(HasTraits):
         window._memento.perspective_mementos[clone.id] = (
             window.layout.get_view_memento(),
             window.active_view and window.active_view.id or None,
-            window.layout.get_editor_memento()
+            window.layout.is_editor_area_visible()
         )
 
         # Update the persistent file information.

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -225,14 +225,11 @@ class WorkbenchWindow(ApplicationWindow):
         if self._memento is None:
             self._memento = WorkbenchWindowMemento()
 
-            # Set the initial perspective.
-            self.active_perspective = self._get_initial_perspective()
-
         else:
-            # Set the initial perspective.
-            self.active_perspective = self._get_initial_perspective()
-
             self._restore_contents()
+
+        # Set the initial perspective.
+        self.active_perspective = self._get_initial_perspective()
 
         return contents
 
@@ -470,6 +467,7 @@ class WorkbenchWindow(ApplicationWindow):
         """ Hide the editor area. """
 
         self.layout.hide_editor_area()
+
         return
 
     def hide_view(self, view):
@@ -531,7 +529,9 @@ class WorkbenchWindow(ApplicationWindow):
 
     def show_editor_area(self):
         """ Show the editor area. """
+
         self.layout.show_editor_area()
+
         return
 
     def show_view(self, view):
@@ -799,6 +799,7 @@ class WorkbenchWindow(ApplicationWindow):
 
     def _restore_contents(self):
         """ Restore the contents of the window. """
+
         self.layout.set_editor_memento(self._memento.editor_area_memento)
 
         self.size = self._memento.size

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -220,7 +220,6 @@ class WorkbenchWindow(ApplicationWindow):
         # to a perspective that has not been seen yet.
         self._initial_layout = self.layout.get_view_memento()
 
-
         # Are we creating the window from scratch or restoring it from a
         # memento?
         if self._memento is None:
@@ -533,7 +532,6 @@ class WorkbenchWindow(ApplicationWindow):
     def show_editor_area(self):
         """ Show the editor area. """
         self.layout.show_editor_area()
-
         return
 
     def show_view(self, view):

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -532,7 +532,6 @@ class WorkbenchWindow(ApplicationWindow):
 
     def show_editor_area(self):
         """ Show the editor area. """
-
         self.layout.show_editor_area()
 
         return
@@ -745,7 +744,20 @@ class WorkbenchWindow(ApplicationWindow):
 
         if memento is not None:
             # Show the editor area?
-            self._restore_editor_area_visibility(memento)
+            # We need to set the editor area before setting the views
+            if len(memento) == 2:
+                logger.warning(("Restoring perspective from a file saved from "
+                                "an older version."))
+                editor_area_visible = True
+            else:
+                editor_area_visible = memento[2]
+
+            # Show the editor area if it is set to be visible
+            if editor_area_visible:
+                self.show_editor_area()
+            else:
+                self.hide_editor_area()
+                self.active_editor = None
 
             # Now set the views
             view_memento, active_view_id = memento[:2]
@@ -787,28 +799,9 @@ class WorkbenchWindow(ApplicationWindow):
 
         return
 
-    def _restore_editor_area_visibility(self, memento):
-        # Is the editor area visible?
-        if len(memento) == 2:
-            logger.warning(("Restoring perspective from a file saved from "
-                            "an older version."))
-            editor_area_visible = True
-        else:
-            editor_area_visible = memento[2]
-
-        # Show the editor area if it is set to be visible
-        if editor_area_visible:
-            self.show_editor_area()
-        else:
-            self.hide_editor_area()
-            self.active_editor = None
-
     def _restore_contents(self):
         """ Restore the contents of the window. """
         self.layout.set_editor_memento(self._memento.editor_area_memento)
-
-        memento = self._memento.perspective_mementos[self.active_perspective.id]
-        self._restore_editor_area_visibility(memento)
 
         self.size = self._memento.size
         self.position = self._memento.position

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -744,8 +744,7 @@ class WorkbenchWindow(ApplicationWindow):
             # Show the editor area?
             # We need to set the editor area before setting the views
             if len(memento) == 2:
-                logger.warning(("Restoring perspective from a file saved from "
-                                "an older version."))
+                logger.warning("Restoring perspective from an older version.")
                 editor_area_visible = True
             else:
                 editor_area_visible = memento[2]

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -7,7 +7,7 @@ import logging
 # Enthought library imports.
 from pyface.api import ApplicationWindow, GUI
 from traits.api import Callable, Constant, Delegate, Event, Instance
-from traits.api import List, Str, Tuple, Unicode, Vetoable
+from traits.api import List, Str, Tuple, Unicode, Vetoable, Undefined
 from traits.api import on_trait_change, provides
 
 # Local imports.
@@ -892,6 +892,9 @@ class WorkbenchWindow(ApplicationWindow):
     @on_trait_change('layout.editor_closed')
     def _on_editor_closed(self, editor):
         """ Dynamic trait change handler. """
+
+        if editor is None or editor is Undefined:
+            return
 
         index = self.editors.index(editor)
         del self.editors[index]

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -745,20 +745,7 @@ class WorkbenchWindow(ApplicationWindow):
 
         if memento is not None:
             # Show the editor area?
-            if len(memento) == 2:
-                logger.warning(("Your saved layout is from an older version. "
-                                "Please reset."))
-                editor_area_visible = True
-            else:
-                editor_area_visible = memento[2]
-
-            # We need to show/hide the editor area before setting
-            # the views
-            if editor_area_visible:
-                self.show_editor_area()
-            else:
-                self.hide_editor_area()
-                self.active_editor = None
+            self._restore_editor_area_visibility(memento)
 
             # Now set the views
             view_memento, active_view_id = memento[:2]
@@ -800,21 +787,28 @@ class WorkbenchWindow(ApplicationWindow):
 
         return
 
-    def _restore_contents(self):
-        """ Restore the contents of the window. """
-
-        self.layout.set_editor_memento(self._memento.editor_area_memento)
-
+    def _restore_editor_area_visibility(self, memento):
         # Is the editor area visible?
-        perspective = self.active_perspective
-        memento = self._memento.perspective_mementos[perspective.id]
-        editor_area_visible = memento[2]
+        if len(memento) == 2:
+            logger.warning(("Restoring perspective from a file saved from "
+                            "an older version."))
+            editor_area_visible = True
+        else:
+            editor_area_visible = memento[2]
 
+        # Show the editor area if it is set to be visible
         if editor_area_visible:
             self.show_editor_area()
         else:
             self.hide_editor_area()
             self.active_editor = None
+
+    def _restore_contents(self):
+        """ Restore the contents of the window. """
+        self.layout.set_editor_memento(self._memento.editor_area_memento)
+
+        memento = self._memento.perspective_mementos[self.active_perspective.id]
+        self._restore_editor_area_visibility(memento)
 
         self.size = self._memento.size
         self.position = self._memento.position


### PR DESCRIPTION
Fix https://github.com/enthought/mayavi/issues/337

Include the info whether the editor_area is visible in the `window_memento` file.  This code still respects old `window_memento` files and assume `show_editor_area = True` in that case.

The more difficult thing to write was the test case.  A lot of mock objects are required for testing this bug fix.
