### PR TITLE
Specify Enaml version to use

### DIFF
--- a/travis-ci-requirements.txt
+++ b/travis-ci-requirements.txt
@@ -3,4 +3,4 @@ pygments
 git+http://github.com/enthought/traits.git#egg=traits
 git+http://github.com/enthought/traitsui.git#egg=traitsui
 traits_enaml ; python_version == '2.7'
-enaml ; python_version == '2.7'
+enaml==0.9.8 ; python_version == '2.7'


### PR DESCRIPTION
I think a recent change to the Enaml imports in Enaml's master may have broken the tests.  So try specifying a known-good version of Enaml.