### PR TITLE
Fix for toolbars in non-AUI windows

### DIFF
--- a/pyface/ui/wx/action/action_item.py
+++ b/pyface/ui/wx/action/action_item.py
@@ -370,11 +370,16 @@ class _Tool(HasTraits):
         # Set the initial checked state.
         tool_bar.ToggleTool(self.control_id, action.checked)
 
-        # Set the initial enabled/disabled state of the action.
-        tool_bar.EnableTool(self.control_id, action.enabled)
+        if hasattr(tool_bar, 'ShowTool'):
+            # Set the initial enabled/disabled state of the action.
+            tool_bar.EnableTool(self.control_id, action.enabled)
 
-        # Set the initial visibility
-        tool_bar.ShowTool(self.control_id, action.visible)
+            # Set the initial visibility
+            tool_bar.ShowTool(self.control_id, action.visible)
+        else:
+            # Set the initial enabled/disabled state of the action.
+            tool_bar.EnableTool(
+                self.control_id, action.enabled and action.visible)
 
         # Wire it up.
         wx.EVT_TOOL(parent, self.control_id, self._on_tool)
@@ -389,8 +394,6 @@ class _Tool(HasTraits):
             self.controller = controller
             controller.add_to_toolbar(self)
 
-        return
-
     ###########################################################################
     # Private interface.
     ###########################################################################
@@ -400,16 +403,20 @@ class _Tool(HasTraits):
     def _enabled_changed(self):
         """ Called when our 'enabled' trait is changed. """
 
-        self.tool_bar.EnableTool(self.control_id, self.enabled)
-
-        return
+        if hasattr(self.tool_bar, 'ShowTool'):
+            self.tool_bar.EnableTool(self.control_id, self.enabled)
+        else:
+            self.tool_bar.EnableTool(
+                self.control_id, self.enabled and self.visible)
 
     def _visible_changed(self):
         """ Called when our 'visible' trait is changed. """
 
-        self.tool_bar.ShowTool(self.control_id, self.visible)
-
-        return
+        if hasattr(self.tool_bar, 'ShowTool'):
+            self.tool_bar.ShowTool(self.control_id, self.visible)
+        else:
+            self.tool_bar.EnableTool(
+                self.control_id, self.enabled and self.visible)
 
     def _checked_changed(self):
         """ Called when our 'checked' trait is changed. """
@@ -434,16 +441,20 @@ class _Tool(HasTraits):
     def _on_action_enabled_changed(self, action, trait_name, old, new):
         """ Called when the enabled trait is changed on an action. """
 
-        self.tool_bar.EnableTool(self.control_id, action.enabled)
-
-        return
+        if hasattr(self.tool_bar, 'ShowTool'):
+            self.tool_bar.EnableTool(self.control_id, action.enabled)
+        else:
+            self.tool_bar.EnableTool(
+                self.control_id, action.enabled and action.visible)
 
     def _on_action_visible_changed(self, action, trait_name, old, new):
         """ Called when the visible trait is changed on an action. """
 
-        self.tool_bar.ShowTool(self.control_id, action.visible)
-
-        return
+        if hasattr(self.tool_bar, 'ShowTool'):
+            self.tool_bar.ShowTool(self.control_id, action.visible)
+        else:
+            self.tool_bar.EnableTool(
+                self.control_id, self.enabled and action.visible)
 
     def _on_action_checked_changed(self, action, trait_name, old, new):
         """ Called when the checked trait is changed on an action. """

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -97,7 +97,7 @@ class ApplicationWindow(MApplicationWindow, Window):
         tool_bar_managers = self._get_tool_bar_managers()
         if len(tool_bar_managers) > 0:
             for tool_bar_manager in reversed(tool_bar_managers):
-                tool_bar = tool_bar_manager.create_tool_bar(parent)
+                tool_bar = tool_bar_manager.create_tool_bar(parent, aui=True)
                 self._add_toolbar_to_aui_manager(
                     tool_bar
                 )
@@ -133,7 +133,7 @@ class ApplicationWindow(MApplicationWindow, Window):
 
         self._aui_manager = PyfaceAuiManager()
         self._aui_manager.SetManagedWindow(self.control)
-        
+
         # Keep a reference to the AUI Manager in the control because Panes
         # will need to access it in order to lay themselves out
         self.control._aui_manager = self._aui_manager
@@ -177,12 +177,12 @@ class ApplicationWindow(MApplicationWindow, Window):
     def _add_toolbar_to_aui_manager(self, tool_bar):
         """ Add a toolbar to the AUI manager. """
 
-        info = self._get_tool_par_pane_info(tool_bar)
+        info = self._get_tool_bar_pane_info(tool_bar)
         self._aui_manager.AddPane(tool_bar, info)
 
         return
-    
-    def _get_tool_par_pane_info(self, tool_bar):
+
+    def _get_tool_bar_pane_info(self, tool_bar):
         info = aui.AuiPaneInfo()
         info.Caption(tool_bar.tool_bar_manager.name)
         info.LeftDockable(False)
@@ -225,7 +225,7 @@ class ApplicationWindow(MApplicationWindow, Window):
             # hidden toolbars and leave gaps in the toolbar dock
             pane.window.Show(False)
             self._aui_manager.DetachPane(pane.window)
-            info = self._get_tool_par_pane_info(pane.window)
+            info = self._get_tool_bar_pane_info(pane.window)
             info.Hide()
             self._aui_manager.AddPane(pane.window, info)
 


### PR DESCRIPTION
Fixes #246. AUI windows must explicitly ask for an AUI toolbar; other code is adapted to the possibility of getting one or the other type.