### PR TITLE
Update gui test assistant

### DIFF
--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013-2015 by Enthought, Inc., Austin, TX
+# Copyright (c) 2013-2017 by Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -12,8 +12,8 @@ import threading
 
 import mock
 
+from pyface.gui import GUI
 from pyface.qt.QtGui import QApplication
-from pyface.ui.qt4.gui import GUI
 from traits.testing.unittest_tools import UnittestTools
 from traits.testing.unittest_tools import _TraitsChangeCollector as \
     TraitsChangeCollector
@@ -51,8 +51,13 @@ class GuiTestAssistant(UnittestTools):
     def tearDown(self):
         with self.event_loop_with_timeout(repeat=5):
             self.gui.invoke_later(self.qt_app.closeAllWindows)
-        self.traitsui_raise_patch.stop()
+        self.qt_app.flush()
+        self.qt_app.quit()
         self.pyface_raise_patch.stop()
+        self.traitsui_raise_patch.stop()
+
+        del self.pyface_raise_patch
+        del self.traitsui_raise_patch
         del self.event_loop_helper
         del self.gui
         del self.qt_app

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -196,9 +196,12 @@ class GuiTestAssistant(UnittestTools):
             if recorded_changes == traits:
                 condition.set()
 
-        handlers = {}
-        for trait in traits:
-            handlers[trait] = lambda: set_event(trait)
+        def make_handler(trait):
+            def handler():
+                set_event(trait)
+            return handler
+
+        handlers = {trait: make_handler(trait) for trait in traits}
 
         for trait, handler in handlers.iteritems():
             traits_object.on_trait_change(handler, trait)

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -135,7 +135,7 @@ class GuiTestAssistant(UnittestTools):
         obj : HasTraits
             The HasTraits instance whose trait will change.
         trait : str
-            The extended trait name of trait changes to listen too.
+            The extended trait name of trait changes to listen to.
         condition : callable
             A callable to determine if the stop criteria have been met. This
             should accept no arguments.

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -187,6 +187,10 @@ class GuiTestAssistant(UnittestTools):
         traits = set(traits)
         recorded_changes = set()
 
+        # Correctly handle the corner case where there are no traits.
+        if not traits:
+            condition.set()
+
         def set_event(trait):
             recorded_changes.add(trait)
             if recorded_changes == traits:

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -12,8 +12,8 @@ import threading
 
 import mock
 
-from pyface.gui import GUI
 from pyface.qt.QtGui import QApplication
+from pyface.ui.qt4.gui import GUI
 from traits.testing.unittest_tools import UnittestTools
 from traits.testing.unittest_tools import _TraitsChangeCollector as \
     TraitsChangeCollector

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -1,5 +1,11 @@
-# (C) Copyright 2014 Enthought, Inc., Austin, TX
+# (C) Copyright 2014-2017 Enthought, Inc., Austin, TX
 # All right reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
 """ A class to facilitate testing components that use TraitsUI or Qt Dialogs.
 
 """
@@ -12,7 +18,7 @@ from pyface.qt import QtCore, QtGui
 from traits.api import Undefined
 
 from .event_loop_helper import EventLoopHelper
-from .gui_test_assistant import find_qt_widget
+from .testing import find_qt_widget
 
 
 BUTTON_TEXT = {

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -135,6 +135,7 @@ class ModalDialogTester(object):
                 condition=self.value_assigned, timeout=15)
         finally:
             condition_timer.stop()
+            condition_timer.timeout.disconnect(handler)
             self.assert_no_errors_collected()
 
     def open_and_wait(self, when_opened, *args, **kwargs):
@@ -195,6 +196,7 @@ class ModalDialogTester(object):
                 condition=condition, timeout=15)
         finally:
             condition_timer.stop()
+            condition_timer.timeout.disconnect(handler)
             self.assert_no_errors_collected()
 
     def open(self, *args, **kwargs):

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -242,7 +242,6 @@ class ModalDialogTester(object):
             self._event_loop_error.append(
                 (sys.exc_info()[0], traceback.format_exc())
             )
-            raise
 
     def assert_no_errors_collected(self):
         """ Assert that the tester has not collected any errors.

--- a/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
+++ b/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
@@ -1,0 +1,62 @@
+import unittest
+
+from pyface.ui.qt4.util.gui_test_assistant import \
+    GuiTestAssistant
+from traits.api import Event, HasStrictTraits
+
+
+class ExampleObject(HasStrictTraits):
+    """ Test class; target for test_event_loop_until_traits_change. """
+    spam = Event
+    eggs = Event
+
+
+class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
+    def test_event_loop_until_traits_change_with_single_trait_success(self):
+        # event_loop_until_traits_change calls self.fail on timeout.
+        obj = ExampleObject()
+
+        # Successful case.
+        with self.event_loop_until_traits_change(obj, 'spam'):
+            obj.spam = True
+
+    def test_event_loop_until_traits_change_with_single_trait_failure(self):
+        # event_loop_until_traits_change calls self.fail on timeout.
+        obj = ExampleObject()
+
+        # Failing case.
+        with self.assertRaises(AssertionError):
+            with self.event_loop_until_traits_change(obj, 'spam',
+                                                     timeout=0.1):
+                obj.eggs = True
+
+    def test_event_loop_until_traits_change_with_multiple_traits_success(self):
+        # Regression test for enthought/canopy_data#381.
+
+        # event_loop_until_traits_change calls self.fail on timeout.
+        obj = ExampleObject()
+        with self.event_loop_until_traits_change(obj, 'spam', 'eggs'):
+            obj.spam = True
+            obj.eggs = True
+
+    def test_event_loop_until_traits_change_with_multiple_traits_failure(self):
+        # event_loop_until_traits_change calls self.fail on timeout.
+        obj = ExampleObject()
+        with self.assertRaises(AssertionError):
+            with self.event_loop_until_traits_change(obj, 'spam', 'eggs',
+                                                     timeout=0.1):
+                obj.eggs = True
+
+        # event_loop_until_traits_change calls self.fail on timeout.
+        with self.assertRaises(AssertionError):
+            with self.event_loop_until_traits_change(obj, 'spam', 'eggs',
+                                                     timeout=0.1):
+                obj.spam = True
+
+    def test_event_loop_until_traits_change_with_no_traits_success(self):
+        # event_loop_until_traits_change calls self.fail on timeout.
+        obj = ExampleObject()
+
+        # Successful case.
+        with self.event_loop_until_traits_change(obj):
+            pass

--- a/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
+++ b/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
@@ -31,8 +31,6 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
                 obj.eggs = True
 
     def test_event_loop_until_traits_change_with_multiple_traits_success(self):
-        # Regression test for enthought/canopy_data#381.
-
         # event_loop_until_traits_change calls self.fail on timeout.
         obj = ExampleObject()
         with self.event_loop_until_traits_change(obj, 'spam', 'eggs'):


### PR DESCRIPTION
This backports some fixes for the GuiTestAssistant to pyface.

- Avoid uncollectable garbage caused by events not being disconnected
- Avoid uncollectable garbage due to references held in `sys.last_traceback`
- Improve robustness by flushing Qt events and quitting the application on `tearDown`
- Correctly handle the case where no traits are waited for in an event loop
- Correctly handle the case where multiple traits are waited for in an event loop