### PR TITLE
Fix nosetests-specific spelling of setUpClass.

### DIFF
--- a/pyface/ui/qt4/code_editor/tests/test_code_widget.py
+++ b/pyface/ui/qt4/code_editor/tests/test_code_widget.py
@@ -25,7 +25,7 @@ from pyface.ui.qt4.code_editor.code_widget import CodeWidget, AdvancedCodeWidget
 
 class TestCodeWidget(unittest.TestCase):
     @classmethod
-    def setupClass(cls):
+    def setUpClass(cls):
         cls.qapp = QtGui.QApplication.instance() or QtGui.QApplication([])
 
     def tearDown(self):


### PR DESCRIPTION
The `setupClass` spelling is only appreciated by nose. `setUpClass` works for nose, unittest and haas. As far as I can tell, neither spelling is understood by pytest.