### PR TITLE
Replace module-level use of unittest.SkipTest with a class decorator.

### DIFF
--- a/pyface/tasks/tests/test_enaml_dock_pane.py
+++ b/pyface/tasks/tests/test_enaml_dock_pane.py
@@ -1,14 +1,19 @@
 from traits.testing.unittest_tools import unittest
 from traits.etsconfig.api import ETSConfig
 
+# Skip tests if Enaml is not installed or we're using the wx backend.
+SKIP_REASON = None
 if ETSConfig.toolkit not in ['', 'qt4']:
-    raise unittest.SkipTest("TestEnamlDockPane: Enaml does not support WX")
-
+    SKIP_REASON = "TestEnamlTaskPane: Enaml does not support WX"
 try:
     from enaml.widgets.api import Label
     from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
 except ImportError:
-    raise unittest.SkipTest("Enaml not installed")
+    SKIP_REASON = "Enaml not installed"
+    # Dummy class so that the TestEnamlTaskPane class definition below
+    # doesn't fail.
+    class GuiTestAssistant(object):
+        pass
 
 from pyface.tasks.api import EnamlDockPane, Task
 
@@ -19,6 +24,7 @@ class DummyDockPane(EnamlDockPane):
         return Label(text='test label')
 
 
+@unittest.skipIf(SKIP_REASON is not None, SKIP_REASON)
 class TestEnamlDockPane(GuiTestAssistant, unittest.TestCase):
 
     ###########################################################################

--- a/pyface/tasks/tests/test_enaml_dock_pane.py
+++ b/pyface/tasks/tests/test_enaml_dock_pane.py
@@ -4,14 +4,18 @@ from traits.etsconfig.api import ETSConfig
 # Skip tests if Enaml is not installed or we're using the wx backend.
 SKIP_REASON = None
 if ETSConfig.toolkit not in ['', 'qt4']:
-    SKIP_REASON = "TestEnamlTaskPane: Enaml does not support WX"
-try:
-    from enaml.widgets.api import Label
-    from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
-except ImportError:
-    SKIP_REASON = "Enaml not installed"
+    SKIP_REASON = "Enaml does not support WX"
+else:
+    try:
+        from enaml.widgets.api import Label
+        from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
+    except ImportError:
+        SKIP_REASON = "Enaml not installed"
+
+if SKIP_REASON is not None:
     # Dummy class so that the TestEnamlTaskPane class definition below
     # doesn't fail.
+
     class GuiTestAssistant(object):
         pass
 

--- a/pyface/tasks/tests/test_enaml_editor.py
+++ b/pyface/tasks/tests/test_enaml_editor.py
@@ -4,16 +4,21 @@ from traits.etsconfig.api import ETSConfig
 # Skip tests if Enaml is not installed or we're using the wx backend.
 SKIP_REASON = None
 if ETSConfig.toolkit not in ['', 'qt4']:
-    SKIP_REASON = "TestEnamlTaskPane: Enaml does not support WX"
-try:
-    from enaml.widgets.api import Label
-    from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
-except ImportError:
-    SKIP_REASON = "Enaml not installed"
+    SKIP_REASON = "Enaml does not support WX"
+else:
+    try:
+        from enaml.widgets.api import Label
+        from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
+    except ImportError:
+        SKIP_REASON = "Enaml not installed"
+
+if SKIP_REASON is not None:
     # Dummy class so that the TestEnamlTaskPane class definition below
     # doesn't fail.
+
     class GuiTestAssistant(object):
         pass
+
 
 from traits.api import Str
 from pyface.tasks.api import EnamlEditor

--- a/pyface/tasks/tests/test_enaml_editor.py
+++ b/pyface/tasks/tests/test_enaml_editor.py
@@ -1,14 +1,19 @@
 from traits.testing.unittest_tools import unittest
 from traits.etsconfig.api import ETSConfig
 
+# Skip tests if Enaml is not installed or we're using the wx backend.
+SKIP_REASON = None
 if ETSConfig.toolkit not in ['', 'qt4']:
-    raise unittest.SkipTest("TestEnamlEditor: Enaml does not support WX")
-
+    SKIP_REASON = "TestEnamlTaskPane: Enaml does not support WX"
 try:
     from enaml.widgets.api import Label
     from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
 except ImportError:
-    raise unittest.SkipTest("Enaml not installed")
+    SKIP_REASON = "Enaml not installed"
+    # Dummy class so that the TestEnamlTaskPane class definition below
+    # doesn't fail.
+    class GuiTestAssistant(object):
+        pass
 
 from traits.api import Str
 from pyface.tasks.api import EnamlEditor
@@ -21,6 +26,7 @@ class DummyStrEditor(EnamlEditor):
     def create_component(self):
         return Label(text=self.obj)
 
+@unittest.skipIf(SKIP_REASON is not None, SKIP_REASON)
 class TestEnamlEditor(GuiTestAssistant, unittest.TestCase):
 
     ###########################################################################

--- a/pyface/tasks/tests/test_enaml_task_pane.py
+++ b/pyface/tasks/tests/test_enaml_task_pane.py
@@ -1,14 +1,19 @@
 from traits.testing.unittest_tools import unittest
 from traits.etsconfig.api import ETSConfig
 
+# Skip tests if Enaml is not installed or we're using the wx backend.
+SKIP_REASON = None
 if ETSConfig.toolkit not in ['', 'qt4']:
-    raise unittest.SkipTest("TestEnamlTaskPane: Enaml does not support WX")
-
+    SKIP_REASON = "TestEnamlTaskPane: Enaml does not support WX"
 try:
     from enaml.widgets.api import Label
     from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
 except ImportError:
-    raise unittest.SkipTest("Enaml not installed")
+    SKIP_REASON = "Enaml not installed"
+    # Dummy class so that the TestEnamlTaskPane class definition below
+    # doesn't fail.
+    class GuiTestAssistant(object):
+        pass
 
 from pyface.tasks.api import EnamlTaskPane
 
@@ -19,6 +24,7 @@ class DummyTaskPane(EnamlTaskPane):
         return Label(text='test label')
 
 
+@unittest.skipIf(SKIP_REASON is not None, SKIP_REASON)
 class TestEnamlTaskPane(GuiTestAssistant, unittest.TestCase):
 
     ###########################################################################

--- a/pyface/tasks/tests/test_enaml_task_pane.py
+++ b/pyface/tasks/tests/test_enaml_task_pane.py
@@ -4,14 +4,18 @@ from traits.etsconfig.api import ETSConfig
 # Skip tests if Enaml is not installed or we're using the wx backend.
 SKIP_REASON = None
 if ETSConfig.toolkit not in ['', 'qt4']:
-    SKIP_REASON = "TestEnamlTaskPane: Enaml does not support WX"
-try:
-    from enaml.widgets.api import Label
-    from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
-except ImportError:
-    SKIP_REASON = "Enaml not installed"
+    SKIP_REASON = "Enaml does not support WX"
+else:
+    try:
+        from enaml.widgets.api import Label
+        from traits_enaml.testing.gui_test_assistant import GuiTestAssistant
+    except ImportError:
+        SKIP_REASON = "Enaml not installed"
+
+if SKIP_REASON is not None:
     # Dummy class so that the TestEnamlTaskPane class definition below
     # doesn't fail.
+
     class GuiTestAssistant(object):
         pass
 


### PR DESCRIPTION
unittest and haas don't understand a module-level `raise unittest.SkipTest`, and report an `ImportError` rather than a skip for each test method.