### PR TITLE
Setup.py improvements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,5 +44,4 @@ Pyface depends on:
 
 * Pygments for syntax highlighting in the Qt code editor widget.
 
-* some widgets may have additional optional dependencies.  For example, the
-  IPython shell widgets require IPython to be installed.
+* some widgets may have additional optional dependencies.

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -23,7 +23,6 @@ except ImportError:
 
 __requires__ = ['traits']
 __extras_require__ = {
-    'workbench': ['traitsui'],
     'wx': ['wxpython>=2.8.10', 'numpy'],
     'pyqt': ['pyqt>=4.10', 'pygments'],
     'pyside': ['pyside>=1.2', 'pygments'],

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -20,6 +20,11 @@ try:
 except ImportError:
     __version__ = 'not-built'
 
-__requires__ = [
-    'pygments', 'traits',
-]
+
+__requires__ = ['traits']
+__extras_require__ = {
+    'workbench': ['traitsui'],
+    'wx': ['wxpython>=2.8.10', 'numpy'],
+    'pyqt': ['pyqt>=4.10', 'pygments'],
+    'pyside': ['pyside>=1.2', 'pygments'],
+}

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,25 @@ IS_RELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
 
+def read_module(module, package='pyface'):
+    """ Read a simple .py file from pyface in a safe way.
+
+    It would be simpler to import the file, but that can be problematic in an
+    unknown system, so we exec the file instead and extract the variables.
+
+    This will fail if things get too complex in the file being read, but is
+    sufficient to get version and requirements information.
+    """
+    base_dir = os.path.dirname(__file__)
+    module_name = package + '.' + module
+    path = os.path.join(base_dir, package, module+'.py')
+    with open(path, 'r') as fp:
+        code = compile(fp.read(), module_name, 'exec')
+    context = {}
+    exec(code, context)
+    return context
+
+
 # Return the git revision as a string
 def git_version():
     def _minimal_ext_cmd(cmd):
@@ -70,14 +89,15 @@ if not is_released:
     elif os.path.exists('pyface/_version.py'):
         # must be a source distribution, use existing version file
         try:
-            from pyface._version import git_revision as git_rev
-            from pyface._version import full_version as full_v
+            data = read_module('_version')
+            git_rev = data['git_revision']
+            fullversion = data['full_version']
         except ImportError:
-            raise ImportError("Unable to import git_revision. Try removing "
+            raise ImportError("Unable to read git_revision. Try removing "
                               "pyface/_version.py and the build directory "
                               "before building.")
 
-        match = re.match(r'.*?\.dev(?P<dev_num>\d+)', full_v)
+        match = re.match(r'.*?\.dev(?P<dev_num>\d+)', fullversion)
         if match is None:
             dev_num = '0'
         else:
@@ -95,9 +115,14 @@ if not is_released:
                                  git_revision=git_rev,
                                  is_released=IS_RELEASED))
 
+    return fullversion
+
+
 if __name__ == "__main__":
-    write_version_py()
-    from pyface import __version__, __requires__
+    __version__ = write_version_py()
+    data = read_module('__init__')
+    __requires__ = data['__requires__']
+    __extras_require__ = data['__extras_require__']
 
     setup(name='pyface',
           version=__version__,
@@ -115,10 +140,10 @@ if __name__ == "__main__":
               Operating System :: POSIX
               Operating System :: Unix
               Programming Language :: Python
-              Programming Language :: Python :: 2.6
               Programming Language :: Python :: 2.7
               Programming Language :: Python :: 3.4
               Programming Language :: Python :: 3.5
+              Programming Language :: Python :: 3.6
               Topic :: Scientific/Engineering
               Topic :: Software Development
               Topic :: Software Development :: Libraries
@@ -127,6 +152,7 @@ if __name__ == "__main__":
           long_description=open('README.rst').read(),
           download_url=('https://github.com/enthought/pyface'),
           install_requires=__requires__,
+          extras_require=__extras_require__,
           license='BSD',
           maintainer='ETS Developers',
           maintainer_email='enthought-dev@enthought.com',


### PR DESCRIPTION
This improves the setup script in two ways:

- Avoid `pyface` imports in `setup.py`. Importing pyface when you don't have pyface installed, or when a different version is installed, can be problematic, particularly when working with non-git clones.
- Use extras_require to allow more specific installs.  In particular, we can specify gui backend requirements, and the fact that Workbench currently relies on traitsui.

This also removes Python 2.6 as officially supported, since Traits no longer supports 2.6.