### PR TITLE
Allow plugin toolkits

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -78,4 +78,5 @@ Contents
    :maxdepth: 2
 
    Overview <overview>
+   Toolkits <toolkits>
    API Documentation <api/pyface>

--- a/docs/source/toolkits.rst
+++ b/docs/source/toolkits.rst
@@ -1,0 +1,99 @@
+========
+Toolkits
+========
+
+Pyface is intended to provide a common API on top of distinct GUI backends to
+permit the same code to be run on different systems with different GUI
+toolkits and produce similar results.  Pyface comes with three built-in
+backends in the core library---Qt, WxPython, and a null backend---but provides
+hooks for other projects to contribute toolkits and have them be discoverable.
+
+Toolkit Selection
+=================
+
+Pyface uses Traits' :py:module:`traits.etsconfig` to determine the current
+toolkit being used.  Applications can control which toolkit to use in two
+ways:
+
+- by setting the environment variable ``ETS_TOOLKIT`` to the name of the
+  desired toolkit.
+- by importing :py:obj:`ETSConfig` and setting its :py:attr:`toolkit`
+  attribute appropriately::
+
+    from tratis.etsconfig.api import ETSConfig
+    ETSConfig.toolkit = 'qt4'
+
+  This must be done _before_ any widget imports in your application, including
+  importing :py:module:`pyface.api`.  Precisely, this must be set before the
+  first import of :py:module:`pyface.toolkit`.
+
+If for some reason Pyface can't load a deliberately specified toolkit, then it
+will raise an exception.
+
+If the toolkit is not specified, Pyface will try to load the ``qt4`` or ``wx``
+toolkits, in that order, and then any other toolkits that it knows about
+other than ``null``.  If all of those fail, then it will try to load the
+``null`` toolkit.
+
+Once selected, the toolkit infrastructure is largely transparent to the
+application.
+
+Toolkit Objects
+===============
+
+The selection of the correct backend object is carried out by each toolkit's
+toolkit object.  For all built-in toolkits, this is an instance of the
+:py:class:`pyface.base_toolkit.Toolkit` class, but it is possible that other
+backends may use their own objects.  The toolkit object for the toolkit that
+has been selected can be found as :py:object:`pyface.toolkit.toolkit_object`.
+
+This is a callable object which expects to be given the an identifier for the
+widget in the form of a relative module name and the object name, separated by
+a ``':'``.  This is most often used when creating new widget types for Pyface.
+The API module for the new widget class typically looks something like this::
+
+    from pyface.toolkit import toolkit_object
+    MyWidget = toolkit_object('my_package.my_widget:MyWidget')
+
+The base toolkits use the identifier to select which module to import the
+toolkit object by constructing a full module path from the partial path and
+importing the object.  For example the ``qt4`` backend will look for the
+concrete implementation in :py:module:`pyface.ui.qt4.my_package.my_widget`
+while the ``wx`` backend will look for
+:py:module:`pyface.ui.wx.my_package.my_widget`.
+
+If no matching object is found, the toolkit will return a special
+:py:class:`Undefined` class that will raise :py:exception:`NotImplementedError`
+when instantiated.
+
+The basic toolkit implementation provides two other features which may be of
+use.  It has a trait that gives the name of the toolkit, and it has a list of
+packages that it searches when trying to import a toolkit object.  This
+second trait provides a hook where an application can insert other packages
+into the search path to override the default implementations of a toolkit's
+widgets, if needed.
+
+Toolkit Entrypoints
+===================
+
+Pyface uses the standard ``pkg_resources`` "entry point" system to allow other
+libraries to contribute new toolkit implementations to Pyface.  The toolkit
+selection process discussed above looks for things contributed to the
+``pyface.toolkits`` entry point.  These are specified in the ``setup.py`` of
+the third party library, something like this::
+
+    setup(
+        # ... a bunch of other standard setup.py stuff
+        entry_points = {
+            'pyface.toolkits': [
+                'my_toolkit = my_project.my_toolkit.init:toolkit_object',
+            ]
+        }
+    )
+
+The left-hand side is the name of the toolkit, suitable for use with
+:py:object:`ETSConfig`, and the right-hand side is the location of a toolkit
+object which matches the specification above: a callable object which takes
+identifiers as specified and returns concrete implementations.  The easiest
+way to do this is to follow the examples of the current toolkits and use
+a :py:class:`pyface.base_toolkit.Toolkit` instance, but this is not required.

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -9,7 +9,7 @@ toolkit, but plugin authors are free to use whatever methods they like.
 import os
 import sys
 
-from traits.api import HasTraits, List, Str
+from traits.api import HasTraits, List, ReadOnly, Str
 
 
 class Toolkit(HasTraits):
@@ -21,7 +21,7 @@ class Toolkit(HasTraits):
     """
 
     #: The name of the toolkit
-    toolkit = ReadOnly(Str)
+    toolkit = ReadOnly
 
     #: The packages to look in for widget implementations.
     package = List(Str)

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -46,9 +46,6 @@ class Toolkit(HasTraits):
         for package in self.packages:
             try:
                 module = import_module('.' + mname, package)
-                obj = getattr(module, oname, None)
-                if obj is not None:
-                    return obj
             except ImportError as exc:
                 # is the error while trying to import package mname or not?
                 if all(part not in exc.args[0] for part in mname.split('.')):
@@ -65,6 +62,10 @@ class Toolkit(HasTraits):
                     filename, lineno, function, text = frames[-1]
                     if not self._package in filename:
                         raise
+            else:
+                obj = getattr(module, oname, None)
+                if obj is not None:
+                    return obj
 
         toolkit = self.toolkit
 

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -66,6 +66,8 @@ class Toolkit(HasTraits):
                     if not self._package in filename:
                         raise
 
+        toolkit = self.toolkit
+
         class Unimplemented(object):
             """ An unimplemented toolkit object
 
@@ -75,6 +77,6 @@ class Toolkit(HasTraits):
 
             def __init__(self, *args, **kwargs):
                 msg = "the %s pyface backend doesn't implement %s"
-                raise NotImplementedError(msg % (self.toolkit, name))
+                raise NotImplementedError(msg % (toolkit, name))
 
-        return Unimplemented(self.toolkit, name)
+        return Unimplemented

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -51,13 +51,10 @@ class Toolkit(object):
 
         mname, oname = name.split(':')
 
-        if not mname.startswith('.'):
-            mname = '.' + mname
-
         be_obj = Unimplemented(self._toolkit, name)
 
         try:
-            module = import_module(mname, self._package)
+            module = import_module('.' + mname, self._package)
 
             try:
                 be_obj = getattr(module, oname)

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -1,0 +1,83 @@
+""" A basic toolkit implementation for use by specific toolkits
+
+Writers of toolkit plugins are expected to provide a callable object which
+takes a relative module path and an object name, separated by a colon.  The
+assumption is that this is implemented by objects in sub-modules of the
+toolkit, but plugin authors are free to use whatever methods they like.
+"""
+
+import os
+import sys
+
+
+class Unimplemented(object):
+    """ An unimplemented toolkit object
+
+    This is returned if an object isn't implemented by the selected
+    toolkit.  It raises an exception if it is ever called, ie. used as a
+    toolkit object factory.
+    """
+
+    def __init__(self, toolkit, name):
+        self._toolkit = toolkit
+        self._name = name
+
+    def __call__(self, *args, **kwargs):
+        msg = "the {} pyface backend doesn't implement {}"
+        raise NotImplementedError(msg.format(self._toolkit, self._name))
+
+
+class Toolkit(object):
+    """ A basic toolkit implementation for use by specific toolkits
+
+    This implementation uses pathname mangling to find modules and objects in
+    those modules
+    """
+
+    def __init__(self, toolkit, package):
+        self._toolkit = toolkit
+        self._package = package
+
+    def __call__(self, name):
+        """ Return the toolkit specific object with the given name.
+
+        Parameters
+        ----------
+        name : str
+            The name consists of the relative module path and the object name
+            separated by a colon.
+        """
+        from importlib import import_module
+
+        mname, oname = name.split(':')
+
+        if not mname.startswith('.'):
+            mname = '.' + mname
+
+        be_obj = Unimplemented(self._toolkit, name)
+
+        try:
+            module = import_module(mname, self._package)
+
+            try:
+                be_obj = getattr(module, oname)
+            except AttributeError:
+                pass
+        except ImportError as exc:
+            # is the error while trying to import package mname or not?
+            if all(part not in exc.args[0] for part in mname.split('.')):
+                # something else went wrong - let the exception be raised
+                raise
+
+            # Ignore *ANY* errors unless a debug ENV variable is set.
+            if 'ETS_DEBUG' in os.environ:
+                # Attempt to only skip errors in importing the backend modules.
+                # The idea here is that this only happens when the last entry in
+                # the traceback's stack frame mentions the toolkit in question.
+                import traceback
+                frames = traceback.extract_tb(sys.exc_traceback)
+                filename, lineno, function, text = frames[-1]
+                if not self._package in filename:
+                    raise
+
+        return be_obj

--- a/pyface/tests/test_new_toolkit/init.py
+++ b/pyface/tests/test_new_toolkit/init.py
@@ -1,0 +1,5 @@
+# Dummy toolkit for testing entrypoints
+
+from pyface.base_toolkit import Toolkit
+
+toolkit_object = Toolkit('test', 'pyface.tests.test_new_toolkit')

--- a/pyface/tests/test_new_toolkit/widget.py
+++ b/pyface/tests/test_new_toolkit/widget.py
@@ -1,0 +1,9 @@
+# Dummy widget module for testing entrypoints
+
+from traits.api import provides
+from pyface.i_widget import IWidget, MWidget
+
+
+@provides(IWidget)
+class Widget(MWidget):
+    pass

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -35,9 +35,8 @@ class TestToolkit(unittest.TestCase):
 
         self.assertEqual(Widget, TestWidget)
 
-    def test_toolkit_object_override(self):
-        # test that the Toolkit class works as expected
-        # note that if this fails many other things will too
+    def test_toolkit_object_overriden(self):
+        # test that the Toolkit class search paths can be overridden
         from pyface.tests.test_new_toolkit.widget import Widget as TestWidget
 
         toolkit_object = pyface.toolkit.toolkit_object
@@ -47,5 +46,18 @@ class TestToolkit(unittest.TestCase):
         try:
             Widget = toolkit_object('widget:Widget')
             self.assertEqual(Widget, TestWidget)
+        finally:
+            toolkit_object.packages = old_packages
+
+    def test_toolkit_object_not_overriden(self):
+        # test that the Toolkit class works when object not overridden
+        toolkit_object = pyface.toolkit.toolkit_object
+        TestWindow = toolkit_object('window:Window')
+
+        old_packages = toolkit_object.packages
+        toolkit_object.packages = ['pyface.tests.test_new_toolkit'] + old_packages
+        try:
+            Window = toolkit_object('window:Window')
+            self.assertEqual(Window, TestWindow)
         finally:
             toolkit_object.packages = old_packages

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -1,11 +1,14 @@
+import pkg_resources
+
 from traits.testing.unittest_tools import unittest
+
 import pyface.toolkit
 
 
 class TestToolkit(unittest.TestCase):
 
     def test_missing_import(self):
-        # test that we get an undefined object if no Qt implementation
+        # test that we get an undefined object if no toolkit implementation
         cls = pyface.toolkit.toolkit_object('tests:Missing')
         with self.assertRaises(NotImplementedError):
             obj = cls()
@@ -14,3 +17,35 @@ class TestToolkit(unittest.TestCase):
         # test that we don't filter unrelated import errors
         with self.assertRaises(ImportError):
             cls = pyface.toolkit.toolkit_object('tests.bad_import:Missing')
+
+    def test_core_plugins(self):
+        # test that we can see appropriate core entrypoints
+        plugins = set(entry_point.name for entry_point in
+                      pkg_resources.iter_entry_points('pyface.toolkits'))
+
+        self.assertLessEqual({'qt4', 'wx', 'null'}, plugins)
+
+    def test_toolkit_object(self):
+        # test that the Toolkit class works as expected
+        # note that if this fails many other things will too
+        from pyface.tests.test_new_toolkit.init import toolkit_object
+        from pyface.tests.test_new_toolkit.widget import Widget as TestWidget
+
+        Widget = toolkit_object('widget:Widget')
+
+        self.assertEqual(Widget, TestWidget)
+
+    def test_toolkit_object_override(self):
+        # test that the Toolkit class works as expected
+        # note that if this fails many other things will too
+        from pyface.tests.test_new_toolkit.widget import Widget as TestWidget
+
+        toolkit_object = pyface.toolkit.toolkit_object
+
+        old_packages = toolkit_object.packages
+        toolkit_object.packages = ['pyface.tests.test_new_toolkit'] + old_packages
+        try:
+            Widget = toolkit_object('widget:Widget')
+            self.assertEqual(Widget, TestWidget)
+        finally:
+            toolkit_object.packages = old_packages

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -98,8 +98,7 @@ def _init_toolkit():
         return import_toolkit(ETSConfig.toolkit)
 
     # Try known toolkits first.
-    known_toolkits = ('qt4', 'wx')
-    for tk in known_toolkits:
+    for tk in ('qt4', 'wx'):
         try:
             with provisional_toolkit(tk):
                 return import_toolkit(tk)
@@ -109,7 +108,7 @@ def _init_toolkit():
             msg = "Could not import Pyface backend %r"
             logger.log(level, msg, tk, excinfo=exc_info)
 
-    # Try all non-null plugins we can find untill success.
+    # Try all non-null plugins we can find until success.
     for plugin in pkg_resources.iter_entry_points('pyface.toolkits'):
         if plugin.name == 'null':
             continue
@@ -142,8 +141,6 @@ def _init_toolkit():
     # if everything else fails toolkit is None
     return None
 
+
 # The toolkit object function.
 toolkit_object = _init_toolkit()
-
-# Only allow initialization to happen once.
-del _init_toolkit

--- a/pyface/ui/null/init.py
+++ b/pyface/ui/null/init.py
@@ -10,7 +10,6 @@
 """ Initialize this backend.
 """
 
-# There is nothing for us to initialize, but the toolkit switching code depends
-# on the existence of this module.
+from pyface.base_toolkit import Toolkit
 
-#### EOF ######################################################################
+toolkit_object = Toolkit('null', 'pyface.ui.null')

--- a/pyface/ui/null/init.py
+++ b/pyface/ui/null/init.py
@@ -12,4 +12,4 @@
 
 from pyface.base_toolkit import Toolkit
 
-toolkit_object = Toolkit('null', ['pyface.ui.null'])
+toolkit_object = Toolkit('null', 'pyface.ui.null')

--- a/pyface/ui/null/init.py
+++ b/pyface/ui/null/init.py
@@ -12,4 +12,4 @@
 
 from pyface.base_toolkit import Toolkit
 
-toolkit_object = Toolkit('null', 'pyface.ui.null')
+toolkit_object = Toolkit('null', ['pyface.ui.null'])

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -2,20 +2,21 @@
 # Copyright (c) 2007, Riverbank Computing Limited
 # All rights reserved.
 #
-# This software is provided without warranty under the terms of the BSD license.
-# However, when used with the GPL version of PyQt the additional terms described in the PyQt GPL exception also apply
-
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
 #
-# Author: Riverbank Computing Limited
-# Description: <Enthought pyface package component>
+# This software is provided without warranty under the terms of the BSD
+# license.  However, when used with the GPL version of PyQt the additional
+# terms described in the PyQt GPL exception also apply.
+#
+# Author: Riverbank Computing Limited and Enthought developers
 #------------------------------------------------------------------------------
 
 
-# Standard library imports.
 import sys
 
-# Major package imports.
 from pyface.qt import QtCore, QtGui, qt_api
+from pyface.base_toolkit import Toolkit
 
 if qt_api == 'pyqt':
     # Check the version numbers are late enough.
@@ -35,4 +36,6 @@ _app = QtGui.QApplication.instance()
 if _app is None:
     _app = QtGui.QApplication(sys.argv)
 
-#### EOF ######################################################################
+
+# create the toolkit object
+toolkit_object = Toolkit('qt4', 'pyface.ui.qt4')

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -38,4 +38,4 @@ if _app is None:
 
 
 # create the toolkit object
-toolkit_object = Toolkit('qt4', ['pyface.ui.qt4'])
+toolkit_object = Toolkit('qt4', 'pyface.ui.qt4')

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -38,4 +38,4 @@ if _app is None:
 
 
 # create the toolkit object
-toolkit_object = Toolkit('qt4', 'pyface.ui.qt4')
+toolkit_object = Toolkit('qt4', ['pyface.ui.qt4'])

--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -36,4 +36,4 @@ wx.Log.SetActiveTarget(_log)
 
 
 # create the toolkit object
-toolkit_object = Toolkit('wx', ['pyface.ui.wx'])
+toolkit_object = Toolkit('wx', 'pyface.ui.wx')

--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -1,17 +1,21 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2007, Riverbank Computing Limited
-#  All rights reserved.
+# Copyright (c) 2007, Riverbank Computing Limited
+# All rights reserved.
 #
-#  This software is provided without warranty under the terms of the BSD
-#  license included in enthought/LICENSE.txt and may be redistributed only
-#  under the conditions described in the aforementioned license.  The license
-#  is also available online at http://www.enthought.com/licenses/BSD.txt
+# Copyright (c) 2017, Enthought, Inc.
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 #------------------------------------------------------------------------------
 
-# Major package imports.
 import wx
+
+from pyface.base_toolkit import Toolkit
 
 
 # Check the version number is late enough.
@@ -20,13 +24,18 @@ if wx.VERSION < (2, 8):
         "Need wx version 2.8 or higher, but got %s" % str(wx.VERSION)
     )
 
+
 # It's possible that it has already been initialised.
 _app = wx.GetApp()
-
 if _app is None:
     _app = wx.App()
+
 
 # stop logging to a modal window by default
 # (apps can override by setting a different active target)
 _log = wx.LogStderr()
 wx.Log.SetActiveTarget(_log)
+
+
+# create the toolkit object
+toolkit_object = Toolkit('wx', 'pyface.ui.wx')

--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -1,5 +1,4 @@
 #------------------------------------------------------------------------------
-#
 # Copyright (c) 2007, Riverbank Computing Limited
 # All rights reserved.
 #
@@ -10,7 +9,6 @@
 # license included in enthought/LICENSE.txt and may be redistributed only
 # under the conditions described in the aforementioned license.  The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
-#
 #------------------------------------------------------------------------------
 
 import wx
@@ -38,4 +36,4 @@ wx.Log.SetActiveTarget(_log)
 
 
 # create the toolkit object
-toolkit_object = Toolkit('wx', 'pyface.ui.wx')
+toolkit_object = Toolkit('wx', ['pyface.ui.wx'])

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,13 @@ if __name__ == "__main__":
             'ui/wx/grid/images/*',
           ]},
           packages=find_packages(),
+          entry_points = {
+              'pyface.toolkits': [
+                  'qt4 = pyface.ui.qt4.init:toolkit_object',
+                  'wx = pyface.ui.wx.init:toolkit_object',
+                  'null = pyface.ui.null.init:toolkit_object',
+              ],
+          },
           platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
           zip_safe=False,
           use_2to3=True,


### PR DESCRIPTION
This PR makes the toolkit selection mechanism a lot cleaner, clearer and more standard.  We use the `pkg_resources` mechanisms to look for `pyface.toolkit` entry points.  This allows third-party libraries to add new backends.  The core library provides entry points for `qt4`, `wx` and `null` backends.

We also provide a base class for the `toolkit_object` importers which allows multiple packages to be searched for backend implementations of toolkit objects.  This allows applications to more easily support custom widgets for multiple toolkits.