### PR TITLE
Fix badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,8 +5,8 @@ pyface: traits-capable windowing framework
 .. image:: https://travis-ci.org/enthought/pyface.svg?branch=master
     :target: https://travis-ci.org/enthought/pyface
 
-.. image:: https://ci.appveyor.com/api/projects/status/7xxghu5phbvml75j/branch/master?svg=true
-    :target: https://ci.appveyor.com/project/itziakos/pyface/branch/master
+.. image:: https://ci.appveyor.com/api/projects/status/68nfb049cdq9wqd1/branch/master?svg=true
+    :target: https://ci.appveyor.com/project/EnthoughtOSS/pyface/branch/master
 
 .. image:: https://codecov.io/github/enthought/pyface/coverage.svg?branch=master
     :target: https://codecov.io/github/enthought/pyface?branch=master

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,7 @@ pyface: traits-capable windowing framework
 .. image:: https://codecov.io/github/enthought/pyface/coverage.svg?branch=master
     :target: https://codecov.io/github/enthought/pyface?branch=master
 
+
 The pyface project contains a toolkit-independent GUI abstraction layer,
 which is used to support the "visualization" features of the Traits package.
 Thus, you can write code in terms of the Traits API (views, items, editors,


### PR DESCRIPTION
Redirect the appveyor build badge to EnthoughtOSS account