### PR TITLE
Qt5 v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ matrix:
     - env: RUNTIME=2.7 TOOLKIT=pyside
     - env: RUNTIME=2.7 TOOLKIT=wx
     - env: RUNTIME=3.5 TOOLKIT=pyqt
+    - env: RUNTIME=3.5 TOOLKIT=pyqt5
     - os: osx
       env: RUNTIME=2.7 TOOLKIT=pyqt
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
       env: RUNTIME=2.7 TOOLKIT=wx
     - os: osx
       env: RUNTIME=3.5 TOOLKIT=pyqt
+  allow_failures:
+    - env: RUNTIME=3.5 TOOLKIT=pyqt5
 cache:
   directories:
     - $HOME/.cache

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -23,7 +23,7 @@ except ImportError:
 
 __requires__ = ['traits']
 __extras_require__ = {
-    'wx': ['wxpython>=2.8.10', 'numpy', 'expat'],
+    'wx': ['wxpython>=2.8.10', 'numpy'],
     'pyqt': ['pyqt>=4.10', 'pygments'],
     'pyqt5': ['pyqt>=5', 'pygments'],
     'pyside': ['pyside>=1.2', 'pygments'],

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -23,7 +23,7 @@ except ImportError:
 
 __requires__ = ['traits']
 __extras_require__ = {
-    'wx': ['wxpython>=2.8.10', 'numpy'],
+    'wx': ['wxpython>=2.8.10', 'numpy', 'expat'],
     'pyqt': ['pyqt>=4.10', 'pygments'],
     'pyside': ['pyside>=1.2', 'pygments'],
 }

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -25,5 +25,6 @@ __requires__ = ['traits']
 __extras_require__ = {
     'wx': ['wxpython>=2.8.10', 'numpy', 'expat'],
     'pyqt': ['pyqt>=4.10', 'pygments'],
+    'pyqt5': ['pyqt>=5', 'pygments'],
     'pyside': ['pyside>=1.2', 'pygments'],
 }

--- a/pyface/qt/QtCore.py
+++ b/pyface/qt/QtCore.py
@@ -12,6 +12,18 @@ if qt_api == 'pyqt':
     __version__ = QT_VERSION_STR
     __version_info__ = tuple(map(int, QT_VERSION_STR.split('.')))
 
+elif qt_api == 'pyqt5':
+    from PyQt5.QtCore import *
+
+    from PyQt5.QtCore import pyqtProperty as Property
+    from PyQt5.QtCore import pyqtSignal as Signal
+    from PyQt5.QtCore import pyqtSlot as Slot
+    from PyQt5.Qt import QCoreApplication
+    from PyQt5.Qt import Qt
+
+    __version__ = QT_VERSION_STR
+    __version_info__ = tuple(map(int, QT_VERSION_STR.split('.')))
+
 else:
     try:
         from PySide import __version__, __version_info__

--- a/pyface/qt/QtGui.py
+++ b/pyface/qt/QtGui.py
@@ -3,6 +3,11 @@ from . import qt_api
 if qt_api == 'pyqt':
     from PyQt4.Qt import QKeySequence, QTextCursor
     from PyQt4.QtGui import *
-    
+
+elif qt_api == 'pyqt5':
+    from PyQt5.QtGui import *
+    from PyQt5.QtWidget import *
+    from PyQt5.QtPrintSupport import *
+
 else:
     from PySide.QtGui import *

--- a/pyface/qt/QtGui.py
+++ b/pyface/qt/QtGui.py
@@ -8,6 +8,10 @@ elif qt_api == 'pyqt5':
     from PyQt5.QtGui import *
     from PyQt5.QtWidget import *
     from PyQt5.QtPrintSupport import *
+    from PyQt5.QtCore import (
+        QAbstractProxyModel, QItemSelection, QItemSelectionModel,
+        QItemSelectionRange, QSortFilterProxyModel, QStringListModel
+    )
 
 else:
     from PySide.QtGui import *

--- a/pyface/qt/QtGui.py
+++ b/pyface/qt/QtGui.py
@@ -6,7 +6,7 @@ if qt_api == 'pyqt':
 
 elif qt_api == 'pyqt5':
     from PyQt5.QtGui import *
-    from PyQt5.QtWidget import *
+    from PyQt5.QtWidgets import *
     from PyQt5.QtPrintSupport import *
     from PyQt5.QtCore import (
         QAbstractProxyModel, QItemSelection, QItemSelectionModel,

--- a/pyface/qt/QtNetwork.py
+++ b/pyface/qt/QtNetwork.py
@@ -2,6 +2,9 @@ from . import qt_api
 
 if qt_api == 'pyqt':
     from PyQt4.QtNetwork import *
-    
+
+elif qt_api == 'pyqt5':
+    from PyQt5.QtNetwork import *
+
 else:
     from PySide.QtNetwork import *

--- a/pyface/qt/QtOpenGL.py
+++ b/pyface/qt/QtOpenGL.py
@@ -2,6 +2,9 @@ from . import qt_api
 
 if qt_api == 'pyqt':
     from PyQt4.QtOpenGL import *
-    
+
+if qt_api == 'pyqt5':
+    from PyQt5.QtOpenGL import *
+
 else:
     from PySide.QtOpenGL import *

--- a/pyface/qt/QtScript.py
+++ b/pyface/qt/QtScript.py
@@ -2,6 +2,10 @@ from . import qt_api
 
 if qt_api == 'pyqt':
     from PyQt4.QtScript import *
-    
+
+if qt_api == 'pyqt5':
+    import warnings
+    warnings.warn(DeprecationWarning("QtScript is not supported in PyQt5"))
+
 else:
     from PySide.QtScript import *

--- a/pyface/qt/QtSvg.py
+++ b/pyface/qt/QtSvg.py
@@ -2,6 +2,9 @@ from . import qt_api
 
 if qt_api == 'pyqt':
     from PyQt4.QtSvg import *
-    
+
+elif qt_api == 'pyqt5':
+    from PyQt5.QtSvg import *
+
 else:
     from PySide.QtSvg import *

--- a/pyface/qt/QtTest.py
+++ b/pyface/qt/QtTest.py
@@ -2,6 +2,9 @@ from . import qt_api
 
 if qt_api == 'pyqt':
     from PyQt4.QtTest import *
-    
+
+elif qt_api == 'pyqt5':
+    from PyQt5.QtTest import *
+
 else:
     from PySide.QtTest import *

--- a/pyface/qt/QtWebKit.py
+++ b/pyface/qt/QtWebKit.py
@@ -2,6 +2,10 @@ from . import qt_api
 
 if qt_api == 'pyqt':
     from PyQt4.QtWebKit import *
-    
+
+elif qt_api == 'pyqt5':
+    from PyQt5.QtWidgets import *
+    from PyQt5.QtWebKitWidgets import *
+
 else:
     from PySide.QtWebKit import *

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -41,10 +41,6 @@ for api_name, module in QtAPIs:
 
 # does our environment give us a preferred API?
 qt_api = os.environ.get('QT_API')
-if qt_api not in {api_name for api_name, module in QtAPIs}:
-    msg = ("Invalid Qt API %r, valid values are: " +
-           "'pyside, 'pyside2, 'pyqt' or 'pyqt5'") % qt_api
-    raise RuntimeError(msg)
 
 # if we have no preference, is a Qt API available? Or fail with ImportError.
 if qt_api is None:
@@ -57,6 +53,13 @@ if qt_api is None:
             continue
         else:
             raise ImportError('Cannot import PySide2, PySide, PyQt5 or PyQt4')
+
+# otherwise check QT_API value is valid
+elif qt_api not in {api_name for api_name, module in QtAPIs}:
+    msg = ("Invalid Qt API %r, valid values are: " +
+           "'pyside, 'pyside2, 'pyqt' or 'pyqt5'") % qt_api
+    raise RuntimeError(msg)
+
 
 if qt_api == 'pyqt':
     # set the PyQt4 APIs

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -14,7 +14,6 @@ import os
 import sys
 
 QtAPIs = [
-    ('pyside2', 'PySide2'),
     ('pyside', 'PySide'),
     ('pyqt5', 'PyQt5'),
     ('pyqt', 'PyQt4'),
@@ -52,12 +51,12 @@ if qt_api is None:
         except ImportError:
             continue
         else:
-            raise ImportError('Cannot import PySide2, PySide, PyQt5 or PyQt4')
+            raise ImportError('Cannot import PySide, PyQt5 or PyQt4')
 
 # otherwise check QT_API value is valid
 elif qt_api not in {api_name for api_name, module in QtAPIs}:
     msg = ("Invalid Qt API %r, valid values are: " +
-           "'pyside, 'pyside2, 'pyqt' or 'pyqt5'") % qt_api
+           "'pyside, 'pyqt' or 'pyqt5'") % qt_api
     raise RuntimeError(msg)
 
 

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -38,9 +38,9 @@ for api_name, module in QtAPIs:
     if module in sys.modules:
         qt_api = api_name
         break
-
-# does our environment give us a preferred API?
-qt_api = os.environ.get('QT_API')
+else:
+    # does our environment give us a preferred API?
+    qt_api = os.environ.get('QT_API')
 
 # if we have no preference, is a Qt API available? Or fail with ImportError.
 if qt_api is None:

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -36,8 +36,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_destroy(self):
         # test that destroy works even when no control
-        with self.delete_widget(self.dialog.control):
-            self.dialog.destroy()
+        self.dialog.destroy()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -105,8 +104,3 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         parent.close()
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
-
-        with self.delete_widget(self.dialog.control):
-            self.dialog.destroy()
-        with self.delete_widget(parent.control):
-            parent.destroy()

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -8,15 +8,25 @@ from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
-class TestAboutDialog(unittest.TestCase):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = AboutDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -24,7 +24,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 
@@ -36,7 +36,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_destroy(self):
         # test that destroy works even when no control
-        with self.destroy_widget(self.dialog.control):
+        with self.delete_widget(self.dialog.control):
             self.dialog.destroy()
 
     def test_create_parent(self):
@@ -47,9 +47,9 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
 
-        with self.destroy_widget(self.dialog.control):
+        with self.delete_widget(self.dialog.control):
             self.dialog.destroy()
-        with self.destroy_widget(parent.control):
+        with self.delete_widget(parent.control):
             parent.destroy()
 
     def test_create_ok_renamed(self):
@@ -106,7 +106,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-        with self.destroy_widget(self.dialog.control):
+        with self.delete_widget(self.dialog.control):
             self.dialog.destroy()
-        with self.destroy_widget(parent.control):
+        with self.delete_widget(parent.control):
             parent.destroy()

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -36,7 +36,8 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
+        with self.destroy_widget(self.dialog.control):
+            self.dialog.destroy()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -45,8 +46,11 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         parent._create()
         self.dialog._create()
         self.gui.process_events()
-        self.dialog.destroy()
-        parent.destroy()
+
+        with self.destroy_widget(self.dialog.control):
+            self.dialog.destroy()
+        with self.destroy_widget(parent.control):
+            parent.destroy()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
@@ -101,3 +105,8 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         parent.close()
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
+
+        with self.destroy_widget(self.dialog.control):
+            self.dialog.destroy()
+        with self.destroy_widget(parent.control):
+            parent.destroy()

--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -20,7 +20,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.window.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -1,18 +1,28 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import unittest
 
 from ..action.api import Action, MenuManager, MenuBarManager, StatusBarManager, ToolBarManager
 from ..application_window import ApplicationWindow
-from ..gui import GUI
+from ..toolkit import toolkit_object
 from ..image_resource import ImageResource
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-class TestApplicationWindow(unittest.TestCase, UnittestTools):
+
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = ApplicationWindow()
+
+    def tearDown(self):
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.window.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_close(self):
         # test that close works even when no control

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -199,7 +199,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
-class TestConfirm(unittest.TestCase, GuiTestAssitant):
+class TestConfirm(unittest.TestCase, GuiTestAssistant):
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_reject(self):

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import os
+
+from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
 from ..confirmation_dialog import ConfirmationDialog, confirm
@@ -14,6 +17,8 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
+
+is_pyqt5 = (ETSConfig.toolkit == 'qt4' and os.environ.get('QT_API') == 'pyqt5')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
@@ -132,6 +137,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_yes(self):
         # test that Yes works as expected
@@ -140,6 +146,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_yes(self):
         self.dialog.yes_label = u"Sure"
@@ -149,6 +156,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_no(self):
         # test that No works as expected
@@ -157,6 +165,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_no(self):
         self.dialog.no_label = u"No way"
@@ -166,6 +175,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         self.dialog.cancel = True
@@ -175,6 +185,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel_renamed(self):
         self.dialog.cancel = True
@@ -198,6 +209,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, OK)
 
 
+
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestConfirm(unittest.TestCase, GuiTestAssistant):
 
@@ -214,6 +226,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         tester.open_and_run(when_opened=lambda x: x.close(accept=False))
         self.assertEqual(tester.result, CANCEL)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_yes(self):
         # test that yes works as expected
@@ -222,6 +235,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.assertEqual(tester.result, YES)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_no(self):
         # test that yes works as expected
@@ -230,6 +244,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.assertEqual(tester.result, NO)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         # test that cancel works as expected

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -198,10 +198,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, OK)
 
 
-class TestConfirm(unittest.TestCase):
-
-    def setUp(self):
-        self.gui = GUI()
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestConfirm(unittest.TestCase, GuiTestAssitant):
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_reject(self):

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -25,7 +25,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -9,15 +9,25 @@ from ..image_resource import ImageResource
 from ..toolkit import toolkit_object
 from ..window import Window
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
-class TestConfirmationDialog(unittest.TestCase):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = ConfirmationDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -201,6 +201,12 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestConfirm(unittest.TestCase, GuiTestAssistant):
 
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+
+    def tearDown(self):
+        GuiTestAssistant.tearDown(self)
+
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_reject(self):
         # test that cancel works as expected

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -23,7 +23,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -18,7 +18,7 @@ no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        GuiTestAssistant.setUp()
+        GuiTestAssistant.setUp(self)
         self.dialog = Dialog()
 
     def tearDown(self):

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -7,15 +7,25 @@ from ..constant import OK, CANCEL
 from ..gui import GUI
 from ..toolkit import toolkit_object
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
-class TestDialog(unittest.TestCase):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp()
         self.dialog = Dialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_directory_dialog.py
+++ b/pyface/tests/test_directory_dialog.py
@@ -24,7 +24,7 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_directory_dialog.py
+++ b/pyface/tests/test_directory_dialog.py
@@ -8,15 +8,25 @@ from ..directory_dialog import DirectoryDialog
 from ..gui import GUI
 from ..toolkit import toolkit_object
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
-class TestDirectoryDialog(unittest.TestCase):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = DirectoryDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_file_dialog.py
+++ b/pyface/tests/test_file_dialog.py
@@ -24,7 +24,7 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_file_dialog.py
+++ b/pyface/tests/test_file_dialog.py
@@ -8,15 +8,25 @@ from ..file_dialog import FileDialog
 from ..gui import GUI
 from ..toolkit import toolkit_object
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
-class TestFileDialog(unittest.TestCase):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestFileDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = FileDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create_wildcard(self):
         wildcard = FileDialog.create_wildcard('Python', '*.py')

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -21,10 +21,10 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.widget.control is not None:
-            with self.destroy_widget(self.widget.control):
+            with self.delete_widget(self.widget.control):
                 self.widget.destroy()
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.window.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -2,22 +2,31 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..gui import GUI
 from ..heading_text import HeadingText
 from ..image_resource import ImageResource
+from ..toolkit import toolkit_object
 from ..window import Window
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-class TestHeadingText(unittest.TestCase):
+
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestHeadingText(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = Window()
         self.window._create()
 
     def tearDown(self):
-        self.widget.destroy()
-        self.window.destroy()
+        if self.widget.control is not None:
+            with self.destroy_widget(self.widget.control):
+                self.widget.destroy()
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.window.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):
         # test that destroy works

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -28,7 +28,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -160,8 +160,9 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, OK)
 
 
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-class TestMessageDialogHelpers(unittest.TestCase):
+class TestMessageDialogHelpers(unittest.TestCase, GuiTestAssistant):
 
     def test_information(self):
         self._check_dialog(information)

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import os
+
 from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
@@ -16,7 +18,8 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
-USING_QT = ETSConfig.toolkit not in ['', 'wx']
+USING_QT = ETSConfig.toolkit not in ['', 'null', 'wx']
+is_pyqt5 = (ETSConfig.toolkit == 'qt4' and os.environ.get('QT_API') == 'pyqt5')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
@@ -129,6 +132,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
+    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_ok(self):
         # test that OK works as expected

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -20,7 +20,7 @@ USING_QT = ETSConfig.toolkit not in ['', 'wx']
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
-class TestMessageDialog(unittest.TestCase):
+class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
         GuiTestAssistant.setUp(self)

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -9,18 +9,28 @@ from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 
-ModalDialogTester = toolkit_object(
-    'util.modal_dialog_tester:ModalDialogTester')
+
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
+ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 USING_QT = ETSConfig.toolkit not in ['', 'wx']
 
 
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestMessageDialog(unittest.TestCase):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = MessageDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -7,15 +7,25 @@ from ..gui import GUI
 from ..progress_dialog import ProgressDialog
 from ..toolkit import toolkit_object
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
-class TestDialog(unittest.TestCase):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = ProgressDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -23,7 +23,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -3,26 +3,35 @@ from __future__ import absolute_import
 import os
 import sys
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import unittest
 
-from ..gui import GUI
 from ..python_editor import PythonEditor
+from ..toolkit import toolkit_object
 from ..window import Window
+
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 
 PYTHON_SCRIPT = os.path.join(os.path.dirname(__file__), 'python_shell_script.py')
 
 
-class TestPythonEditor(unittest.TestCase, UnittestTools):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = Window()
         self.window._create()
 
     def tearDown(self):
-        self.widget.destroy()
-        self.window.destroy()
+        if self.widget.control is not None:
+            with self.destroy_widget(self.widget.control):
+                self.widget.destroy()
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.window.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):
         # test that destroy works

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -26,10 +26,10 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.widget.control is not None:
-            with self.destroy_widget(self.widget.control):
+            with self.delete_widget(self.widget.control):
                 self.widget.destroy()
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.window.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -3,27 +3,36 @@ from __future__ import absolute_import
 import os
 import sys
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import unittest
 
-from ..gui import GUI
 from ..python_shell import PythonShell
+from ..toolkit import toolkit_object
 from ..window import Window
+
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 
 PYTHON_SCRIPT = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                 'python_shell_script.py'))
 
 
-class TestPythonShell(unittest.TestCase, UnittestTools):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestPythonShell(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = Window()
         self.window._create()
 
     def tearDown(self):
-        self.widget.destroy()
-        self.window.destroy()
+        if self.widget.control is not None:
+            with self.destroy_widget(self.widget.control):
+                self.widget.destroy()
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.window.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):
         # test that destroy works

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -27,10 +27,10 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.widget.control is not None:
-            with self.destroy_widget(self.widget.control):
+            with self.delete_widget(self.widget.control):
                 self.widget.destroy()
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.window.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -43,7 +43,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -25,16 +25,27 @@ from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 USING_QT = ETSConfig.toolkit not in ['', 'wx']
 
-class TestMessageDialog(unittest.TestCase):
+
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = SingleChoiceDialog(choices=['red', 'blue', 'green'])
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import unittest
 
 from ..gui import GUI
 from ..image_resource import ImageResource
@@ -12,7 +12,7 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
-class TestWindow(unittest.TestCase, UnittestTools):
+class TestWindow(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
         GuiTestAssistant.setUp(self)

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -5,13 +5,24 @@ from traits.testing.unittest_tools import unittest, UnittestTools
 from ..gui import GUI
 from ..image_resource import ImageResource
 from ..splash_screen import SplashScreen
+from ..toolkit import toolkit_object
+
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestWindow(unittest.TestCase, UnittestTools):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = SplashScreen()
+
+    def tearDown(self):
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.widnow.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_destroy(self):
         # test that destroy works even when no control

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -20,7 +20,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.widnow.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_split_application_window.py
+++ b/pyface/tests/test_split_application_window.py
@@ -19,7 +19,7 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.window.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_split_application_window.py
+++ b/pyface/tests/test_split_application_window.py
@@ -1,17 +1,27 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import unittest
 
-from ..gui import GUI
 from ..heading_text import HeadingText
 from ..split_application_window import SplitApplicationWindow
+from ..toolkit import toolkit_object
+
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 
-class TestSplitApplicationWindow(unittest.TestCase, UnittestTools):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = SplitApplicationWindow()
+
+    def tearDown(self):
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.window.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_destroy(self):
         # test that destroy works even when no control

--- a/pyface/tests/test_split_dialog.py
+++ b/pyface/tests/test_split_dialog.py
@@ -2,16 +2,26 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..gui import GUI
 from ..heading_text import HeadingText
 from ..split_dialog import SplitDialog
+from ..toolkit import toolkit_object
+
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 
-class TestDialog(unittest.TestCase):
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = SplitDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.destroy_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/tests/test_split_dialog.py
+++ b/pyface/tests/test_split_dialog.py
@@ -19,7 +19,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.dialog.control is not None:
-            with self.destroy_widget(self.dialog.control):
+            with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -21,10 +21,10 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
 
     def tearDown(self):
         if self.widget.control is not None:
-            with self.destroy_widget(self.widget.control):
+            with self.delete_widget(self.widget.control):
                 self.widget.destroy()
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.window.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -2,22 +2,31 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..gui import GUI
 from ..heading_text import HeadingText
 from ..split_panel import SplitPanel
+from ..toolkit import toolkit_object
 from ..window import Window
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-class TestHeadingText(unittest.TestCase):
+
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestHeadingText(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = Window()
         self.window._create()
 
     def tearDown(self):
-        self.widget.destroy()
-        self.window.destroy()
+        if self.widget.control is not None:
+            with self.destroy_widget(self.widget.control):
+                self.widget.destroy()
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.window.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):
         # test that destroy works

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import unittest
 
 from ..constant import CANCEL, NO, OK, YES
 from ..gui import GUI
@@ -15,7 +15,7 @@ no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
-class TestWindow(unittest.TestCase, UnittestTools):
+class TestWindow(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
         GuiTestAssistant.setUp(self)

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -7,15 +7,25 @@ from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
+@unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestWindow(unittest.TestCase, UnittestTools):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.window = Window()
+
+    def tearDown(self):
+        if self.window.control is not None:
+            with self.destroy_widget(self.window.control):
+                self.window.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_destroy(self):
         # test that destroy works even when no control

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -23,7 +23,7 @@ class TestWindow(unittest.TestCase, UnittestTools):
 
     def tearDown(self):
         if self.window.control is not None:
-            with self.destroy_widget(self.window.control):
+            with self.delete_widget(self.window.control):
                 self.window.destroy()
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -80,18 +80,21 @@ def _init_toolkit():
             modules = ', '.join(plugin.module_name for plugin in plugins)
             logger.warning(msg, tk, modules)
 
+        exception = None
         while plugins:
             plugin = plugins.pop(0)
             try:
                 tk_object = plugin.load()
                 return tk_object
             except ImportError as exc:
+                exception = exc
                 logger.exception(exc)
                 msg = "Could not load plugin %r from %r"
                 logger.warning(msg, plugin.name, plugin.module_name)
         else:
             # no success
-            raise exc
+            if exception is not None:
+                raise exception
 
     # Get the toolkit.
     if ETSConfig.toolkit:

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -95,6 +95,8 @@ def _init_toolkit():
             # no success
             if exception is not None:
                 raise exception
+            else:
+                raise RuntimeError("No toolkit loaded or exception raised.")
 
     # Get the toolkit.
     if ETSConfig.toolkit:

--- a/pyface/toolkit.py
+++ b/pyface/toolkit.py
@@ -86,9 +86,8 @@ def _init_toolkit():
             try:
                 tk_object = plugin.load()
                 return tk_object
-            except ImportError as exc:
-                exception = exc
-                logger.exception(exc)
+            except ImportError as exception:
+                logger.exception(exception)
                 msg = "Could not load plugin %r from %r"
                 logger.warning(msg, plugin.name, plugin.module_name)
         else:

--- a/pyface/ui/qt4/directory_dialog.py
+++ b/pyface/ui/qt4/directory_dialog.py
@@ -74,7 +74,7 @@ class DirectoryDialog(MDirectoryDialog, Dialog):
         dlg.setFileMode(QtGui.QFileDialog.DirectoryOnly)
 
         if not self.new_directory:
-            dlg.setReadOnly(True)
+            dlg.setOptions(QtGui.QFileDialog.ReadOnly)
 
         if self.message:
             dlg.setLabelText(QtGui.QFileDialog.LookIn, self.message)

--- a/pyface/ui/qt4/image_cache.py
+++ b/pyface/ui/qt4/image_cache.py
@@ -41,9 +41,9 @@ class ImageCache(MImageCache, HasTraits):
     ###########################################################################
 
     def get_image(self, filename):
-        image = QtGui.QPixmap(self._width, self._height)
+        image = QtGui.QPixmapCache.find(filename)
 
-        if QtGui.QPixmapCache.find(filename, image):
+        if image is not None:
             scaled = self._qt4_scale(image)
 
             if scaled is not image:
@@ -53,7 +53,7 @@ class ImageCache(MImageCache, HasTraits):
                 QtGui.QPixmapCache.insert(filename, scaled)
         else:
             # Load the image from the file and add it to the cache.
-            image.load(filename)
+            image = QtGui.QPixmap(filename)
             scaled = self._qt4_scale(image)
             QtGui.QPixmapCache.insert(filename, scaled)
 

--- a/pyface/ui/qt4/tests/test_progress_dialog.py
+++ b/pyface/ui/qt4/tests/test_progress_dialog.py
@@ -6,16 +6,21 @@ from pyface.gui import GUI
 from pyface.toolkit import toolkit_object
 
 from ..progress_dialog import ProgressDialog
+from ..util.gui_test_assistant import GuiTestAssistant
+from ..util.modal_dialog_tester import ModalDialogTester
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
-no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
-
-class TestDialog(unittest.TestCase):
+class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
-        self.gui = GUI()
+        GuiTestAssistant.setUp(self)
         self.dialog = ProgressDialog()
+
+    def tearDown(self):
+        if self.dialog.control is not None:
+            with self.delete_widget(self.dialog.control):
+                self.dialog.destroy()
+        GuiTestAssistant.tearDown(self)
 
     def test_create(self):
         # test that creation and destruction works as expected

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -197,6 +197,7 @@ class ModalDialogTester(object):
         finally:
             condition_timer.stop()
             condition_timer.timeout.disconnect(handler)
+            self._dialog_widget = None
             self.assert_no_errors_collected()
 
     def open(self, *args, **kwargs):
@@ -267,6 +268,9 @@ class ModalDialogTester(object):
             type_,
             test=lambda widget: widget.text() == text
         )
+        if widget is None:
+            # this will only occur if there is some problem with the test
+            raise RuntimeError("Could not find matching child widget.")
         widget.click()
 
     def click_button(self, button_id):

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -22,8 +22,8 @@ from .testing import find_qt_widget
 
 
 BUTTON_TEXT = {
-    OK: '&OK' if qt_api == 'pyqt5' else 'OK',
-    CANCEL: '&Cancel' if qt_api == 'pyqt5' else 'Cancel',
+    OK: 'OK',
+    CANCEL: 'Cancel',
     YES: '&Yes',
     NO: '&No',
 }

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -14,7 +14,7 @@ import sys
 import traceback
 
 from pyface.api import GUI, OK, CANCEL, YES, NO
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtCore, QtGui, qt_api
 from traits.api import Undefined
 
 from .event_loop_helper import EventLoopHelper
@@ -22,8 +22,8 @@ from .testing import find_qt_widget
 
 
 BUTTON_TEXT = {
-    OK: 'OK',
-    CANCEL: 'Cancel',
+    OK: '&OK' if qt_api == 'pyqt5' else 'OK',
+    CANCEL: '&Cancel' if qt_api == 'pyqt5' else 'Cancel',
     YES: '&Yes',
     NO: '&No',
 }

--- a/setup.py
+++ b/setup.py
@@ -170,6 +170,7 @@ if __name__ == "__main__":
           packages=find_packages(),
           entry_points = {
               'pyface.toolkits': [
+                  'qt = pyface.ui.qt4.init:toolkit_object',
                   'qt4 = pyface.ui.qt4.init:toolkit_object',
                   'wx = pyface.ui.wx.init:toolkit_object',
                   'null = pyface.ui.null.init:toolkit_object',

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,6 @@ if __name__ == "__main__":
           packages=find_packages(),
           entry_points = {
               'pyface.toolkits': [
-                  'qt = pyface.ui.qt4.init:toolkit_object',
                   'qt4 = pyface.ui.qt4.init:toolkit_object',
                   'wx = pyface.ui.wx.init:toolkit_object',
                   'null = pyface.ui.null.init:toolkit_object',

--- a/tasks.py
+++ b/tasks.py
@@ -66,6 +66,7 @@ how to run commands within an EDM enviornment.
 from contextlib import contextmanager
 import os
 from shutil import rmtree, copy as copyfile
+import sys
 from tempfile import mkdtemp
 
 from invoke import task
@@ -89,14 +90,17 @@ dependencies = {
 extra_dependencies = {
     'pyside': {'pyside'},
     'pyqt': {'pyqt'},
-    'pyqt5': {'pyqt5'},
-    'wx': {'wxpython'},
+    # XXX once pyqt5 is available in EDM, we will want it here
+    'pyqt5': {},
+    # XXX temporary workaround for bug in recent EDM wxpython build on OS X
+    'wx': {'wxpython' if sys.platform != 'darwin' else 'wxpython==3.0.2.0-3'},
     'null': set()
 }
 
 environment_vars = {
     'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
-    'pyqt': {'ETS_TOOLKIT': 'qt', 'QT_API': 'pyqt5'},
+    'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
+    'pyqt5': {'ETS_TOOLKIT': 'qt', 'QT_API': 'pyqt5'},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null'},
 }

--- a/tasks.py
+++ b/tasks.py
@@ -91,7 +91,7 @@ extra_dependencies = {
     'pyside': {'pyside'},
     'pyqt': {'pyqt'},
     # XXX once pyqt5 is available in EDM, we will want it here
-    'pyqt5': {},
+    'pyqt5': set(),
     # XXX temporary workaround for bug in recent EDM wxpython build on OS X
     'wx': {'wxpython' if sys.platform != 'darwin' else 'wxpython==3.0.2.0-3'},
     'null': set()

--- a/tasks.py
+++ b/tasks.py
@@ -100,7 +100,7 @@ extra_dependencies = {
 environment_vars = {
     'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
     'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
-    'pyqt5': {'ETS_TOOLKIT': 'qt', 'QT_API': 'pyqt5'},
+    'pyqt5': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt5'},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null'},
 }

--- a/tasks.py
+++ b/tasks.py
@@ -73,8 +73,8 @@ from invoke import task
 
 
 supported_combinations = {
-    '2.7': {'pyside', 'pyqt', 'wx', 'null'},
-    '3.5': {'pyqt', 'pyqt5', 'null'},
+    '2.7': {'pyside', 'pyqt', 'wx'},
+    '3.5': {'pyqt', 'pyqt5'},
 }
 
 dependencies = {

--- a/tasks.py
+++ b/tasks.py
@@ -73,7 +73,7 @@ from invoke import task
 
 supported_combinations = {
     '2.7': {'pyside', 'pyqt', 'wx', 'null'},
-    '3.5': {'pyqt', 'null'},
+    '3.5': {'pyqt', 'pyqt5', 'null'},
 }
 
 dependencies = {
@@ -89,13 +89,14 @@ dependencies = {
 extra_dependencies = {
     'pyside': {'pyside'},
     'pyqt': {'pyqt'},
+    'pyqt5': {'pyqt5'},
     'wx': {'wxpython'},
     'null': set()
 }
 
 environment_vars = {
     'pyside': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyside'},
-    'pyqt': {'ETS_TOOLKIT': 'qt4', 'QT_API': 'pyqt'},
+    'pyqt': {'ETS_TOOLKIT': 'qt', 'QT_API': 'pyqt5'},
     'wx': {'ETS_TOOLKIT': 'wx'},
     'null': {'ETS_TOOLKIT': 'null'},
 }
@@ -118,6 +119,12 @@ def install(ctx, runtime='3.5', toolkit='null', environment=None):
         # install the project
         "edm run -e '{environment}' -- python setup.py install",
     ]
+    if toolkit == 'pyqt5':
+        commands += [
+            # pip install pyqt5, because we don't have in EDM yet
+            # this assumes Qt5 is available, which implies Linux, for now
+            "edm run -e '{environment}' -- pip install pyqt5",
+        ]
 
     print("Creating environment '{environment}'".format(**parameters))
     for command in commands:


### PR DESCRIPTION
This is another attempt at Qt5 compatibility.  Following #256 we should have removed all old-style signals and slots, so at the object level, we have compatibility with Qt5.  This PR takes a different approach to the previous PRs like #171 and is inspired by a comment by @pankajp there.

This PR tries to make the PyQt5 API compatible with PyQt4, so that code which depends on pyface.qt does not need to be modified.  We may, at some future point, add a pyface.qt5 module or something similar which attempts forward compatibility instead of backwards compatibility.

To do:

- [x] CI integration for Qt5.  This is still a blocker for merging.