### PR TITLE
Travis CI for Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,29 @@ language: generic
 sudo: false
 matrix:
   include:
-    - env: RUNTIME=2.7 TOOLKIT=pyqt
-    - env: RUNTIME=2.7 TOOLKIT=pyside
-    - env: RUNTIME=2.7 TOOLKIT=wx
-    - env: RUNTIME=3.5 TOOLKIT=pyqt
-    - env: RUNTIME=3.5 TOOLKIT=pyqt5
+    - env: RUNTIME=2.7 TOOLKITS="pyqt pyside wx"
+    - env: RUNTIME=3.5 TOOLKITS=pyqt
+    - env: RUNTIME=3.5 TOOLKITS=pyqt5
+    - env: RUNTIME=3.6 TOOLKITS=pyqt
+    - env: RUNTIME=3.6 TOOLKITS=pyqt5
     - os: osx
-      env: RUNTIME=2.7 TOOLKIT=pyqt
+      env: RUNTIME=2.7 TOOLKITS="pyqt pyside wx"
     - os: osx
-      env: RUNTIME=2.7 TOOLKIT=pyside
-    - os: osx
-      env: RUNTIME=2.7 TOOLKIT=wx
-    - os: osx
-      env: RUNTIME=3.5 TOOLKIT=pyqt
+      env: RUNTIME=3.5 TOOLKITS=pyqt
   allow_failures:
-    - env: RUNTIME=3.5 TOOLKIT=pyqt5
+    - env: RUNTIME=3.5 TOOLKITS=pyqt5
 cache:
   directories:
     - $HOME/.cache
 before_install:
   - export DISPLAY=:99.0; 
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sh -e /etc/init.d/xvfb start; fi
-  - ./travis_ci_bootstrap_edm.sh
 install:
-  - edm run -- invoke install --runtime=${RUNTIME} --toolkit=${TOOLKIT}
+  - ./travis_ci_bootstrap_edm.sh
+  - for toolkit in ${TOOLKITS}; do edm run -- invoke install --runtime=${RUNTIME} --toolkit=${toolkit}; done
 script:
-  - edm run -- invoke test --runtime=${RUNTIME} --toolkit=${TOOLKIT}
+  - for toolkit in ${TOOLKITS}; do edm run -- invoke test --runtime=${RUNTIME} --toolkit=${toolkit}; done
 after_success:
+  - edm run -- coverage combine
   - edm run -- pip install codecov
   - edm run -- codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
       env: RUNTIME=3.5 TOOLKITS=pyqt
   allow_failures:
     - env: RUNTIME=3.5 TOOLKITS=pyqt5
+    - env: RUNTIME=3.6 TOOLKITS=pyqt5
 cache:
   directories:
     - $HOME/.cache

--- a/tasks.py
+++ b/tasks.py
@@ -64,6 +64,7 @@ how to run commands within an EDM enviornment.
 """
 
 from contextlib import contextmanager
+import glob
 import os
 from shutil import rmtree, copy as copyfile
 import sys

--- a/tasks.py
+++ b/tasks.py
@@ -75,6 +75,7 @@ from invoke import task
 supported_combinations = {
     '2.7': {'pyside', 'pyqt', 'wx'},
     '3.5': {'pyqt', 'pyqt5'},
+    '3.6': {'pyqt', 'pyqt5'},
 }
 
 dependencies = {
@@ -163,7 +164,7 @@ def test(ctx, runtime='3.5', toolkit='null', environment=None):
     # code from a local dir.  We need to ensure a good .coveragerc is in
     # that directory, plus coverage has a bug that means a non-local coverage
     # file doesn't get populated correctly.
-    with do_in_tempdir(files=['.coveragerc'], capture_files=['.coverage']):
+    with do_in_tempdir(files=['.coveragerc'], capture_files=['./.coverage*']):
         for command in commands:
             ctx.run(command.format(**parameters), env=environ)
 
@@ -246,6 +247,7 @@ def do_in_tempdir(files=(), capture_files=()):
 
     # send across any files we need
     for filepath in files:
+        print('copying file to tempdir: {}'.format(filepath))
         copyfile(filepath, path)
 
     os.chdir(path)
@@ -253,8 +255,10 @@ def do_in_tempdir(files=(), capture_files=()):
         yield path
 
         # retrieve any result files we want
-        for filepath in capture_files:
-            copyfile(filepath, old_path)
+        for pattern in capture_files:
+            for filepath in glob.iglob(pattern):
+                print('copying file back: {}'.format(filepath))
+                copyfile(filepath, old_path)
     finally:
         os.chdir(old_path)
         rmtree(path)

--- a/tasks.py
+++ b/tasks.py
@@ -152,6 +152,7 @@ def test(ctx, runtime='3.5', toolkit='null', environment=None):
 
     environ = environment_vars.get(toolkit, {}).copy()
     environ['PYTHONUNBUFFERED'] = "1"
+    environ['COVERAGE_FILE'] = ".coverage.{}.{}".format(runtime, toolkit)
 
     commands = [
         # run the main test suite

--- a/travis_ci_bootstrap_edm.sh
+++ b/travis_ci_bootstrap_edm.sh
@@ -12,4 +12,4 @@ else
 fi
 
 # install pip and invoke into default EDM environment
-edm install -y pip invoke
+edm install -y pip invoke coverage


### PR DESCRIPTION
Also reduce the number of Travis CI runs by combining backend tests, as done for TraitsUI tests.