### PR TITLE
Don't attempt to quit a QApplication from outside its event loop.

### DIFF
--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -52,7 +52,6 @@ class GuiTestAssistant(UnittestTools):
         with self.event_loop_with_timeout(repeat=5):
             self.gui.invoke_later(self.qt_app.closeAllWindows)
         self.qt_app.flush()
-        self.qt_app.quit()
         self.pyface_raise_patch.stop()
         self.traitsui_raise_patch.stop()
 


### PR DESCRIPTION
The `self.qt_app.quit()` call in `GuiTestAssistant.tearDown` was causing test interactions, and appears to be useless: as far as I can see, it only ever makes sense to call `quit` or `exit` from within the event loop, and if we're running the `tearDown` method from within the event loop then something's very wrong indeed.