### PR TITLE
Fixed unnecessary full re-layout of AUI when only changing a pane's name

### DIFF
--- a/pyface/ui/wx/tasks/dock_pane.py
+++ b/pyface/ui/wx/tasks/dock_pane.py
@@ -196,7 +196,10 @@ class DockPane(TaskPane, MDockPane):
         if self.control is not None:
             info = self.get_pane_info()
             self.update_dock_title(info)
-            self.commit_if_active()
+
+            # Don't need to refresh everything if only the name is changing
+            info.window.Refresh()
+            info.window.Update()
 
     def update_floating(self, info):
         if self.floating:


### PR DESCRIPTION
Simple fix that prevents a time-consuming re-layout of the entire AUI manager. The pane name can be changed with a simple refresh of the pane. Removes flicker and is sooooo much faster.