### PR TITLE
Fixed unnecessary full re-layout of AUI when only changing a pane's name

### DIFF
--- a/pyface/ui/wx/tasks/dock_pane.py
+++ b/pyface/ui/wx/tasks/dock_pane.py
@@ -151,14 +151,17 @@ class DockPane(TaskPane, MDockPane):
         info = self.task.window._aui_manager.GetPane(self.pane_name)
         return info
     
-    def commit_layout(self):
-        self.task.window._aui_manager.Update()
+    def commit_layout(self, layout=True):
+        if layout:
+            self.task.window._aui_manager.Update()
+        else:
+            self.task.window._aui_manager.UpdateWithoutLayout()
 
-    def commit_if_active(self):
+    def commit_if_active(self, layout=True):
         # Only attempt to commit the AUI changes if the area if the task is active.
         main_window = self.task.window.control
         if main_window and self.task == self.task.window.active_task:
-            self.commit_layout()
+            self.commit_layout(layout)
         else:
             logger.debug("task not active so not committing...")
 
@@ -196,7 +199,9 @@ class DockPane(TaskPane, MDockPane):
         if self.control is not None:
             info = self.get_pane_info()
             self.update_dock_title(info)
-            self.commit_if_active()
+
+            # Don't need to refresh everything if only the name is changing
+            self.commit_if_active(False)
 
     def update_floating(self, info):
         if self.floating:

--- a/pyface/wx/aui.py
+++ b/pyface/wx/aui.py
@@ -273,3 +273,21 @@ class PyfaceAuiManager(aui.AuiManager):
             self.Update()
 
         return True
+
+    def UpdateWithoutLayout(self):
+        """If the layout in the AUI manager is not changing, this can be called
+        to refresh all the panes but preventing a big time usage doing a re-
+        layout that isn't necessary.
+        """
+        pane_count = len(self._panes)
+
+        for ii in xrange(pane_count):
+            p = self._panes[ii]
+            if p.window and p.IsShown() and p.IsDocked():
+                p.window.Refresh()
+                p.window.Update()
+
+        if wx.Platform == "__WXMAC__":
+            self._frame.Refresh()
+        else:
+            self.Repaint()


### PR DESCRIPTION
OK, for realz this time. The simple fix of the last pull request has issues on different platforms, so it require a little more code. It still prevents a time-consuming re-layout of the entire AUI manager, although it does refresh everything. Still much faster than a layout, though.