### PR TITLE
Always run the event loop during tearDown.

### DIFF
--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -50,6 +50,11 @@ class GuiTestAssistant(UnittestTools):
         self.pyface_raise_patch.start()
 
     def tearDown(self):
+        # Process any tasks that a misbehaving test might have left on the
+        # queue.
+        with self.event_loop_with_timeout(repeat=5):
+            pass
+
         # Some top-level widgets may only be present due to cyclic garbage not
         # having been collected; force a garbage collection before we decide to
         # close windows. This may need several rounds.


### PR DESCRIPTION
@itziakos pointed out that #277 introduced a potential regression: before #277, the event loop was always run in the `GUITestAssistant.tearDown` method. This PR restores the running of the event loop.