### PR TITLE
Be more careful about object cleanup when tests finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,8 @@ install:
   - ./travis_ci_bootstrap_edm.sh
   - for toolkit in ${TOOLKITS}; do edm run -- invoke install --runtime=${RUNTIME} --toolkit=${toolkit}; done
 script:
-  - for toolkit in ${TOOLKITS}; do edm run -- invoke test --runtime=${RUNTIME} --toolkit=${toolkit}; done
+  - declare -i RESULT=0
+  - for toolkit in ${TOOLKITS}; do edm run -- invoke test --runtime=${RUNTIME} --toolkit=${toolkit}; RESULT+=$?; done
 after_success:
   - edm run -- coverage combine
   - edm run -- pip install codecov

--- a/pyface/tasks/tests/test_dock_pane_toggle_group.py
+++ b/pyface/tasks/tests/test_dock_pane_toggle_group.py
@@ -5,6 +5,7 @@ import unittest
 from pyface.tasks.action.api import SMenu, SMenuBar, SGroup, \
     DockPaneToggleGroup
 from pyface.tasks.api import DockPane, Task, TaskPane, TaskWindow
+from pyface.gui import GUI
 from traits.api import List
 from traits.etsconfig.api import ETSConfig
 
@@ -48,6 +49,8 @@ class DockPaneToggleGroupTestCase(unittest.TestCase):
 
     @unittest.skipIf(USING_WX, "TaskWindowBackend is not implemented in WX")
     def setUp(self):
+        self.gui = GUI()
+
         # Set up the bogus task with its window.
         self.task = BogusTask()
 
@@ -67,14 +70,15 @@ class DockPaneToggleGroupTestCase(unittest.TestCase):
         self.dock_pane_toggle_group = dock_pane_toggle_group[0]
 
     def tearDown(self):
-        self.task = None
-        self.task_state = None
-        self.dock_pane_toggle_group = None
+        del self.task
+        del self.task_state
+        del self.dock_pane_toggle_group
 
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
                 self.window.destroy()
-        self.window = None
+        del self.window
+        del self.gui
 
 
     def get_dock_pane_toggle_action_names(self):

--- a/pyface/tasks/tests/test_dock_pane_toggle_group.py
+++ b/pyface/tasks/tests/test_dock_pane_toggle_group.py
@@ -75,8 +75,8 @@ class DockPaneToggleGroupTestCase(unittest.TestCase):
         del self.dock_pane_toggle_group
 
         if self.window.control is not None:
-            with self.delete_widget(self.window.control):
-                self.window.destroy()
+            self.window.destroy()
+            self.gui.process_events()
         del self.window
         del self.gui
 

--- a/pyface/tasks/tests/test_dock_pane_toggle_group.py
+++ b/pyface/tasks/tests/test_dock_pane_toggle_group.py
@@ -51,7 +51,7 @@ class DockPaneToggleGroupTestCase(unittest.TestCase):
         # Set up the bogus task with its window.
         self.task = BogusTask()
 
-        window = TaskWindow()
+        self.window = window = TaskWindow()
         window.add_task(self.task)
 
         self.task_state = window._get_state(self.task)
@@ -65,6 +65,17 @@ class DockPaneToggleGroupTestCase(unittest.TestCase):
         self.task_state.menu_bar_manager.walk(find_doc_pane_toggle)
 
         self.dock_pane_toggle_group = dock_pane_toggle_group[0]
+
+    def tearDown(self):
+        self.task = None
+        self.task_state = None
+        self.dock_pane_toggle_group = None
+
+        if self.window.control is not None:
+            with self.delete_widget(self.window.control):
+                self.window.destroy()
+        self.window = None
+
 
     def get_dock_pane_toggle_action_names(self):
         names =  [

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -55,14 +55,6 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
             parent.destroy()
         self.gui.process_events()
 
-    def test_create_ok_renamed(self):
-        # test that creation and destruction works as expected with ok_label
-        self.dialog.ok_label = u"Sure"
-        self.dialog._create()
-        self.gui.process_events()
-        self.dialog.destroy()
-        self.gui.process_events()
-
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
         # test that accept works as expected
@@ -80,23 +72,6 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
-
-    @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    def test_ok(self):
-        # test that OK works as expected
-        tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_button(OK))
-        self.assertEqual(tester.result, OK)
-        self.assertEqual(self.dialog.return_code, OK)
-
-    @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    def test_renamed_ok(self):
-        self.dialog.ok_label = u"Sure"
-        # test that OK works as expected if renamed
-        tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
-        self.assertEqual(tester.result, OK)
-        self.assertEqual(self.dialog.return_code, OK)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_parent(self):

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -26,6 +26,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        self.dialog = None
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -33,10 +34,12 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -50,6 +53,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
             self.dialog.destroy()
         with self.delete_widget(parent.control):
             parent.destroy()
+        self.gui.process_events()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
@@ -57,6 +61,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
@@ -102,5 +107,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
+        self.gui.process_events()
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -32,14 +32,14 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -47,13 +47,13 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.parent = parent.control
         parent._create()
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
 
         with self.delete_widget(self.dialog.control):
             self.dialog.destroy()
         with self.delete_widget(parent.control):
             parent.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
@@ -82,7 +82,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)

--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -33,81 +33,81 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_show(self):
         # test that show and hide works as expected
         self.window._create()
         self.window.show(True)
-        self.gui.process_events()
+        self.event_loop()
         self.window.show(False)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_activate(self):
         # test that activation works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.activate()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_position(self):
         # test that default position works as expected
         self.window.position = (100, 100)
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_reposition(self):
         # test that changing position works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.position = (100, 100)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_size(self):
         # test that default size works as expected
         self.window.size = (100, 100)
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_resize(self):
         # test that changing size works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.size = (100, 100)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_title(self):
         # test that default title works as expected
         self.window.title = "Test Title"
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_retitle(self):
         # test that changing title works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.title = "Test Title"
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_menubar(self):
         # test that menubar gets created as expected
@@ -123,11 +123,11 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         )
         self.window._create()
         self.window.show(True)
-        self.gui.process_events()
+        self.event_loop()
         self.window.show(False)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_toolbar(self):
         # test that toolbar gets created as expected
@@ -140,11 +140,11 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         )
         self.window._create()
         self.window.show(True)
-        self.gui.process_events()
+        self.event_loop()
         self.window.show(False)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_statusbar(self):
         # test that status bar gets created as expected
@@ -153,19 +153,19 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         )
         self.window._create()
         self.window.show(True)
-        self.gui.process_events()
+        self.event_loop()
         self.window.show(False)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_icon(self):
         # test that status bar gets created as expected
         self.window.icon = ImageResource('core')
         self.window._create()
         self.window.show(True)
-        self.gui.process_events()
+        self.event_loop()
         self.window.show(False)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -47,6 +47,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.show(False)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_activate(self):
         # test that activation works as expected
@@ -55,6 +56,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.activate()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_position(self):
         # test that default position works as expected
@@ -62,6 +64,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.open()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_reposition(self):
         # test that changing position works as expected
@@ -70,6 +73,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.position = (100, 100)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_size(self):
         # test that default size works as expected
@@ -77,6 +81,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.open()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_resize(self):
         # test that changing size works as expected
@@ -85,6 +90,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.size = (100, 100)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_title(self):
         # test that default title works as expected
@@ -92,6 +98,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.open()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_retitle(self):
         # test that changing title works as expected
@@ -100,6 +107,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.title = "Test Title"
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_menubar(self):
         # test that menubar gets created as expected
@@ -119,6 +127,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.show(False)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_toolbar(self):
         # test that toolbar gets created as expected
@@ -135,6 +144,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.show(False)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_statusbar(self):
         # test that status bar gets created as expected
@@ -147,6 +157,7 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.show(False)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_icon(self):
         # test that status bar gets created as expected
@@ -157,3 +168,4 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.show(False)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -138,6 +138,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # XXX duplicate of Dialog test, not needed?
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
+        self.gui.process_events()
+
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
 
@@ -147,6 +149,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.cancel = True
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
+        self.gui.process_events()
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
@@ -156,6 +160,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Yes works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(YES))
+        self.gui.process_events()
+
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
 
@@ -166,6 +172,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Yes works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
+        self.gui.process_events()
+
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
 
@@ -175,6 +183,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that No works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(NO))
+        self.gui.process_events()
+
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
 
@@ -185,6 +195,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that No works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"No way"))
+        self.gui.process_events()
+
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
 
@@ -195,6 +207,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(CANCEL))
+        self.gui.process_events()
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
@@ -206,6 +220,8 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Back"))
+        self.gui.process_events()
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
@@ -238,6 +254,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         # test that cancel works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message", cancel=True))
         tester.open_and_run(when_opened=lambda x: x.close(accept=False))
+        self.gui.process_events()
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
@@ -273,6 +290,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(lambda: confirm(None, "message",
                                    title='Title'))
         tester.open_and_run(when_opened=lambda x: x.click_button(NO))
+        self.gui.process_events()
         self.assertEqual(tester.result, NO)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
@@ -280,6 +298,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         # test that default works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message", default=YES))
         tester.open_and_run(when_opened=lambda x: x.click_button(YES))
+        self.gui.process_events()
         self.assertEqual(tester.result, YES)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
@@ -288,4 +307,5 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(lambda: confirm(None, "message",
                                                    cancel=True, default=YES))
         tester.open_and_run(when_opened=lambda x: x.click_button(CANCEL))
+        self.gui.process_events()
         self.assertEqual(tester.result, CANCEL)

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -1,14 +1,11 @@
 from __future__ import absolute_import
 
 import platform
-import os
 
-from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
 from ..confirmation_dialog import ConfirmationDialog, confirm
 from ..constant import YES, NO, OK, CANCEL
-from ..gui import GUI
 from ..image_resource import ImageResource
 from ..toolkit import toolkit_object
 from ..window import Window

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -218,9 +218,10 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
+        self.gui.process_events()
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
-
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -32,6 +32,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        self.dialog = None
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -39,10 +40,12 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_size(self):
         # test that size works as expected
@@ -50,6 +53,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_position(self):
         # test that position works as expected
@@ -57,6 +61,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -67,6 +72,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.dialog.destroy()
         parent.destroy()
+        self.gui.process_events()
 
     def test_create_yes_renamed(self):
         # test that creation and destruction works as expected with ok_label
@@ -74,6 +80,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_no_renamed(self):
         # test that creation and destruction works as expected with ok_label
@@ -81,6 +88,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_yes_default(self):
         # test that creation and destruction works as expected with ok_label
@@ -88,6 +96,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_cancel(self):
         # test that creation and destruction works with cancel button
@@ -95,6 +104,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_cancel_renamed(self):
         # test that creation and destruction works with cancel button
@@ -103,6 +113,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_cancel_default(self):
         # test that creation and destruction works as expected with ok_label
@@ -111,6 +122,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_image(self):
         # test that creation and destruction works with a non-standard image
@@ -118,6 +130,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_close(self):

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -41,30 +41,30 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_size(self):
         # test that size works as expected
         self.dialog.size = (100, 100)
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_position(self):
         # test that position works as expected
         self.dialog.position = (100, 100)
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -72,68 +72,68 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.parent = parent.control
         parent._create()
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
         parent.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_yes_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.yes_label = u"Sure"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_no_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.no_label = u"No Way"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_yes_default(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.default = YES
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_cancel(self):
         # test that creation and destruction works with cancel button
         self.dialog.cancel = True
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_cancel_renamed(self):
         # test that creation and destruction works with cancel button
         self.dialog.cancel = True
         self.dialog.cancel_label = "Back"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_cancel_default(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.cancel = True
         self.dialog.default = CANCEL
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_image(self):
         # test that creation and destruction works with a non-standard image
         self.dialog.image = ImageResource('core')
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_close(self):
@@ -141,7 +141,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # XXX duplicate of Dialog test, not needed?
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
@@ -152,7 +152,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.cancel = True
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
@@ -164,7 +164,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Yes works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(YES))
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
@@ -177,7 +177,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Yes works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
@@ -189,7 +189,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that No works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(NO))
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
@@ -202,7 +202,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that No works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"No way"))
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
@@ -215,7 +215,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(CANCEL))
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
@@ -229,7 +229,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Back"))
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
@@ -243,7 +243,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
@@ -263,7 +263,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         # test that cancel works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message", cancel=True))
         tester.open_and_run(when_opened=lambda x: x.close(accept=False))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
@@ -273,7 +273,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         # test that yes works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(YES))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, YES)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
@@ -283,7 +283,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         # test that yes works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(NO))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, NO)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
@@ -293,7 +293,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         # test that cancel works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message", cancel=True))
         tester.open_and_wait(when_opened=lambda x: x.click_button(CANCEL))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
@@ -304,7 +304,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(lambda: confirm(None, "message",
                                    title='Title'))
         tester.open_and_run(when_opened=lambda x: x.click_button(NO))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, NO)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
@@ -314,7 +314,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         # test that default works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message", default=YES))
         tester.open_and_run(when_opened=lambda x: x.click_button(YES))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, YES)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
@@ -325,5 +325,5 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(lambda: confirm(None, "message",
                                                    cancel=True, default=YES))
         tester.open_and_run(when_opened=lambda x: x.click_button(CANCEL))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, CANCEL)

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -1,8 +1,5 @@
 from __future__ import absolute_import
 
-import faulthandler
-faulthandler.enable()
-
 import platform
 import os
 

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 
+import faulthandler
+faulthandler.enable()
+
+import platform
 import os
 
 from traits.etsconfig.api import ETSConfig
@@ -12,13 +16,18 @@ from ..image_resource import ImageResource
 from ..toolkit import toolkit_object
 from ..window import Window
 
+is_qt = toolkit_object.toolkit == 'qt4'
+if is_qt:
+    from pyface.qt import qt_api
+
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
-is_pyqt5 = (ETSConfig.toolkit == 'qt4' and os.environ.get('QT_API') == 'pyqt5')
+is_pyqt5 = (is_qt and qt_api == 'pyqt5')
+is_pyqt4_linux = (is_qt and qt_api == 'pyqt' and platform.system() == 'Linux')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
@@ -155,6 +164,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, CANCEL)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_yes(self):
         # test that Yes works as expected
@@ -166,6 +176,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, YES)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_yes(self):
         self.dialog.yes_label = u"Sure"
@@ -178,6 +189,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, YES)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_no(self):
         # test that No works as expected
@@ -189,6 +201,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, NO)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_no(self):
         self.dialog.no_label = u"No way"
@@ -201,6 +214,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, NO)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         self.dialog.cancel = True
@@ -213,6 +227,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(self.dialog.return_code, CANCEL)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel_renamed(self):
         self.dialog.cancel = True
@@ -258,6 +273,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_yes(self):
         # test that yes works as expected
@@ -267,6 +283,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, YES)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_no(self):
         # test that yes works as expected
@@ -276,6 +293,7 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, NO)
 
     @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         # test that cancel works as expected
@@ -284,6 +302,8 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.assertEqual(tester.result, CANCEL)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_title(self):
         # test that title works as expected
@@ -293,6 +313,8 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.assertEqual(tester.result, NO)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_default_yes(self):
         # test that default works as expected
@@ -301,6 +323,8 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.assertEqual(tester.result, YES)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_default_cancel(self):
         # test that default works as expected

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -25,6 +25,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        self.dialog = None
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -32,10 +33,12 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_size(self):
         # test that size works as expected
@@ -43,6 +46,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_position(self):
         # test that position works as expected
@@ -50,6 +54,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
@@ -57,6 +62,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_cancel_renamed(self):
         # test that creation and destruction works as expected with cancel_label
@@ -64,6 +70,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_help(self):
         # test that creation and destruction works as expected with help
@@ -79,6 +86,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -1,5 +1,9 @@
 from __future__ import absolute_import
 
+import platform
+import os
+
+from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
 from ..dialog import Dialog
@@ -7,11 +11,19 @@ from ..constant import OK, CANCEL
 from ..gui import GUI
 from ..toolkit import toolkit_object
 
+
+is_qt = toolkit_object.toolkit == 'qt4'
+if is_qt:
+    from pyface.qt import qt_api
+
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
+
+is_pyqt5 = (is_qt and qt_api == 'pyqt5')
+is_pyqt4_linux = (is_qt and qt_api == 'pyqt' and platform.system() == 'Linux')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
@@ -112,6 +124,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_ok(self):
         # test that OK works as expected
@@ -120,6 +134,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         # test that cancel works as expected
@@ -128,6 +144,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_ok(self):
         self.dialog.ok_label = u"Sure"
@@ -137,6 +155,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_cancel(self):
         self.dialog.cancel_label = u"I Don't Think So"
@@ -146,6 +166,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_help(self):
         def click_help_and_close(tester):
@@ -159,6 +181,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_help(self):
         def click_help_and_close(tester):

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -1,14 +1,11 @@
 from __future__ import absolute_import
 
 import platform
-import os
 
-from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
 from ..dialog import Dialog
 from ..constant import OK, CANCEL
-from ..gui import GUI
 from ..toolkit import toolkit_object
 
 

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -40,52 +40,52 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_size(self):
         # test that size works as expected
         self.dialog.size = (100, 100)
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_position(self):
         # test that position works as expected
         self.dialog.position = (100, 100)
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.ok_label = u"Sure"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_cancel_renamed(self):
         # test that creation and destruction works as expected with cancel_label
         self.dialog.cancel_label = u"I Don't Think So"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_help(self):
         # test that creation and destruction works as expected with help
         self.dialog.help_id = "test_help"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
 
     def test_create_help_label(self):
@@ -93,9 +93,9 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.help_id = "test_help"
         self.dialog.help_label = u"Assistance"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
@@ -198,9 +198,9 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         # test that closing works as expected
         self.dialog.style = 'nonmodal'
         result = self.dialog.open()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
@@ -210,8 +210,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.style = 'nonmodal'
         self.dialog.resizable = False
         result = self.dialog.open()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(result, OK)
         self.assertEqual(self.dialog.return_code, OK)

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -124,8 +124,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_ok(self):
         # test that OK works as expected
@@ -134,8 +134,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         # test that cancel works as expected
@@ -144,8 +144,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_ok(self):
         self.dialog.ok_label = u"Sure"
@@ -155,8 +155,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_cancel(self):
         self.dialog.cancel_label = u"I Don't Think So"
@@ -166,8 +166,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_help(self):
         def click_help_and_close(tester):
@@ -181,8 +181,8 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_help(self):
         def click_help_and_close(tester):

--- a/pyface/tests/test_directory_dialog.py
+++ b/pyface/tests/test_directory_dialog.py
@@ -32,44 +32,44 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_close(self):
         # test that close works
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_default_path(self):
         # test that default path works
         self.dialog.default_path = os.path.join('images', 'core.png')
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_no_new_directory(self):
         # test that block on new directories works
         self.dialog.new_directory = False
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_message(self):
         # test that message setting works
         self.dialog.message = 'Select a directory'
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     #XXX would be nice to actually test with an open dialog, but not right now

--- a/pyface/tests/test_directory_dialog.py
+++ b/pyface/tests/test_directory_dialog.py
@@ -26,6 +26,7 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        del self.dialog
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -33,16 +34,19 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_close(self):
         # test that close works
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     def test_default_path(self):
         # test that default path works
@@ -50,6 +54,7 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     def test_no_new_directory(self):
         # test that block on new directories works
@@ -57,6 +62,7 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     def test_message(self):
         # test that message setting works
@@ -64,5 +70,6 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     #XXX would be nice to actually test with an open dialog, but not right now

--- a/pyface/tests/test_file_dialog.py
+++ b/pyface/tests/test_file_dialog.py
@@ -41,53 +41,53 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_close(self):
         # test that close works
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_default_path(self):
         # test that default path works
         self.dialog.default_path = os.path.join('images', 'core.png')
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_default_dir_and_file(self):
         # test that default dir and path works
         self.dialog.default_directory = 'images'
         self.dialog.default_filename = 'core.png'
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_open_files(self):
         # test that open files action works
         self.dialog.action = 'open files'
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_save_as(self):
         # test that open files action works
         self.dialog.action = 'save as'
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
     #XXX would be nice to actually test with an open dialog, but not right now

--- a/pyface/tests/test_file_dialog.py
+++ b/pyface/tests/test_file_dialog.py
@@ -26,6 +26,7 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        del self.dialog
         GuiTestAssistant.tearDown(self)
 
     def test_create_wildcard(self):
@@ -42,16 +43,19 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_close(self):
         # test that close works
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     def test_default_path(self):
         # test that default path works
@@ -59,6 +63,7 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     def test_default_dir_and_file(self):
         # test that default dir and path works
@@ -67,6 +72,7 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     def test_open_files(self):
         # test that open files action works
@@ -74,6 +80,7 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     def test_save_as(self):
         # test that open files action works
@@ -81,5 +88,6 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.close()
+        self.gui.process_events()
 
     #XXX would be nice to actually test with an open dialog, but not right now

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -35,31 +35,31 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
     def test_lifecycle(self):
         # test that destroy works
         self.widget = HeadingText(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_message(self):
         # test that create works with message
         self.widget = HeadingText(self.window.control, text="Hello")
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_image(self):
         # test that image works
         # XXX this image doesn't make sense here, but that's fine
         # XXX this isn't implemented in qt4 backend, but shouldn't fail
         self.widget = HeadingText(self.window.control, image=ImageResource('core.png'))
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_level(self):
         # test that create works with level
         # XXX this image doesn't make sense here, but that's fine
         # XXX this isn't implemented in qt4 backend, but shouldn't fail
         self.widget = HeadingText(self.window.control, level=2)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -23,9 +23,13 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
         if self.widget.control is not None:
             with self.delete_widget(self.widget.control):
                 self.widget.destroy()
+
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
                 self.window.destroy()
+
+        del self.widget
+        del self.window
         GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -160,6 +160,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
+        self.gui.process_events()
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -1,14 +1,11 @@
 from __future__ import absolute_import
 
 import platform
-import os
 
-from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
 from ..message_dialog import MessageDialog, information, warning, error
 from ..constant import OK
-from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 
@@ -40,7 +37,6 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
-                self.gui.process_events()
         del self.dialog
         GuiTestAssistant.tearDown(self)
 

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -43,30 +43,30 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_size(self):
         # test that size works as expected
         self.dialog.size = (100, 100)
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_position(self):
         # test that position works as expected
         self.dialog.position = (100, 100)
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -74,35 +74,35 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.parent = parent.control
         parent._create()
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
         parent.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.ok_label = u"Sure"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_message(self):
         # test that creation and destruction works as expected with message
         self.dialog.message = u"This is the message"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_informative(self):
         # test that creation and destruction works with informative
         self.dialog.message = u"This is the message"
         self.dialog.informative = u"This is the additional message"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_detail(self):
         # test that creation and destruction works with detail
@@ -110,25 +110,25 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.informative = u"This is the additional message"
         self.dialog.detail = u"This is the detail"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_warning(self):
         # test that creation and destruction works with warning message
         self.dialog.severity = "warning"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_error(self):
         # test that creation and destruction works with error message
         self.dialog.severity = "error"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
@@ -179,7 +179,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -152,8 +152,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_ok(self):
         # test that OK works as expected
@@ -172,8 +172,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_parent(self):
         # test that lifecycle works with a parent

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+import platform
 import os
 
 from traits.etsconfig.api import ETSConfig
@@ -12,14 +13,20 @@ from ..toolkit import toolkit_object
 from ..window import Window
 
 
+is_qt = toolkit_object.toolkit == 'qt4'
+if is_qt:
+    from pyface.qt import qt_api
+
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
-USING_QT = ETSConfig.toolkit not in ['', 'null', 'wx']
-is_pyqt5 = (ETSConfig.toolkit == 'qt4' and os.environ.get('QT_API') == 'pyqt5')
+is_pyqt5 = (is_qt and qt_api == 'pyqt5')
+is_pyqt4_linux = (is_qt and qt_api == 'pyqt' and platform.system() == 'Linux')
+
+USING_QT = is_qt
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
@@ -33,6 +40,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+                self.gui.process_events()
+        del self.dialog
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -40,10 +49,12 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_size(self):
         # test that size works as expected
@@ -51,6 +62,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_position(self):
         # test that position works as expected
@@ -58,6 +70,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -68,6 +81,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.dialog.destroy()
         parent.destroy()
+        self.gui.process_events()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
@@ -75,6 +89,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_message(self):
         # test that creation and destruction works as expected with message
@@ -82,6 +97,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_informative(self):
         # test that creation and destruction works with informative
@@ -90,6 +106,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_detail(self):
         # test that creation and destruction works with detail
@@ -99,6 +116,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_warning(self):
         # test that creation and destruction works with warning message
@@ -106,6 +124,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_error(self):
         # test that creation and destruction works with error message
@@ -113,6 +132,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
@@ -132,7 +152,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_ok(self):
         # test that OK works as expected
@@ -151,6 +172,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_parent(self):
         # test that lifecycle works with a parent

--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -2,8 +2,6 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from ..constant import CANCEL
-from ..gui import GUI
 from ..progress_dialog import ProgressDialog
 from ..toolkit import toolkit_object
 
@@ -15,7 +13,7 @@ no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
-class TestDialog(unittest.TestCase, GuiTestAssistant):
+class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
         GuiTestAssistant.setUp(self)
@@ -32,10 +30,12 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_can_cancel(self):
         # test that creation works with can_cancel
@@ -43,6 +43,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_show_time(self):
         # test that creation works with show_time
@@ -50,6 +51,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     @unittest.skip("not implemented in any backend")
     def test_show_percent(self):
@@ -58,6 +60,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_update(self):
         self.dialog.min = 0

--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -29,39 +29,39 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_can_cancel(self):
         # test that creation works with can_cancel
         self.dialog.can_cancel =  True
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_show_time(self):
         # test that creation works with show_time
         self.dialog.show_time =  True
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     @unittest.skip("not implemented in any backend")
     def test_show_percent(self):
         # test that creation works with show_percent
         self.dialog.show_percent =  True
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_update(self):
         self.dialog.min = 0
@@ -69,7 +69,7 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.open()
         for i in range(11):
             result = self.dialog.update(i)
-            self.gui.process_events()
+            self.event_loop()
             self.assertEqual(result, (True, False))
 
         self.assertIsNone(self.dialog.control)
@@ -88,11 +88,11 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.open()
         for i in range(5):
             result = self.dialog.update(i)
-            self.gui.process_events()
+            self.event_loop()
             self.assertEqual(result, (True, False))
         self.assertIsNotNone(self.dialog.control)
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertIsNone(self.dialog.control)
 
@@ -103,7 +103,7 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         for i in range(11):
             self.dialog.change_message('Updating {}'.format(i))
             result = self.dialog.update(i)
-            self.gui.process_events()
+            self.event_loop()
             self.assertEqual(result, (True, False))
             self.assertEqual(self.dialog.message, 'Updating {}'.format(i))
         self.assertIsNone(self.dialog.control)
@@ -115,7 +115,7 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.open()
         for i in range(11):
             result = self.dialog.update(i)
-            self.gui.process_events()
+            self.event_loop()
             self.assertEqual(result, (True, False))
         self.assertIsNone(self.dialog.control)
 
@@ -125,10 +125,10 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.open()
         for i in range(10):
             result = self.dialog.update(i)
-            self.gui.process_events()
+            self.event_loop()
             self.assertEqual(result, (True, False))
         self.dialog.close()
-        self.gui.process_events()
+        self.event_loop()
         # XXX not really sure what correct behaviour is here
 
     def test_update_negative(self):
@@ -136,6 +136,6 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.max = -10
         with self.assertRaises(AttributeError):
             self.dialog.open()
-            self.gui.process_events()
+            self.event_loop()
 
         self.assertIsNone(self.dialog.control)

--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -23,6 +23,7 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        del self.dialog
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -70,6 +71,7 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
             result = self.dialog.update(i)
             self.gui.process_events()
             self.assertEqual(result, (True, False))
+
         self.assertIsNone(self.dialog.control)
 
     @unittest.skip("inconsistent implementations")
@@ -90,6 +92,8 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
             self.assertEqual(result, (True, False))
         self.assertIsNotNone(self.dialog.control)
         self.dialog.close()
+        self.gui.process_events()
+
         self.assertIsNone(self.dialog.control)
 
     def test_change_message(self):
@@ -124,6 +128,7 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
             self.gui.process_events()
             self.assertEqual(result, (True, False))
         self.dialog.close()
+        self.gui.process_events()
         # XXX not really sure what correct behaviour is here
 
     def test_update_negative(self):
@@ -131,4 +136,6 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.max = -10
         with self.assertRaises(AttributeError):
             self.dialog.open()
+            self.gui.process_events()
+
         self.assertIsNone(self.dialog.control)

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -31,6 +31,8 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
                 self.window.destroy()
+        del self.widget
+        del self.window
         GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -38,36 +38,36 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
     def test_lifecycle(self):
         # test that destroy works
         self.widget = PythonEditor(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         self.assertFalse(self.widget.dirty)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_show_line_numbers(self):
         # test that destroy works
         self.widget = PythonEditor(self.window.control, show_line_numbers=False)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.show_line_numbers = True
-        self.gui.process_events()
+        self.event_loop()
         self.widget.show_line_numbers = False
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_load(self):
         # test that destroy works
         self.widget = PythonEditor(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.widget, 'changed', count=1):
             self.widget.path = PYTHON_SCRIPT
         self.assertFalse(self.widget.dirty)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_select_line(self):
         # test that destroy works
         self.widget = PythonEditor(self.window.control, path=PYTHON_SCRIPT)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.select_line(3)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -39,63 +39,63 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
     def test_lifecycle(self):
         # test that destroy works
         self.widget = PythonShell(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_bind(self):
         # test that binding a variable works
         self.widget = PythonShell(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.bind('x', 1)
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_execute_command(self):
         # test that executing a command works
         self.widget = PythonShell(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.widget, 'command_executed', count=1):
             self.widget.execute_command('x = 1')
-            self.gui.process_events()
+            self.event_loop()
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_execute_command_not_hidden(self):
         # test that executing a non-hidden command works
         self.widget = PythonShell(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.widget, 'command_executed', count=1):
             self.widget.execute_command('x = 1', hidden=False)
-            self.gui.process_events()
+            self.event_loop()
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_execute_file(self):
         # test that executing a file works
         self.widget = PythonShell(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         # XXX inconsistent behaviour between backends
         #with self.assertTraitChanges(self.widget, 'command_executed', count=1):
         self.widget.execute_file(PYTHON_SCRIPT)
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
         self.assertEqual(self.widget.interpreter().locals.get('sys'), sys)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_execute_file_not_hidden(self):
         # test that executing a file works
         self.widget = PythonShell(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         # XXX inconsistent behaviour between backends
         #with self.assertTraitChanges(self.widget, 'command_executed', count=1):
         self.widget.execute_file(PYTHON_SCRIPT, hidden=False)
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
         self.assertEqual(self.widget.interpreter().locals.get('sys'), sys)
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -32,6 +32,8 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
                 self.window.destroy()
+        del self.widget
+        del self.window
         GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -28,7 +28,7 @@ from ..window import Window
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')  # noqa: E501
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 USING_QT = ETSConfig.toolkit not in ['', 'wx']
@@ -89,7 +89,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_choice_strings(self):
         # test that choice strings work using simple strings
-        self.assertEqual(self.dialog._choice_strings(), ['red', 'blue', 'green'])
+        self.assertEqual(self.dialog._choice_strings(),
+                         ['red', 'blue', 'green'])
 
     def test_choice_strings_convert(self):
         # test that choice strings work using simple strings
@@ -102,9 +103,11 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
             def __init__(self, description):
                 self.description = description
 
-        self.dialog.choices = [Item(name) for name in ['red', 'blue', 'green']]
+        self.dialog.choices = [Item(name)
+                               for name in ['red', 'blue', 'green']]
         self.dialog.name_attribute = 'description'
-        self.assertEqual(self.dialog._choice_strings(), ['red', 'blue', 'green'])
+        self.assertEqual(self.dialog._choice_strings(),
+                         ['red', 'blue', 'green'])
 
     def test_choice_strings_name_attribute_convert(self):
         # test that choice strings work using attribute name of objects
@@ -150,7 +153,10 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
     def test_close(self):
         # test that closing works as expected
         tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_run(when_opened=lambda x: x.get_dialog_widget().close())
+        tester.open_and_run(
+            when_opened=lambda x: x.get_dialog_widget().close()
+        )
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
         self.assertIsNone(self.dialog.choice)

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -51,22 +51,22 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_cancel(self):
         # test that creation and destruction works no cancel button
         self.dialog.cancel = False
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -74,18 +74,18 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.parent = parent.control
         parent._create()
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
         parent.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_message(self):
         # test that creation and destruction works as expected with message
         self.dialog.message = u"This is the message"
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_choice_strings(self):
         # test that choice strings work using simple strings
@@ -170,7 +170,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
-        self.gui.process_events()
+        self.event_loop()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -45,6 +45,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        self.dialog = None
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -52,10 +53,12 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_cancel(self):
         # test that creation and destruction works no cancel button
@@ -63,6 +66,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
@@ -73,6 +77,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.dialog.destroy()
         parent.destroy()
+        self.gui.process_events()
 
     def test_message(self):
         # test that creation and destruction works as expected with message
@@ -80,6 +85,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_choice_strings(self):
         # test that choice strings work using simple strings
@@ -158,6 +164,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
         parent.close()
+        self.gui.process_events()
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -29,28 +29,28 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
     def test_destroy(self):
         # test that destroy works even when no control
         self.window.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_open_close(self):
         # test that opening and closing works as expected
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_show(self):
         # test that show works as expected
         self.window._create()
         self.window.show(True)
-        self.gui.process_events()
+        self.event_loop()
         self.window.show(False)
-        self.gui.process_events()
+        self.event_loop()
         self.window.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_image(self):
         # test that images work
@@ -58,11 +58,11 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_text(self):
         # test that images work
@@ -70,11 +70,11 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_text_changed(self):
         # test that images work
@@ -83,10 +83,10 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.text = "Splash screen"
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -21,12 +21,15 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
     def tearDown(self):
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
-                self.widnow.destroy()
+                self.window.destroy()
+
+        del self.window
         GuiTestAssistant.tearDown(self)
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.window.destroy()
+        self.gui.process_events()
 
     def test_open_close(self):
         # test that opening and closing works as expected
@@ -47,6 +50,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.show(False)
         self.gui.process_events()
         self.window.destroy()
+        self.gui.process_events()
 
     def test_image(self):
         # test that images work

--- a/pyface/tests/test_split_application_window.py
+++ b/pyface/tests/test_split_application_window.py
@@ -21,6 +21,7 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
                 self.window.destroy()
+        del self.window
         GuiTestAssistant.tearDown(self)
 
     def test_destroy(self):

--- a/pyface/tests/test_split_application_window.py
+++ b/pyface/tests/test_split_application_window.py
@@ -33,11 +33,11 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_horizontal_split(self):
         # test that horizontal split works
@@ -45,11 +45,11 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_contents(self):
         # test that contents works
@@ -58,11 +58,11 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_ratio(self):
         # test that ratio split works
@@ -70,8 +70,8 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_split_dialog.py
+++ b/pyface/tests/test_split_dialog.py
@@ -27,36 +27,36 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
     def test_create(self):
         # test that creation and destruction works as expected
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_horizontal(self):
         # test that horizontal split works
         self.dialog.direction = 'horizontal'
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_ratio(self):
         # test that ratio works
         self.dialog.ratio = 0.25
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_contents(self):
         # test that contents works
         self.dialog.lhs = HeadingText
         self.dialog.rhs = HeadingText
         self.dialog._create()
-        self.gui.process_events()
+        self.event_loop()
         self.dialog.destroy()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_split_dialog.py
+++ b/pyface/tests/test_split_dialog.py
@@ -21,6 +21,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         if self.dialog.control is not None:
             with self.delete_widget(self.dialog.control):
                 self.dialog.destroy()
+        del self.dialog
         GuiTestAssistant.tearDown(self)
 
     def test_create(self):
@@ -28,10 +29,12 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_horizontal(self):
         # test that horizontal split works
@@ -39,6 +42,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_ratio(self):
         # test that ratio works
@@ -46,6 +50,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_contents(self):
         # test that contents works
@@ -54,3 +59,4 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog._create()
         self.gui.process_events()
         self.dialog.destroy()
+        self.gui.process_events()

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -23,9 +23,13 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
         if self.widget.control is not None:
             with self.delete_widget(self.widget.control):
                 self.widget.destroy()
+
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
                 self.window.destroy()
+
+        del self.widget
+        del self.window
         GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -35,28 +35,28 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
     def test_lifecycle(self):
         # test that destroy works
         self.widget = SplitPanel(self.window.control)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_horizontal(self):
         # test that horizontal split works
         self.widget = SplitPanel(self.window.control, direction='horizontal')
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_ratio(self):
         # test that ratio works
         self.widget = SplitPanel(self.window.control, ratio=0.25)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_contents(self):
         # test that contents works
         self.widget = SplitPanel(self.window.control, lhs=HeadingText,
                                  rhs=HeadingText)
-        self.gui.process_events()
+        self.event_loop()
         self.widget.destroy()
-        self.gui.process_events()
+        self.event_loop()

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -10,6 +10,9 @@ class TestWidget(unittest.TestCase, UnittestTools):
     def setUp(self):
         self.widget = Widget()
 
+    def tearDown(self):
+        del self.widget
+
     def test_create(self):
         # create is not Implemented
         with self.assertRaises(NotImplementedError):

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -169,8 +169,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.information)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_information_ok(self):
         self._check_message_dialog_ok(self.window.information)
 
@@ -179,8 +179,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.warning)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_warning_ok(self):
         self._check_message_dialog_ok(self.window.warning)
 
@@ -189,8 +189,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.error)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_error_ok(self):
         self._check_message_dialog_ok(self.window.error)
 

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -1,9 +1,7 @@
 from __future__ import absolute_import
 
 import platform
-import os
 
-from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
 from ..constant import CANCEL, NO, OK, YES

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from traits.testing.unittest_tools import unittest
 
 from ..constant import CANCEL, NO, OK, YES
-from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 
@@ -25,11 +24,13 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         if self.window.control is not None:
             with self.delete_widget(self.window.control):
                 self.window.destroy()
+        self.window = None
         GuiTestAssistant.tearDown(self)
 
     def test_destroy(self):
         # test that destroy works even when no control
         self.window.destroy()
+        self.gui.process_events()
 
     def test_open_close(self):
         # test that opening and closing works as expected
@@ -50,6 +51,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.show(False)
         self.gui.process_events()
         self.window.destroy()
+        self.gui.process_events()
 
     def test_activate(self):
         # test that activation works as expected
@@ -58,6 +60,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.activate()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_position(self):
         # test that default position works as expected
@@ -65,6 +68,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.open()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_reposition(self):
         # test that changing position works as expected
@@ -73,6 +77,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.position = (100, 100)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_size(self):
         # test that default size works as expected
@@ -80,6 +85,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.open()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_resize(self):
         # test that changing size works as expected
@@ -88,6 +94,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.size = (100, 100)
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_title(self):
         # test that default title works as expected
@@ -95,6 +102,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.open()
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     def test_retitle(self):
         # test that changing title works as expected
@@ -103,6 +111,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.window.title = "Test Title"
         self.gui.process_events()
         self.window.close()
+        self.gui.process_events()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_confirm_reject(self):

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -1,16 +1,28 @@
 from __future__ import absolute_import
 
+import platform
+import os
+
+from traits.etsconfig.api import ETSConfig
 from traits.testing.unittest_tools import unittest
 
 from ..constant import CANCEL, NO, OK, YES
 from ..toolkit import toolkit_object
 from ..window import Window
 
+
+is_qt = toolkit_object.toolkit == 'qt4'
+if is_qt:
+    from pyface.qt import qt_api
+
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
+
+is_pyqt5 = (is_qt and qt_api == 'pyqt5')
+is_pyqt4_linux = (is_qt and qt_api == 'pyqt' and platform.system() == 'Linux')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
@@ -122,6 +134,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_confirm_yes(self):
         # test that yes works as expected
         tester = ModalDialogTester(lambda: self.window.confirm("message"))
@@ -130,6 +144,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, YES)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_confirm_no(self):
         # test that no works as expected
         tester = ModalDialogTester(lambda: self.window.confirm("message"))
@@ -138,6 +154,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, NO)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_confirm_cancel(self):
         # test that cncel works as expected
         tester = ModalDialogTester(
@@ -151,6 +169,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.information)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_information_ok(self):
         self._check_message_dialog_ok(self.window.information)
 
@@ -159,6 +179,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.warning)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_warning_ok(self):
         self._check_message_dialog_ok(self.window.warning)
 
@@ -167,6 +189,8 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.error)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
+    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
     def test_error_ok(self):
         self._check_message_dialog_ok(self.window.error)
 

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -40,88 +40,88 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
     def test_destroy(self):
         # test that destroy works even when no control
         self.window.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_open_close(self):
         # test that opening and closing works as expected
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
                 self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
                 self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_show(self):
         # test that showing works as expected
         self.window._create()
         self.window.show(True)
-        self.gui.process_events()
+        self.event_loop()
         self.window.show(False)
-        self.gui.process_events()
+        self.event_loop()
         self.window.destroy()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_activate(self):
         # test that activation works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.activate()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_position(self):
         # test that default position works as expected
         self.window.position = (100, 100)
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_reposition(self):
         # test that changing position works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.position = (100, 100)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_size(self):
         # test that default size works as expected
         self.window.size = (100, 100)
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_resize(self):
         # test that changing size works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.size = (100, 100)
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_title(self):
         # test that default title works as expected
         self.window.title = "Test Title"
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     def test_retitle(self):
         # test that changing title works as expected
         self.window.open()
-        self.gui.process_events()
+        self.event_loop()
         self.window.title = "Test Title"
-        self.gui.process_events()
+        self.event_loop()
         self.window.close()
-        self.gui.process_events()
+        self.event_loop()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_confirm_reject(self):
@@ -138,7 +138,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         # test that yes works as expected
         tester = ModalDialogTester(lambda: self.window.confirm("message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(YES))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, YES)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
@@ -148,7 +148,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         # test that no works as expected
         tester = ModalDialogTester(lambda: self.window.confirm("message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(NO))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, NO)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
@@ -159,7 +159,7 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         tester = ModalDialogTester(
             lambda: self.window.confirm("message", cancel=True))
         tester.open_and_wait(when_opened=lambda x: x.click_button(CANCEL))
-        self.gui.process_events()
+        self.event_loop()
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')

--- a/pyface/ui/qt4/tests/test_progress_dialog.py
+++ b/pyface/ui/qt4/tests/test_progress_dialog.py
@@ -2,15 +2,11 @@ from __future__ import absolute_import
 
 from traits.testing.unittest_tools import unittest
 
-from pyface.gui import GUI
-from pyface.toolkit import toolkit_object
-
 from ..progress_dialog import ProgressDialog
 from ..util.gui_test_assistant import GuiTestAssistant
-from ..util.modal_dialog_tester import ModalDialogTester
 
 
-class TestDialog(unittest.TestCase, GuiTestAssistant):
+class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
 
     def setUp(self):
         GuiTestAssistant.setUp(self)
@@ -33,6 +29,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.dialog._estimated_control)
         self.assertIsNone(self.dialog._remaining_control)
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_show_time(self):
         # test that creation works with show_time
@@ -43,6 +40,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.assertIsNotNone(self.dialog._estimated_control)
         self.assertIsNotNone(self.dialog._remaining_control)
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_show_percent(self):
         # test that creation works with show_percent
@@ -51,6 +49,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.gui.process_events()
         self.assertEqual(self.dialog.progress_bar.format(), "%p%")
         self.dialog.destroy()
+        self.gui.process_events()
 
     def test_update(self):
         self.dialog.min = 0
@@ -63,6 +62,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
             if i < 10:
                 self.assertEqual(self.dialog.progress_bar.value(), i)
         self.assertIsNone(self.dialog.control)
+        self.gui.process_events()
 
     def test_update_no_control(self):
         # note: inconsistent implementation with Wx
@@ -70,6 +70,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.max = 10
         result = self.dialog.update(1)
         self.assertEqual(result, (None, None))
+        self.gui.process_events()
 
     def test_change_message(self):
         self.dialog.min = 0
@@ -84,6 +85,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
             self.assertEqual(self.dialog._message_control.text(),
                              'Updating {}'.format(i))
         self.assertIsNone(self.dialog.control)
+        self.gui.process_events()
 
     def test_change_message_trait(self):
         self.dialog.min = 0
@@ -98,6 +100,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
             self.assertEqual(self.dialog._message_control.text(),
                              'Updating {}'.format(i))
         self.assertIsNone(self.dialog.control)
+        self.gui.process_events()
 
     def test_update_show_time(self):
         self.dialog.min = 0
@@ -112,3 +115,4 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
             self.assertNotEqual(self.dialog._estimated_control.text(), "")
             self.assertNotEqual(self.dialog._remaining_control.text(), "")
         self.assertIsNone(self.dialog.control)
+        self.gui.process_events()

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -10,6 +10,7 @@
 
 """
 import contextlib
+import platform
 import sys
 import traceback
 
@@ -22,10 +23,10 @@ from .testing import find_qt_widget
 
 
 BUTTON_TEXT = {
-    OK: 'OK',
-    CANCEL: 'Cancel',
-    YES: '&Yes',
-    NO: '&No',
+    OK: u'OK',
+    CANCEL: u'Cancel',
+    YES: u'Yes',
+    NO: u'No',
 }
 
 
@@ -183,7 +184,7 @@ class ModalDialogTester(object):
                 value = (self.get_dialog_widget() != self._dialog_widget)
                 if value:
                     # process any pending events so that we have a clean
-                    # even loop before we exit.
+                    # event loop before we exit.
                     self._helper.event_loop()
                 return value
 
@@ -268,12 +269,21 @@ class ModalDialogTester(object):
     def click_widget(self, text, type_=QtGui.QPushButton):
         """ Execute click on the widget of `type_` with `text`.
 
+        This strips '&' chars from the string, since usage varies from platform
+        to platform.
         """
         control = self.get_dialog_widget()
+
+        def test(widget):
+            # XXX asking for widget.text() causes occasional segfaults on Linux
+            # and pyqt (both 4 and 5).  Not sure why this is happening.
+            # See issue #282
+            return widget.text().replace('&', '') == text
+
         widget = find_qt_widget(
             control,
             type_,
-            test=lambda widget: widget.text() == text
+            test=test
         )
         if widget is None:
             # this will only occur if there is some problem with the test

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -136,6 +136,7 @@ class ModalDialogTester(object):
         finally:
             condition_timer.stop()
             condition_timer.timeout.disconnect(handler)
+            self._helper.event_loop()
             self.assert_no_errors_collected()
 
     def open_and_wait(self, when_opened, *args, **kwargs):
@@ -198,6 +199,7 @@ class ModalDialogTester(object):
             condition_timer.stop()
             condition_timer.timeout.disconnect(handler)
             self._dialog_widget = None
+            self._helper.event_loop()
             self.assert_no_errors_collected()
 
     def open(self, *args, **kwargs):

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -120,7 +120,7 @@ class ModalDialogTester(object):
             else:
                 condition_timer.start()
 
-        # Setup and start the timer to singla the handler every 100 msec.
+        # Setup and start the timer to fire the handler every 100 msec.
         condition_timer.setInterval(100)
         condition_timer.setSingleShot(True)
         condition_timer.timeout.connect(handler)
@@ -180,7 +180,12 @@ class ModalDialogTester(object):
             if self._dialog_widget is None:
                 return False
             else:
-                return self.get_dialog_widget() != self._dialog_widget
+                value = (self.get_dialog_widget() != self._dialog_widget)
+                if value:
+                    # process any pending events so that we have a clean
+                    # even loop before we exit.
+                    self._helper.event_loop()
+                return value
 
         # Setup and start the timer to signal the handler every 100 msec.
         condition_timer.setInterval(100)
@@ -283,7 +288,12 @@ class ModalDialogTester(object):
         """ A value was assigned to the result attribute.
 
         """
-        return self._assigned
+        result = self._assigned
+        if result:
+            # process any pending events so that we have a clean
+            # even loop before we exit.
+            self._helper.event_loop()
+        return result
 
     def dialog_opened(self):
         """ Check that the dialog has opened.

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -167,9 +167,9 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                     self.assertIsInstance(widget, QtGui.QPushButton)
             finally:
                 tester.close()
-                self.gui.process_events()
 
         tester.open_and_run(when_opened=check_and_close)
+        self.gui.process_events()
 
 
 if __name__ == '__main__':

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -12,15 +12,22 @@ from __future__ import absolute_import
 
 import unittest
 import cStringIO
+import platform
+import os
 
-from pyface.qt import QtGui
+from pyface.qt import QtGui, qt_api
 from pyface.api import Dialog, MessageDialog, OK, CANCEL
 from traits.api import HasStrictTraits
+from traits.etsconfig.api import ETSConfig
 
 from pyface.ui.qt4.util.testing import silence_output
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from pyface.ui.qt4.util.modal_dialog_tester import ModalDialogTester
 from pyface.util.testing import skip_if_no_traitsui
+
+
+is_pyqt5 = qt_api == 'pyqt5'
+is_pyqt4_linux = (qt_api == 'pyqt' and platform.system() == 'Linux')
 
 
 class MyClass(HasStrictTraits):
@@ -134,6 +141,8 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                 tester.open_and_run(when_opened=raise_error)
             self.assertIn('ZeroDivisionError', alt_stderr)
 
+    @unittest.skipIf(is_pyqt5, "Has widget tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Has widget tests don't reliably on linux.  Issue #282.")  # noqa
     def test_has_widget(self):
         dialog = Dialog()
         tester = ModalDialogTester(dialog.open)
@@ -153,6 +162,8 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
         tester.open_and_run(when_opened=check_and_close)
         self.gui.process_events()
 
+    @unittest.skipIf(is_pyqt5, "Find widget tests don't work on pyqt5.")  # noqa
+    @unittest.skipIf(is_pyqt4_linux, "Find widget tests don't reliably on linux.  Issue #282.")  # noqa
     def test_find_widget(self):
         dialog = Dialog()
         tester = ModalDialogTester(dialog.open)

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -149,10 +149,9 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                     )
             finally:
                 tester.close()
-                self.gui.process_events()
-
 
         tester.open_and_run(when_opened=check_and_close)
+        self.gui.process_events()
 
     def test_find_widget(self):
         dialog = Dialog()

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -12,22 +12,15 @@ from __future__ import absolute_import
 
 import unittest
 import cStringIO
-import platform
-import os
 
-from pyface.qt import QtGui, qt_api
+from pyface.qt import QtGui
 from pyface.api import Dialog, MessageDialog, OK, CANCEL
 from traits.api import HasStrictTraits
-from traits.etsconfig.api import ETSConfig
 
 from pyface.ui.qt4.util.testing import silence_output
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from pyface.ui.qt4.util.modal_dialog_tester import ModalDialogTester
 from pyface.util.testing import skip_if_no_traitsui
-
-
-is_pyqt5 = qt_api == 'pyqt5'
-is_pyqt4_linux = (qt_api == 'pyqt' and platform.system() == 'Linux')
 
 
 class MyClass(HasStrictTraits):
@@ -141,8 +134,6 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                 tester.open_and_run(when_opened=raise_error)
             self.assertIn('ZeroDivisionError', alt_stderr)
 
-    @unittest.skipIf(is_pyqt5, "Has widget tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Has widget tests don't reliably on linux.  Issue #282.")  # noqa
     def test_has_widget(self):
         dialog = Dialog()
         tester = ModalDialogTester(dialog.open)
@@ -160,10 +151,7 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                 tester.close()
 
         tester.open_and_run(when_opened=check_and_close)
-        self.gui.process_events()
 
-    @unittest.skipIf(is_pyqt5, "Find widget tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Find widget tests don't reliably on linux.  Issue #282.")  # noqa
     def test_find_widget(self):
         dialog = Dialog()
         tester = ModalDialogTester(dialog.open)
@@ -180,7 +168,6 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                 tester.close()
 
         tester.open_and_run(when_opened=check_and_close)
-        self.gui.process_events()
 
 
 if __name__ == '__main__':

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -107,6 +107,7 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                     self.fail()
             finally:
                 tester.close()
+                self.gui.process_events()
 
         with self.assertRaises(AssertionError):
             alt_stderr = cStringIO.StringIO
@@ -125,6 +126,7 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                     1 / 0
             finally:
                 tester.close()
+                self.gui.process_events()
 
         with self.assertRaises(ZeroDivisionError):
             alt_stderr = cStringIO.StringIO
@@ -147,6 +149,8 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                     )
             finally:
                 tester.close()
+                self.gui.process_events()
+
 
         tester.open_and_run(when_opened=check_and_close)
 
@@ -164,6 +168,7 @@ class TestModalDialogTester(unittest.TestCase, GuiTestAssistant):
                     self.assertIsInstance(widget, QtGui.QPushButton)
             finally:
                 tester.close()
+                self.gui.process_events()
 
         tester.open_and_run(when_opened=check_and_close)
 


### PR DESCRIPTION
This is an attempt to fix the issues with excess objects after tests have finished as identified by #254.  There is some hope that these may address the segfault issues we are seeing under PyQt.