### PR TITLE
example conversion to wxPython 4

### DIFF
--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -23,7 +23,7 @@ except ImportError:
 
 __requires__ = ['traits']
 __extras_require__ = {
-    'wx': ['wxpython>=2.8.10', 'numpy'],
+    'wx': ['wxpython>=4', 'numpy'],
     'pyqt': ['pyqt>=4.10', 'pygments'],
     'pyqt5': ['pyqt>=5', 'pygments'],
     'pyside': ['pyside>=1.2', 'pygments'],

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -193,7 +193,7 @@ def set_standard_font ( dc ):
     global standard_font
 
     if standard_font is None:
-        standard_font = wx.SystemSettings_GetFont( wx.SYS_DEFAULT_GUI_FONT )
+        standard_font = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
 
     dc.SetFont( standard_font )
 
@@ -207,9 +207,10 @@ def clear_window ( window ):
     """ Clears a window to the standard background color.
     """
     bg_color = SystemMetrics().dialog_background_color
-    bg_color = wx.Colour(bg_color[0]*255, bg_color[1]*255, bg_color[2]*255)
+    bg_color = wx.Colour(
+        int(bg_color[0] * 255), int(bg_color[1] * 255), int(bg_color[2] * 255))
 
-    dx, dy = window.GetSizeTuple()
+    dx, dy = window.GetSize().Get()
     dc     = wx.PaintDC( window )
     dc.SetBrush( wx.Brush( bg_color, wx.SOLID ) )
     dc.SetPen( wx.TRANSPARENT_PEN )
@@ -224,14 +225,14 @@ def get_dc ( window ):
     """
     if is_mac:
         dc     = wx.ClientDC( window )
-        x, y   = window.GetPositionTuple()
-        dx, dy = window.GetSizeTuple()
+        x, y = window.GetPosition().Get()
+        dx, dy = window.GetSize().Get()
         while True:
             window = window.GetParent()
             if window is None:
                 break
-            xw, yw   = window.GetPositionTuple()
-            dxw, dyw = window.GetSizeTuple()
+            xw, yw = window.GetPosition().Get()
+            dxw, dyw = window.GetSize().Get()
             dx, dy   = min( dx, dxw - x ), min( dy, dyw - y )
             x += xw
             y += yw
@@ -240,7 +241,7 @@ def get_dc ( window ):
 
         return ( dc, 0, 0 )
 
-    x, y = window.ClientToScreenXY( 0, 0 )
+    x, y = window.ClientToScreen(0, 0)
     return ( wx.ScreenDC(), x, y )
 
 #-------------------------------------------------------------------------------
@@ -532,7 +533,10 @@ class DockItem ( HasPrivateTraits ):
         """ Sets the control's drag bounds.
         """
         bx, by, bdx, bdy = self.bounds
-        self.drag_bounds = ( x, y, min( x + dx, bx + bdx ) - x, dy )
+        if (bx + bdx - x) > 0:
+            self.drag_bounds = ( x, y, min( x + dx, bx + bdx ) - x, dy )
+        else:
+            self.drag_bounds = (x, y, dx, dy)
 
     #---------------------------------------------------------------------------
     #  Gets the cursor to use when the mouse is over the item:
@@ -769,9 +773,9 @@ class DockItem ( HasPrivateTraits ):
         window = self.control.GetParent()
         if begin:
             dc, x, y = get_dc( window )
-            dx, dy   = window.GetSize()
+            dx, dy = window.GetSize().Get()
             dc2      = wx.MemoryDC()
-            self._drag_bitmap = wx.EmptyBitmap( dx, dy )
+            self._drag_bitmap = wx.Bitmap(dx, dy)
             dc2.SelectObject( self._drag_bitmap )
             dc2.Blit( 0, 0, dx, dy, dc, x, y )
             try:
@@ -824,10 +828,10 @@ class DockItem ( HasPrivateTraits ):
         if state == TabActive:
             pass
         elif state == TabInactive:
-            r,g,b = tab_color.Get()
+            r, g, b = tab_color.Get()[0:3]
             tab_color.Set(max(0, r-20), max(0, g-20), max(0, b-20))
         else:
-            r,g,b = tab_color.Get()
+            r, g, b = tab_color.Get()[0:3]
             tab_color.Set(min(255, r+20), min(255, g+20), min(255, b+20))
 
         self._is_tab   = True
@@ -846,13 +850,14 @@ class DockItem ( HasPrivateTraits ):
             bdc.DrawRectangle(0, 0, dx, dy)
 
             # Draw the left, top, and right side of a rectange around the tab
-            pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNSHADOW))
+            pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNSHADOW))
             bdc.SetPen(pen)
             bdc.DrawLine(0,dy,0,0) #up
             bdc.DrawLine(0,0,dx,0) #right
             bdc.DrawLine(dx-1,0,dx-1,dy) #down
 
-            pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNHIGHLIGHT))
+            pen = wx.Pen(
+                wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNHIGHLIGHT))
             bdc.SetPen(pen)
             bdc.DrawLine(1,dy,1,1)
             bdc.DrawLine(1,1,dx-2,1)
@@ -866,7 +871,7 @@ class DockItem ( HasPrivateTraits ):
             bdc.DrawRectangle(0, 3, dx, dy)
 
             # Draw the left, top, and right side of a rectange around the tab
-            pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNSHADOW))
+            pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNSHADOW))
             bdc.SetPen(pen)
             bdc.DrawLine(0,dy,0,3)
             bdc.DrawLine(0,3,dx-1,3)
@@ -930,7 +935,7 @@ class DockItem ( HasPrivateTraits ):
 
         self.fill_bg_color( dc, x, y, dx, dy )
 
-        pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNHILIGHT))
+        pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNHILIGHT))
         dc.SetPen(pen)
         dc.DrawLine(x, y, x+dx, y)
         dc.DrawLine(x, y+2, x+dx, y+2)
@@ -947,7 +952,7 @@ class DockItem ( HasPrivateTraits ):
 
         self.fill_bg_color( dc, x, y, dx, dy )
 
-        pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNHILIGHT))
+        pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNHILIGHT))
         dc.SetPen(pen)
         dc.DrawLine(x, y, x, y+dy)
         dc.DrawLine(x+2, y, x+2, y+dy)
@@ -1146,12 +1151,12 @@ class DockItem ( HasPrivateTraits ):
                     object.feature_can_drop_on_dock_control( self )):
                     from feature_tool import FeatureTool
 
-                    self.drop_features = [
-                        FeatureTool( dock_control = self ) ]
+                    self.drop_features = [FeatureTool(dock_control=self)]
             else:
-                self.drop_features = [ f for f in self.features
-                                         if f.can_drop( object ) and
-                                            (f.bitmap is not None) ]
+                    self.drop_features = [
+                    f for f in self.features
+                    if f.can_drop(object) and (f.bitmap is not None)
+                ]
 
             self._feature_mode = self.feature_mode + tag
 
@@ -1235,7 +1240,7 @@ class DockSplitter ( DockItem ):
         if self.style == 'horizontal':
             # Draw a line the same color as the system button shadow, which
             # should be a darkish color in the users color scheme
-            pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNSHADOW))
+            pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNSHADOW))
             dc.SetPen(pen)
             dc.DrawLine(x+idx+1,y+dy/2,x+dx-2,y+dy/2)
 
@@ -1248,7 +1253,7 @@ class DockSplitter ( DockItem ):
         else:
             # Draw a line the same color as the system button shadow, which
             # should be a darkish color in the users color scheme
-            pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNSHADOW))
+            pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNSHADOW))
             dc.SetPen(pen)
             dc.DrawLine(x+dx/2,y+idy+1,x+dx/2,y+dy-2)
 
@@ -1340,7 +1345,8 @@ class DockSplitter ( DockItem ):
         """ Handles the mouse moving while the left mouse button is pressed.
         """
         if not self._click_pending:
-            x, y, dx, dy     = self._first_bounds
+            if (self._first_bounds is not None):
+                x, y, dx, dy     = self._first_bounds
             mx, my, mdx, mdy = self._max_bounds
 
             if self.style == 'horizontal':
@@ -1618,7 +1624,7 @@ class DockControl ( DockItem ):
         dx, dy = self.width, self.height
         if self.control is not None:
             if wx_26:
-                size = self.control.GetBestFittingSize()
+                size = self.control.GetEffectiveMinSize()
             else:
                 size = self.control.GetEffectiveMinSize()
             dx = size.GetWidth()
@@ -1642,17 +1648,17 @@ class DockControl ( DockItem ):
         self.height = dy = max( 0, dy )
         self.bounds = ( x, y, dx, dy )
 
-        # Note: All we really want to do is the 'SetDimensions' call, but the
+        # Note: All we really want to do is the 'SetSize' call, but the
         # other code is needed for Linux/GTK which will not correctly process
-        # the SetDimensions call if the min size is larger than the specified
+        # the SetSize call if the min size is larger than the specified
         # size. So we temporarily set its min size to (0,0), do the
-        # SetDimensions, then restore the original min size. The restore is
+        # SetSize, then restore the original min size. The restore is
         # necessary so that DockWindow itself will correctly draw the 'drag'
         # box when performing a docking maneuver...
         control  = self.control
         min_size = control.GetMinSize()
         control.SetMinSize( wx.Size( 0, 0 ) )
-        control.SetDimensions( x, y, dx, dy )
+        control.SetSize(x, y, dx, dy)
         control.SetMinSize( min_size )
 
     #---------------------------------------------------------------------------
@@ -2943,12 +2949,12 @@ class DockRegion ( DockGroup ):
 
         # Draws a box around the frame containing the tab contents, starting
         # below the tab
-        pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNSHADOW))
+        pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNSHADOW))
         dc.SetPen(pen)
         dc.DrawRectangle(x, y+tab_height, dx, dy-tab_height)
 
         # draw highlight
-        pen = wx.Pen(wx.SystemSettings_GetColour(wx.SYS_COLOUR_BTNHIGHLIGHT))
+        pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNHIGHLIGHT))
         dc.SetPen(pen)
         dc.DrawLine(x+1, y+tab_height+1, x+dx-1, y+tab_height+1)
 
@@ -3672,7 +3678,7 @@ class DockInfo ( HasPrivateTraits ):
             bdc         = wx.MemoryDC()
             bdc2        = wx.MemoryDC()
             bdx, bdy    = bitmap.GetWidth(), bitmap.GetHeight()
-            bitmap2     = wx.EmptyBitmap( bdx, bdy )
+            bitmap2 = wx.Bitmap(bdx, bdy)
             bdc.SelectObject(  bitmap )
             bdc2.SelectObject( bitmap2 )
             bdc2.Blit( 0, 0, bdx, bdy, bdc, 0, 0 )
@@ -3791,7 +3797,8 @@ class SetStructureHandler ( object ):
 #  'DockSizer' class:
 #-------------------------------------------------------------------------------
 
-class DockSizer ( wx.PySizer ):
+#class DockSizer ( wx.PySizer ):
+class DockSizer(wx.Sizer):
 
     #---------------------------------------------------------------------------
     #  Initializes the object:
@@ -3830,8 +3837,8 @@ class DockSizer ( wx.PySizer ):
         if self._contents is None:
             return
 
-        x,   y = self.GetPositionTuple()
-        dx, dy = self.GetSizeTuple()
+        x, y = self.GetPosition().Get()
+        dx, dy = self.GetSize().Get()
         self._contents.recalc_sizes( x, y, dx, dy )
 
     #---------------------------------------------------------------------------

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -798,7 +798,7 @@ class DockItem ( HasPrivateTraits ):
         """ Gets the background color
         """
         color = SystemMetrics().dialog_background_color
-        return wx.Colour( color[0]*255, color[1]*255, color[2]*255 )
+        return wx.Colour( int(color[0]*255), int(color[1]*255), int(color[2]*255) )
 
 
     #---------------------------------------------------------------------------

--- a/pyface/dock/dock_window.py
+++ b/pyface/dock/dock_window.py
@@ -306,17 +306,17 @@ class DockWindow ( HasPrivateTraits ):
         control.owner = self
 
         # Set up the 'paint' event handler:
-        wx.EVT_PAINT( control, self._paint )
-        wx.EVT_SIZE(  control, self._size )
+        control.Bind(wx.EVT_PAINT, self._paint)
+        control.Bind(wx.EVT_SIZE, self._size)
 
         # Set up mouse event handlers:
-        wx.EVT_LEFT_DOWN(    control, self._left_down )
-        wx.EVT_LEFT_UP(      control, self._left_up )
-        wx.EVT_LEFT_DCLICK(  control, self._left_dclick )
-        wx.EVT_RIGHT_DOWN(   control, self._right_down )
-        wx.EVT_RIGHT_UP(     control, self.right_up )
-        wx.EVT_MOTION(       control, self._mouse_move )
-        wx.EVT_LEAVE_WINDOW( control, self._mouse_leave )
+        control.Bind(wx.EVT_LEFT_DOWN, self._left_down)
+        control.Bind(wx.EVT_LEFT_UP, self._left_up)
+        control.Bind(wx.EVT_LEFT_DCLICK, self._left_dclick)
+        control.Bind(wx.EVT_RIGHT_DOWN, self._right_down)
+        control.Bind(wx.EVT_RIGHT_UP, self.right_up)
+        control.Bind(wx.EVT_MOTION, self._mouse_move)
+        control.Bind(wx.EVT_LEAVE_WINDOW, self._mouse_leave)
 
         control.SetDropTarget( PythonDropTarget( self ) )
 
@@ -369,7 +369,7 @@ class DockWindow ( HasPrivateTraits ):
         global cursor_map
 
         if cursor not in cursor_map:
-            cursor_map[ cursor ] = wx.StockCursor( cursor )
+            cursor_map[cursor] = wx.Cursor(cursor)
 
         self.control.SetCursor( cursor_map[ cursor ] )
 
@@ -393,13 +393,16 @@ class DockWindow ( HasPrivateTraits ):
         """
         # There are cases where a layout has been scheduled for a DockWindow,
         # but then the DockWindow is destroyed, which will cause the calls
-        # below to fail. So we catch the 'PyDeadObjectError' exception and
+        # below to fail. So we catch the 'RuntimeError' exception and
         # ignore it:
-        try:
+        #try:
+        #self.control.Layout()
+        #self.control.Refresh()
+        #except wx.PyDeadObjectError:
+        #pass
+        if self.control:
             self.control.Layout()
             self.control.Refresh()
-        except wx.PyDeadObjectError:
-            pass
 
     #---------------------------------------------------------------------------
     #  Minimizes/Maximizes a specified DockControl:
@@ -463,15 +466,15 @@ class DockWindow ( HasPrivateTraits ):
         """
         control = self.control
         if control is not None:
-            wx.EVT_PAINT(            control, None )
-            wx.EVT_SIZE(             control, None )
-            wx.EVT_LEFT_DOWN(        control, None )
-            wx.EVT_LEFT_UP(          control, None )
-            wx.EVT_LEFT_DCLICK(      control, None )
-            wx.EVT_RIGHT_DOWN(       control, None )
-            wx.EVT_RIGHT_UP(         control, None )
-            wx.EVT_MOTION(           control, None )
-            wx.EVT_LEAVE_WINDOW(     control, None )
+            control.Bind(wx.EVT_PAINT, None)
+            control.Bind(wx.EVT_SIZE, None)
+            control.Bind(wx.EVT_LEFT_DOWN, None)
+            control.Bind(wx.EVT_LEFT_UP, None)
+            control.Bind(wx.EVT_LEFT_DCLICK, None)
+            control.Bind(wx.EVT_RIGHT_DOWN, None)
+            control.Bind(wx.EVT_RIGHT_UP, None)
+            control.Bind(wx.EVT_MOTION, None)
+            control.Bind(wx.EVT_LEAVE_WINDOW, None)
 
     #---------------------------------------------------------------------------
     #  Handles repainting the window:
@@ -503,7 +506,7 @@ class DockWindow ( HasPrivateTraits ):
             update_rect = self.control.UpdateRegion.Box
             for child in self.control.Children:
                 if not child.HasTransparentBackground() and \
-                        child.Rect.ContainsRect(update_rect):
+                        child.Rect.Contains(update_rect):
                     return True
         return False
 
@@ -517,13 +520,14 @@ class DockWindow ( HasPrivateTraits ):
         sizer = self.sizer
         if sizer is not None:
             try:
-                dx, dy = self.control.GetSizeTuple()
+                dx, dy = self.control.GetSize().Get()
                 sizer.SetDimension( 0, 0, dx, dy )
             except:
                 # fixme: This is temporary code to work around a problem in
                 #        ProAVA2 that we are still trying to track down...
                 pass
 
+        event.Skip()
     #---------------------------------------------------------------------------
     #  Handles the left mouse button being pressed:
     #---------------------------------------------------------------------------
@@ -661,7 +665,8 @@ class DockWindow ( HasPrivateTraits ):
                                        edit_action,
                                        name = 'popup' )
 
-                window.PopupMenuXY( popup_menu.create_menu( window, self ),
+                window.PopupMenu(
+                    popup_menu.create_menu(window, self),
                                     event.GetX() - 10, event.GetY() - 10 )
                 self._object = None
 

--- a/pyface/dock/dock_window.py
+++ b/pyface/dock/dock_window.py
@@ -325,7 +325,7 @@ class DockWindow ( HasPrivateTraits ):
             color = self.theme.tab.image_slice.bg_color
         else:
             color = SystemMetrics().dialog_background_color
-            color = wx.Colour(color[0]*255, color[1]*255, color[2]*255)
+            color = wx.Colour(int(color[0]*255), int(color[1]*255), int(color[2]*255))
 
         self.control.SetBackgroundColour( color )
 

--- a/pyface/dock/dock_window_shell.py
+++ b/pyface/dock/dock_window_shell.py
@@ -86,7 +86,7 @@ class DockWindowShell ( HasPrivateTraits ):
                                                  wx.FRAME_NO_TASKBAR )
         shell.SetIcon( FrameIcon.create_icon() )
         shell.SetBackgroundColour( SystemMetrics().dialog_background_color )
-        wx.EVT_CLOSE( shell, self._on_close )
+        shell.Bind(wx.EVT_CLOSE, self._on_close)
 
         theme = dock_control.theme
         self._dock_window = dw = DockWindow( shell, auto_close = True,
@@ -99,10 +99,10 @@ class DockWindowShell ( HasPrivateTraits ):
         if use_mouse:
             x, y = wx.GetMousePosition()
         else:
-            x, y = old_control.GetPositionTuple()
-            x, y = old_control.GetParent().ClientToScreenXY( x, y )
+            x, y = old_control.Sizer.GetPosition().Get()
+            x, y = old_control.GetParent().Window.ClientToScreen(x, y)
 
-        dx, dy = old_control.GetSize()
+        dx, dy = old_control.GetSize().Get()
         tis    = theme.tab.image_slice
         tc     = theme.tab.content
         tdy    = theme.tab_active.image_slice.dy
@@ -113,12 +113,12 @@ class DockWindowShell ( HasPrivateTraits ):
 
         # Set the correct window size and position, accounting for the tab size
         # and window borders:
-        shell.SetDimensions( x, y, dx, dy )
-        cdx, cdy = shell.GetClientSizeTuple()
+        shell.SetSize(x, y, dx, dy)
+        cdx, cdy = shell.GetClientSize().Get()
         ex_dx    = dx - cdx
         ex_dy    = dy - cdy
-        shell.SetDimensions( x - (ex_dx / 2) - tis.xleft - tc.left,
-                             y - ex_dy + (ex_dx / 2) - tdy - tis.xtop - tc.top,
+        shell.SetSize(x - (ex_dx // 2) - tis.xleft - tc.left,
+                      y - ex_dy + (ex_dx // 2) - tdy - tis.xtop - tc.top,
                              dx + ex_dx, dy + ex_dy )
         shell.Show()
 

--- a/pyface/dock/feature_bar.py
+++ b/pyface/dock/feature_bar.py
@@ -99,18 +99,18 @@ class FeatureBar ( HasPrivateTraits ):
                                                style = wx.BORDER_NONE )
 
             # Set up the 'erase background' event handler:
-            wx.EVT_ERASE_BACKGROUND( control, self._erase_background )
+            control.Bind(wx.EVT_ERASE_BACKGROUND, self._erase_background)
 
             # Set up the 'paint' event handler:
-            wx.EVT_PAINT( control, self._paint )
+            control.Bind(wx.EVT_PAINT, self._paint)
 
             # Set up mouse event handlers:
-            wx.EVT_LEFT_DOWN(    control, self._left_down )
-            wx.EVT_LEFT_UP(      control, self._left_up )
-            wx.EVT_RIGHT_DOWN(   control, self._right_down )
-            wx.EVT_RIGHT_UP(     control, self._right_up )
-            wx.EVT_MOTION(       control, self._mouse_move )
-            wx.EVT_ENTER_WINDOW( control, self._mouse_enter )
+            control.Bind(wx.EVT_LEFT_DOWN, self._left_down)
+            control.Bind(wx.EVT_LEFT_UP, self._left_up)
+            control.Bind(wx.EVT_RIGHT_DOWN, self._right_down)
+            control.Bind(wx.EVT_RIGHT_UP, self._right_up)
+            control.Bind(wx.EVT_MOTION, self._mouse_move)
+            control.Bind(wx.EVT_ENTER_WINDOW, self._mouse_enter)
 
             control.SetDropTarget( PythonDropTarget( self ) )
 
@@ -150,7 +150,7 @@ class FeatureBar ( HasPrivateTraits ):
         """ Handles repainting the window.
         """
         window = self.control
-        dx, dy = window.GetSizeTuple()
+        dx, dy = window.GetSize().Get()
         dc     = wx.PaintDC( window )
 
         # Draw the feature container:
@@ -272,7 +272,7 @@ class FeatureBar ( HasPrivateTraits ):
             # Check to see if the mouse has left the window, and mark it
             # completed if it has:
             x, y   = event.GetX(), event.GetY()
-            dx, dy = self.control.GetSizeTuple()
+            dx, dy = self.control.GetSize().Get()
             if (x < 0) or (y < 0) or (x >= dx) or (y >= dy):
                 self.control.ReleaseMouse()
                 self._tooltip_feature = None

--- a/pyface/sizers/flow.py
+++ b/pyface/sizers/flow.py
@@ -68,7 +68,7 @@ class FlowSizer ( wx.PySizer ):
         """
         horizontal = (self._orient == wx.HORIZONTAL)
         x,   y     = self.GetPosition()
-        dx, dy     = self.GetSize()
+        dx, dy = self.GetSize().Get()
         x0, y0     = x, y
         ex         = x + dx
         ey         = y + dy

--- a/pyface/tree/node_tree.py
+++ b/pyface/tree/node_tree.py
@@ -91,9 +91,10 @@ class NodeTree(Tree):
 
         return
 
-    def _node_right_clicked_changed(self, (obj, point)):
+    def _node_right_clicked_changed(self, obj_point):
         """ Called when the right mouse button is clicked on the tree. """
 
+        obj, point = obj_point
         # Add the node that the right-click occurred on to the selection.
         self.select(obj)
 

--- a/pyface/ui/wx/about_dialog.py
+++ b/pyface/ui/wx/about_dialog.py
@@ -125,7 +125,8 @@ class AboutDialog(MAboutDialog, Dialog):
         )
 
         # Make the 'OK' button the default button.
-        ok_button = html.FindWindowById(wx.ID_OK)
+        ok_button = parent.FindWindowById(
+            wx.ID_OK)  #html.Window.FindWindowById(wx.ID_OK)
         ok_button.SetDefault()
 
         # Set the height of the HTML window to match the height of the content.
@@ -136,7 +137,7 @@ class AboutDialog(MAboutDialog, Dialog):
         # We add a fudge factor to the height here, although I'm not sure why
         # it should be necessary, the HTML window should report its required
         # size!?!
-        width, height = html.GetSize()
+        width, height = html.GetSize().Get()
         parent.SetClientSize((width, height + 10))
 
 ### EOF #######################################################################

--- a/pyface/ui/wx/action/action_item.py
+++ b/pyface/ui/wx/action/action_item.py
@@ -106,7 +106,7 @@ class _MenuItem(HasTraits):
                 # bitmaps, so just ignore the exception if it happens
                 pass
 
-        menu.AppendItem(self.control)
+        menu.Append(self.control)
         menu.menu_items.append(self)
 
         # Set the initial enabled/disabled state of the action.
@@ -119,7 +119,8 @@ class _MenuItem(HasTraits):
         # Wire it up...create an ugly flag since some platforms dont skip the
         # event when we thought they would
         self._skip_menu_event = False
-        wx.EVT_MENU(parent, self.control_id, self._on_menu)
+        #wx.EVT_MENU(parent, self.control_id, self._on_menu)
+        parent.Bind(wx.EVT_MENU, self._on_menu, self.control)
 
         # Listen for trait changes on the action (so that we can update its
         # enabled/disabled/checked state etc).
@@ -363,9 +364,12 @@ class _Tool(HasTraits):
             self.tool_bar.SetSize((-1, 50))
 
         self.control_id = wx.NewId()
-        self.control = tool_bar.AddLabelTool(
-            self.control_id, label, bmp, wx.NullBitmap, kind, tooltip, longtip, None
-        )
+        #self.control = tool_bar.AddLabelTool(
+        #    self.control_id, label, bmp, wx.NullBitmap, kind, tooltip, longtip, None
+        #)
+        self.control = tool_bar.AddTool(self.control_id, label, bmp,
+                                        wx.NullBitmap, kind, tooltip, longtip,
+                                        None)
 
         # Set the initial checked state.
         tool_bar.ToggleTool(self.control_id, action.checked)
@@ -382,7 +386,8 @@ class _Tool(HasTraits):
                 self.control_id, action.enabled and action.visible)
 
         # Wire it up.
-        wx.EVT_TOOL(parent, self.control_id, self._on_tool)
+        #wx.EVT_TOOL(parent, self.control_id, self._on_tool)
+        parent.Bind(wx.EVT_TOOL, self._on_tool, self.control)
 
         # Listen for trait changes on the action (so that we can update its
         # enabled/disabled/checked state etc).

--- a/pyface/ui/wx/action/menu_manager.py
+++ b/pyface/ui/wx/action/menu_manager.py
@@ -74,7 +74,7 @@ class MenuManager(ActionManager, ActionManagerItem):
         sub._id = id
         sub._menu = menu
 
-        menu.AppendMenu(id, self.name, sub)
+        menu.Append(id, self.name, sub)
 
         return
 
@@ -164,7 +164,7 @@ class _Menu(wx.Menu):
         if x is None or y is None:
             self._parent.PopupMenu(self)
         else:
-            self._parent.PopupMenuXY(self, x, y)
+            self._parent.PopupMenu(self, x, y)
 
         return
 

--- a/pyface/ui/wx/action/tool_bar_manager.py
+++ b/pyface/ui/wx/action/tool_bar_manager.py
@@ -304,14 +304,23 @@ class _AuiToolBar(aui.AuiToolBar):
             self.EnableTool(tool_id, True)
             self.Realize()
             # Update the toolbar in the AUI manager to force toolbar resize
-            wx.CallAfter(self.tool_bar_manager.controller.task.window._aui_manager.Update)
+            try:
+                wx.CallAfter(self.tool_bar_manager.controller.task.window.
+                             _aui_manager.Update)
+            except:
+                pass
         elif not state and tool is not None:
             self.RemoveTool(tool_id)
             # Update the toolbar in the AUI manager to force toolbar resize
-            wx.CallAfter(self.tool_bar_manager.controller.task.window._aui_manager.Update)
+            try:
+                wx.CallAfter(self.tool_bar_manager.controller.task.window.
+                             _aui_manager.Update)
+            except:
+                pass
 
     def InsertToolInOrder(self, tool_id):
         orig_pos, tool = self.tool_map[tool_id]
+        pos = -1
         for pos in range(self.GetToolsCount()):
             existing_tool = self.GetToolByPos(pos)
             existing_id = existing_tool.GetId()
@@ -394,15 +403,22 @@ class _AuiToolBar(aui.AuiToolBar):
     def _on_tool_bar_manager_enabled_changed(self, obj, trait_name, old, new):
         """ Dynamic trait change handler. """
 
-        obj.controller.task.window._wx_enable_tool_bar(self, new)
+        try:
+            obj.controller.task.window._wx_enable_tool_bar(self, new)
+        except:
+
+            pass
 
         return
 
     def _on_tool_bar_manager_visible_changed(self, obj, trait_name, old, new):
         """ Dynamic trait change handler. """
 
-        obj.controller.task.window._wx_show_tool_bar(self, new)
+        try:
+            obj.controller.task.window._wx_show_tool_bar(self, new)
+        except:
 
+            pass
         return
 
 #### EOF ######################################################################

--- a/pyface/ui/wx/action/tool_palette.py
+++ b/pyface/ui/wx/action/tool_palette.py
@@ -195,9 +195,9 @@ class ToolPalette(Widget):
 
         self.button_tool_map[button.GetId()] = wxid
         self.tool_id_to_button_map[wxid] = button
-        wx.EVT_BUTTON(panel, button.GetId(), self._on_button)
+        panel.Bind(wx.EVT_BUTTON, self._on_button, button)
         button.SetBitmapLabel(bmp)
-        button.SetToolTipString(label)
+        button.SetToolTip(label)
         sizer.Add(button, 0, wx.EXPAND)
 
 

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -76,7 +76,10 @@ class ApplicationWindow(MApplicationWindow, Window):
 
     def _create_contents(self, parent):
         panel = wx.Panel(parent, -1, name="ApplicationWindow")
-        panel.SetSize((500, 400))
+        #sizer = wx.BoxSizer(wx.HORIZONTAL)
+        #panel.SetSize((4000, 1400))
+        #sizer.SetSizeHints(panel)
+        #panel.SetSizer(sizer)
         panel.SetBackgroundColour('blue')
 
         return panel

--- a/pyface/ui/wx/clipboard.py
+++ b/pyface/ui/wx/clipboard.py
@@ -21,7 +21,7 @@ from traits.api import provides
 from pyface.i_clipboard import IClipboard, BaseClipboard
 
 # Data formats
-PythonObjectFormat = wx.CustomDataFormat('PythonObject')
+PythonObjectFormat = wx.DataFormat('PythonObject')
 TextFormat         = wx.DataFormat(wx.DF_TEXT)
 FileFormat         = wx.DataFormat(wx.DF_FILENAME)
 

--- a/pyface/ui/wx/confirmation_dialog.py
+++ b/pyface/ui/wx/confirmation_dialog.py
@@ -71,7 +71,8 @@ class ConfirmationDialog(MConfirmationDialog, Dialog):
         self._yes = yes = wx.Button(parent, wx.ID_YES, label)
         if self.default == YES:
             yes.SetDefault()
-        wx.EVT_BUTTON(parent, wx.ID_YES, self._on_yes)
+        #wx.EVT_BUTTON(parent, wx.ID_YES, self._on_yes)
+        parent.Bind(wx.EVT_BUTTON, self._on_yes, yes)
         sizer.AddButton(yes)
 
         # 'NO' button.
@@ -83,7 +84,8 @@ class ConfirmationDialog(MConfirmationDialog, Dialog):
         self._no = no = wx.Button(parent, wx.ID_NO, label)
         if self.default == NO:
             no.SetDefault()
-        wx.EVT_BUTTON(parent, wx.ID_NO, self._on_no)
+        #wx.EVT_BUTTON(parent, wx.ID_NO, self._on_no)
+        parent.Bind(wx.EVT_BUTTON, self._on_no, no)
         sizer.AddButton(no)
 
         if self.cancel:
@@ -97,7 +99,8 @@ class ConfirmationDialog(MConfirmationDialog, Dialog):
             if self.default == CANCEL:
                 cancel.SetDefault()
 
-            wx.EVT_BUTTON(parent, wx.ID_CANCEL, self._wx_on_cancel)
+            #wx.EVT_BUTTON(parent, wx.ID_CANCEL, self._wx_on_cancel)
+            parent.Bind(wx.EVT_BUTTON, self._wx_on_cancel, cancel)
             sizer.AddButton(cancel)
 
         sizer.Realize()

--- a/pyface/ui/wx/dialog.py
+++ b/pyface/ui/wx/dialog.py
@@ -86,7 +86,7 @@ class Dialog(MDialog, Window):
 
         self._wx_ok = ok = wx.Button(parent, wx.ID_OK, label)
         ok.SetDefault()
-        wx.EVT_BUTTON(parent, wx.ID_OK, self._wx_on_ok)
+        parent.Bind(wx.EVT_BUTTON, self._wx_on_ok, id=wx.ID_OK)
         sizer.AddButton(ok)
 
         # The 'Cancel' button.
@@ -96,7 +96,7 @@ class Dialog(MDialog, Window):
             label = "Cancel"
 
         self._wx_cancel = cancel = wx.Button(parent, wx.ID_CANCEL, label)
-        wx.EVT_BUTTON(parent, wx.ID_CANCEL, self._wx_on_cancel)
+        parent.Bind(wx.EVT_BUTTON, self._wx_on_cancel, id=wx.ID_CANCEL)
         sizer.AddButton(cancel)
 
         # The 'Help' button.
@@ -107,7 +107,7 @@ class Dialog(MDialog, Window):
                 label = "Help"
 
             help = wx.Button(parent, wx.ID_HELP, label)
-            wx.EVT_BUTTON(parent, wx.ID_HELP, self._wx_on_help)
+            parent.Bind(wx.EVT_BUTTON, self._wx_on_help, id=wx.ID_HELP)
             sizer.AddButton(help)
 
         sizer.Realize()

--- a/pyface/ui/wx/directory_dialog.py
+++ b/pyface/ui/wx/directory_dialog.py
@@ -70,7 +70,7 @@ class DirectoryDialog(MDirectoryDialog, Dialog):
 
     def _create_control(self, parent):
         # The default style.
-        style = wx.OPEN
+        style = wx.FD_OPEN
 
         # Create the wx style depending on which buttons are required etc.
         if self.new_directory:

--- a/pyface/ui/wx/expandable_header.py
+++ b/pyface/ui/wx/expandable_header.py
@@ -126,13 +126,13 @@ class ExpandableHeader(Widget):
         height = self._get_preferred_height(parent, self.title, self._font)
         panel.SetSize((-1, height))
 
-        wx.EVT_ERASE_BACKGROUND(panel, self._on_erase_background)
-        wx.EVT_ENTER_WINDOW(panel, self._on_enter_leave)
-        wx.EVT_LEAVE_WINDOW(panel, self._on_enter_leave)
-        wx.EVT_LEFT_DOWN(panel, self._on_down)
-        wx.EVT_RIGHT_DOWN(panel, self._on_down)
+        panel.Bind(wx.EVT_ERASE_BACKGROUND, self._on_erase_background)
+        panel.Bind(wx.EVT_ENTER_WINDOW, self._on_enter_leave)
+        panel.Bind(wx.EVT_LEAVE_WINDOW, self._on_enter_leave)
+        panel.Bind(wx.EVT_LEFT_DOWN, self._on_down)
+        panel.Bind(wx.EVT_RIGHT_DOWN, self._on_down)
 
-        wx.EVT_BUTTON(panel, remove.GetId(), self._on_remove)
+        panel.Bind(wx.EVT_BUTTON, self._on_remove)
 
         return panel
 

--- a/pyface/ui/wx/expandable_panel.py
+++ b/pyface/ui/wx/expandable_panel.py
@@ -95,9 +95,9 @@ class ExpandablePanel(Widget):
         sizer = self.control.GetSizer()
         panel = self._layers[name]
         header = self._headers[name]
-        sizer.Remove(panel)
+        #sizer.Remove(panel)
         panel.Destroy()
-        sizer.Remove(header)
+        #sizer.Remove(header)
         header.Destroy()
 
         sizer.Layout()
@@ -155,6 +155,6 @@ class ExpandablePanel(Widget):
         sizer.Layout()
 
         # fixme: Errrr, maybe we can NOT do this!
-        w, h = self.control.GetSize()
+        w, h = self.control.GetSize().Get()
         self.control.SetSize((w+1, h+1))
         self.control.SetSize((w, h))

--- a/pyface/ui/wx/file_dialog.py
+++ b/pyface/ui/wx/file_dialog.py
@@ -105,11 +105,11 @@ class FileDialog(MFileDialog, Dialog):
             default_filename = self.default_filename
 
         if self.action == 'open':
-            style = wx.OPEN
+            style = wx.FD_OPEN
         elif self.action == 'open files':
-            style = wx.OPEN | wx.MULTIPLE
+            style = wx.FD_OPEN | wx.FD_MULTIPLE
         else:
-            style = wx.SAVE | wx.OVERWRITE_PROMPT
+            style = wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT
 
         # Create the actual dialog.
         dialog = wx.FileDialog(parent, self.title, defaultDir=default_directory,

--- a/pyface/ui/wx/grid/combobox_focus_handler.py
+++ b/pyface/ui/wx/grid/combobox_focus_handler.py
@@ -39,7 +39,7 @@ class ComboboxFocusHandler(wx.EvtHandler):
         wx.EvtHandler.__init__(self)
 
         self._grid = grid
-        wx.EVT_KEY_DOWN(self, self._on_key)
+        self.Bind(wx.EVT_KEY_DOWN, self._on_key)
 
     def _on_key(self, evt):
         """ Called when a key is pressed. """

--- a/pyface/ui/wx/grid/grid_cell_image_renderer.py
+++ b/pyface/ui/wx/grid/grid_cell_image_renderer.py
@@ -18,11 +18,11 @@
 # Major package imports
 import wx
 
-from wx.grid import PyGridCellRenderer
+from wx.grid import GridCellRenderer
 from wx.grid import GridCellStringRenderer
 from wx import SOLID, Brush, Rect, TRANSPARENT_PEN
 
-class GridCellImageRenderer(PyGridCellRenderer):
+class GridCellImageRenderer(GridCellRenderer):
     """ A renderer which will display a cell-specific image in addition to some
         text displayed in the same way the standard string renderer normally
         would. """
@@ -34,7 +34,7 @@ class GridCellImageRenderer(PyGridCellRenderer):
             get_image_for_cell(row, col) to specify an image to appear
             in the cell at row, col. """
 
-        PyGridCellRenderer.__init__(self)
+        GridCellRenderer.__init__(self)
 
         # save the string renderer to use for text.
         self._string_renderer = GridCellStringRenderer()

--- a/pyface/ui/wx/grid/grid_model.py
+++ b/pyface/ui/wx/grid/grid_model.py
@@ -277,8 +277,16 @@ class GridModel(HasPrivateTraits):
         Note that subclasses should not override this method, but should
         override the _set_value method instead.
         """
-        #print 'GridModel.set_value row: ', row, ' col: ', col, ' value: ', value
-        rows_appended = self._set_value(row, col, value)
+        #grids are passing only strings, this is temp workaraound
+        try:
+            val1=int(value)
+        except:
+            try:
+                val1=float(value)
+            except:
+                val1=value
+        rows_appended = self._set_value(row, col, val1)
+        #rows_appended = self._set_value(row, col, value)
 
         self.fire_content_changed()
         return

--- a/pyface/ui/wx/grid/trait_grid_cell_adapter.py
+++ b/pyface/ui/wx/grid/trait_grid_cell_adapter.py
@@ -15,7 +15,7 @@
 
 # Major package imports
 import wx
-from wx.grid import PyGridCellEditor
+from wx.grid import GridCellEditor as PyGridCellEditor
 from wx import SIZE_ALLOW_MINUS_ONE
 
 # Local imports:
@@ -108,13 +108,13 @@ class TraitGridCellAdapter(PyGridCellEditor):
         if self_height > 1.0:
             height = int( self_height )
         elif (self_height >= 0.0) and (grid is not None):
-            height = int( self_height * grid.GetSize()[1] )
+            height = int(self_height * grid.GetSize().Get()[1])
 
         self_width = self._width
         if self_width > 1.0:
             width = int( self_width )
         elif (self_width >= 0.0) and (grid is not None):
-            width = int( self_width * grid.GetSize()[0] )
+            width = int(self_width * grid.GetSize().Get()[0])
 
         self._edit_width, self._edit_height = width, height
 
@@ -167,8 +167,7 @@ class TraitGridCellAdapter(PyGridCellEditor):
             if changed:
                 grid.ForceRefresh()
 
-        self._control.SetDimensions(rect.x + 1, rect.y + 1,
-                                    edit_width, edit_height,
+        self._control.SetSize(rect.x + 1, rect.y + 1, edit_width, edit_height,
                                     SIZE_ALLOW_MINUS_ONE)
 
         if changed:
@@ -205,11 +204,7 @@ class TraitGridCellAdapter(PyGridCellEditor):
         if isinstance(control, wx.TextCtrl):
             control.SetSelection(-1, -1)
 
-    def EndEdit(self, *args):
-        """ Validate the input data. """
-        return True  # Pass on all data to ApplyEdit
-
-    def ApplyEdit(self, row, col, grid):
+    def EndEdit(self, row, col, grid):
         """ Do anything necessary to complete the editing. """
         self._control.Show(False)
 

--- a/pyface/ui/wx/grid/trait_grid_model.py
+++ b/pyface/ui/wx/grid/trait_grid_model.py
@@ -499,7 +499,10 @@ class TraitGridModel(GridModel):
                 # this is the case when an object method is specified
                 value = getattr(row, column.method)()
 
-        return value
+        if value is None:
+            return None
+        else:
+            return str(value)  #value
 
     def _set_data_on_row(self, row, column, value):
         """ Retrieve the data specified by column for this row. Attribute
@@ -617,7 +620,11 @@ class TraitGridModel(GridModel):
         coldata = []
         for row in range(row_count):
             try:
-                coldata.append(self.get_value(row, col))
+                val = self.get_value(row, col)
+                if val is None:
+                    coldata.append(None)
+                else:
+                    coldata.append(val)  #self.get_value(row, col))
             except IndexError:
                 coldata.append(None)
 

--- a/pyface/ui/wx/gui.py
+++ b/pyface/ui/wx/gui.py
@@ -64,7 +64,7 @@ class GUI(MGUI, HasTraits):
     ###########################################################################
 
     def invoke_after(cls, millisecs, callable, *args, **kw):
-        wx.FutureCall(millisecs, callable, *args, **kw)
+        wx.CallLater(millisecs, callable, *args, **kw)
 
     invoke_after = classmethod(invoke_after)
 
@@ -74,7 +74,7 @@ class GUI(MGUI, HasTraits):
     invoke_later = classmethod(invoke_later)
 
     def set_trait_after(cls, millisecs, obj, trait_name, new):
-        wx.FutureCall(millisecs, setattr, obj, trait_name, new)
+        wx.CallLater(millisecs, setattr, obj, trait_name, new)
 
     set_trait_after = classmethod(set_trait_after)
 

--- a/pyface/ui/wx/heading_text.py
+++ b/pyface/ui/wx/heading_text.py
@@ -82,8 +82,8 @@ class HeadingText(MHeadingText, Widget):
         width, height = self._get_preferred_size(self.text, self._font)
         panel.SetMinSize((width, height))
 
-        wx.EVT_PAINT(panel, self._on_paint_background)
-        wx.EVT_ERASE_BACKGROUND(panel, self._on_erase_background)
+        panel.Bind(wx.EVT_PAINT, self._on_paint_background)
+        panel.Bind(wx.EVT_ERASE_BACKGROUND, self._on_erase_background)
 
         return panel
 

--- a/pyface/ui/wx/image_button.py
+++ b/pyface/ui/wx/image_button.py
@@ -45,12 +45,10 @@ class ImageButton ( Widget ):
 
     # Pens used to draw the 'selection' marker:
     _selectedPenDark = wx.Pen(
-        wx.SystemSettings_GetColour( wx.SYS_COLOUR_3DSHADOW ), 1, wx.SOLID
-    )
+        wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DSHADOW), 1, wx.SOLID)
 
     _selectedPenLight = wx.Pen(
-        wx.SystemSettings_GetColour( wx.SYS_COLOUR_3DHIGHLIGHT ), 1, wx.SOLID
-    )
+        wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DHIGHLIGHT), 1, wx.SOLID)
 
     #---------------------------------------------------------------------------
     #  Trait definitions:
@@ -130,11 +128,11 @@ class ImageButton ( Widget ):
         self._mouse_over    = self._button_down = False
 
         # Set up mouse event handlers:
-        wx.EVT_ENTER_WINDOW( self.control, self._on_enter_window )
-        wx.EVT_LEAVE_WINDOW( self.control, self._on_leave_window )
-        wx.EVT_LEFT_DOWN(    self.control, self._on_left_down )
-        wx.EVT_LEFT_UP(      self.control, self._on_left_up )
-        wx.EVT_PAINT(        self.control, self._on_paint )
+        self.control.Bind(wx.EVT_ENTER_WINDOW, self._on_enter_window)
+        self.control.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave_window)
+        self.control.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
+        self.control.Bind(wx.EVT_LEFT_UP, self._on_left_up)
+        self.control.Bind(wx.EVT_PAINT, self._on_paint)
 
     #---------------------------------------------------------------------------
     #  Handles the 'image' trait being changed:
@@ -193,7 +191,7 @@ class ImageButton ( Widget ):
         control = self.control
         control.ReleaseMouse()
         self._button_down = False
-        wdx, wdy          = control.GetClientSizeTuple()
+        wdx, wdy = control.GetClientSize().Get()
         x, y              = event.GetX(), event.GetY()
         control.Refresh()
         if (0 <= x < wdx) and (0 <= y < wdy):
@@ -208,7 +206,7 @@ class ImageButton ( Widget ):
         """ Called when the widget needs repainting.
         """
         wdc      = wx.PaintDC( self.control )
-        wdx, wdy = self.control.GetClientSizeTuple()
+        wdx, wdy = self.control.GetClientSize().Get()
         ox       = (wdx - self._dx) / 2
         oy       = (wdy - self._dy) / 2
 
@@ -223,7 +221,7 @@ class ImageButton ( Widget ):
                     g = data[ :, 0 ] + data[ :, 1 ] + data[ :, 2 ]
                     data[ :, 0 ] = data[ :, 1 ] = data[ :, 2 ] = g
                     img.SetData(ravel(data.astype(dtype('uint8'))).tostring())
-                    img.SetMaskColour(0, 0, 0)
+                    img.SetColour(0, 0, 0)
                     self._mono_image = img.ConvertToBitmap()
                     self._img        = None
                 image = self._mono_image

--- a/pyface/ui/wx/image_list.py
+++ b/pyface/ui/wx/image_list.py
@@ -69,7 +69,7 @@ class ImageList(wx.ImageList):
             # probably related to a MIME type).
             else:
                 # Create a bitmap from the icon.
-                bmp = wx.EmptyBitmap(self._width, self._height)
+                bmp = wx.Bitmap(self._width, self._height)
                 bmp.CopyFromIcon(filename)
 
                 # Turn it into an image so that we can scale it.

--- a/pyface/ui/wx/image_resource.py
+++ b/pyface/ui/wx/image_resource.py
@@ -69,7 +69,7 @@ class ImageResource(MImageResource, HasTraits):
             # We have to convert the image to a bitmap first and then create an
             # icon from that.
             bmp = image.ConvertToBitmap()
-            icon = wx.EmptyIcon()
+            icon = wx.Icon()
             icon.CopyFromBitmap(bmp)
 
         return icon

--- a/pyface/ui/wx/image_widget.py
+++ b/pyface/ui/wx/image_widget.py
@@ -83,22 +83,21 @@ class ImageWidget(Widget):
         self._button_down = False
 
         # Set up mouse event handlers:
-        wx.EVT_ENTER_WINDOW(self.control, self._on_enter_window)
-        wx.EVT_LEAVE_WINDOW(self.control, self._on_leave_window)
-        wx.EVT_LEFT_DCLICK(self.control, self._on_left_dclick)
-        wx.EVT_LEFT_DOWN(self.control, self._on_left_down)
-        wx.EVT_LEFT_UP(self.control, self._on_left_up)
-        wx.EVT_PAINT(self.control, self._on_paint)
+        self.control.Bind(wx.EVT_ENTER_WINDOW, self._on_enter_window)
+        self.control.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave_window)
+        self.control.Bind(wx.EVT_LEFT_DCLICK, self._on_left_dclick)
+        self.control.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
+        self.control.Bind(wx.EVT_LEFT_UP, self._on_left_up)
+        self.control.Bind(wx.EVT_PAINT, self._on_paint)
 
         # Pens used to draw the 'selection' marker:
         # ZZZ: Make these class instances when moved to the wx toolkit code.
         self._selectedPenDark = wx.Pen(
-            wx.SystemSettings_GetColour(wx.SYS_COLOUR_3DSHADOW), 1, wx.SOLID
-        )
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DSHADOW), 1, wx.SOLID)
 
         self._selectedPenLight = wx.Pen(
-            wx.SystemSettings_GetColour(wx.SYS_COLOUR_3DHIGHLIGHT), 1, wx.SOLID
-        )
+            wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DHIGHLIGHT), 1,
+            wx.SOLID)
 
         return
 
@@ -184,7 +183,7 @@ class ImageWidget(Widget):
             self._button_down = False
 
         if self._selected is not None:
-            wdx, wdy = self.GetClientSizeTuple()
+            wdx, wdy = self.GetClientSize().Get()
             x        = event.GetX()
             y        = event.GetY()
             if (0 <= x < wdx) and (0 <= y < wdy):
@@ -206,7 +205,7 @@ class ImageWidget(Widget):
         """ Called when the widget needs repainting. """
 
         wdc      = wx.PaintDC( self.control )
-        wdx, wdy = self.control.GetClientSizeTuple()
+        wdx, wdy = self.control.GetClientSize().Get()
         bitmap   = self.bitmap
         bdx      = bitmap.GetWidth()
         bdy      = bitmap.GetHeight()

--- a/pyface/ui/wx/ipython_widget.py
+++ b/pyface/ui/wx/ipython_widget.py
@@ -374,7 +374,7 @@ class IPythonWidget(Widget):
         shell = klass(parent, -1, shell=self.interp)
 
         # Listen for key press events.
-        wx.EVT_CHAR(shell, self._wx_on_char)
+        shell.Bind(wx.EVT_CHAR, self._wx_on_char)
 
         # Enable the shell as a drag and drop target.
         shell.SetDropTarget(PythonDropTarget(self))

--- a/pyface/ui/wx/mdi_application_window.py
+++ b/pyface/ui/wx/mdi_application_window.py
@@ -25,7 +25,8 @@ from .application_window import ApplicationWindow
 from .image_resource import ImageResource
 
 try:
-    import wx.aui
+    #import wx.aui
+    from wx.lib.agw import aui
     AUI = True
 except:
     AUI = False
@@ -91,13 +92,15 @@ class MDIApplicationWindow(ApplicationWindow):
         # Frame events.
         #
         # We respond to size events to layout windows around the MDI frame.
-        wx.EVT_SIZE(self.control, self._on_size)
+        self.control.Bind(wx.EVT_SIZE, self._on_size)
 
         # Client window events.
         client_window = self.control.GetClientWindow()
-        wx.EVT_ERASE_BACKGROUND(client_window, self._on_erase_background)
-
-        self._wx_offset = client_window.GetPositionTuple()
+        client_window.Bind(wx.EVT_ERASE_BACKGROUND, self._on_erase_background)
+        try:
+            self._wx_offset = client_window.GetPosition().Get()
+        except:
+            self._wx_offset = (0, 0)
 
         if AUI:
             # Let the AUI manager look after the frame.
@@ -158,7 +161,8 @@ class MDIApplicationWindow(ApplicationWindow):
     def _on_size(self, event):
         """ Called when the frame is resized. """
 
-        wx.LayoutAlgorithm().LayoutMDIFrame(self.control)
+        wx.adv.LayoutAlgorithm().LayoutMDIFrame(self.control)
+        event.Skip()
 
         return
 

--- a/pyface/ui/wx/preference/preference_dialog.py
+++ b/pyface/ui/wx/preference/preference_dialog.py
@@ -68,7 +68,7 @@ class PreferenceDialog(SplitDialog):
         # 'Done' button.
         done = wx.Button(parent, wx.ID_OK, "Done")
         done.SetDefault()
-        wx.EVT_BUTTON(parent, wx.ID_OK, self._wx_on_ok)
+        parent.Bind(wx.EVT_BUTTON, self._wx_on_ok, wx.ID_OK)
         sizer.Add(done)
 
         return sizer
@@ -147,12 +147,12 @@ class PreferenceDialog(SplitDialog):
 
         # 'Help' button. Comes first so 'Restore Defaults' doesn't jump around.
         self._help = help = wx.Button(parent, -1, "Help")
-        wx.EVT_BUTTON(parent, help.GetId(), self._on_help)
+        parent.Bind(wx.EVT_BUTTON, self._on_help, help.GetId())
         sizer.Add(help, 0, wx.RIGHT, 5)
 
         # 'Restore Defaults' button.
         restore = wx.Button(parent, -1, "Restore Defaults")
-        wx.EVT_BUTTON(parent, restore.GetId(), self._on_restore_defaults)
+        parent.Bind(wx.EVT_BUTTON, self._on_restore_defaults, restore.GetId())
         sizer.Add(restore)
 
         return sizer

--- a/pyface/ui/wx/progress_dialog.py
+++ b/pyface/ui/wx/progress_dialog.py
@@ -279,7 +279,7 @@ class ProgressDialog(MProgressDialog, Window):
             # 'Cancel' button.
             self._cancel = cancel = wx.Button(dialog, wx.ID_CANCEL,
                                               self.cancel_button_label)
-            wx.EVT_BUTTON(dialog, wx.ID_CANCEL, self._on_cancel)
+            dialog.Bind(wx.EVT_BUTTON, self._on_cancel, id=wx.ID_CANCEL)
             sizer.Add(cancel, 0, wx.LEFT, 10)
 
             button_size = cancel.GetSize()

--- a/pyface/ui/wx/python_editor.py
+++ b/pyface/ui/wx/python_editor.py
@@ -259,10 +259,10 @@ class PythonEditor(MPythonEditor, Widget):
                             wx.stc.STC_PERFORMED_REDO)
 
         # Listen for changes to the file.
-        wx.stc.EVT_STC_CHANGE(stc, stc.GetId(), self._on_stc_changed)
+        stc.Bind(wx.stc.EVT_STC_CHANGE, self._on_stc_changed)
 
         # Listen for key press events.
-        wx.EVT_CHAR(stc, self._on_char)
+        stc.Bind(wx.EVT_CHAR, self._on_char)
 
         # Load the editor's contents.
         self.load()

--- a/pyface/ui/wx/python_shell.py
+++ b/pyface/ui/wx/python_shell.py
@@ -147,7 +147,7 @@ class PythonShell(MPythonShell, Widget):
         shell = PyShell(parent, -1)
 
         # Listen for key press events.
-        wx.EVT_CHAR(shell, self._wx_on_char)
+        shell.Bind(wx.EVT_CHAR, self._wx_on_char)
 
         # Enable the shell as a drag and drop target.
         shell.SetDropTarget(PythonDropTarget(self))

--- a/pyface/ui/wx/resource_manager.py
+++ b/pyface/ui/wx/resource_manager.py
@@ -49,9 +49,9 @@ class PyfaceResourceFactory(ResourceFactory):
     def image_from_data(self, data, filename=None):
         """ Creates an image from the specified data. """
         try:
-            return wx.ImageFromStream(StringIO(data))
+            return wx.Image(StringIO(data))
         except:
-            # wx.ImageFromStream is only in wx 2.8 or later(?)
+            # wx.Image is only in wx 2.8 or later(?)
             if filename is Undefined:
                 return None
 

--- a/pyface/ui/wx/splash_screen.py
+++ b/pyface/ui/wx/splash_screen.py
@@ -66,11 +66,11 @@ class SplashScreen(MSplashScreen, Window):
         # Get the splash screen image.
         image = self.image.create_image()
 
-        splash_screen = wx.SplashScreen(
+        splash_screen = adv.SplashScreen(
             # The bitmap to display on the splash screen.
             image.ConvertToBitmap(),
             # Splash Style.
-            wx.SPLASH_NO_TIMEOUT | wx.SPLASH_CENTRE_ON_SCREEN,
+            adv.SPLASH_NO_TIMEOUT | adv.SPLASH_CENTRE_ON_SCREEN,
             # Timeout in milliseconds (we don't currently timeout!).
             0,
             # The parent of the splash screen.
@@ -91,7 +91,7 @@ class SplashScreen(MSplashScreen, Window):
         )
 
         # This allows us to write status text on the splash screen.
-        wx.EVT_PAINT(splash_screen, self._on_paint)
+        splash_screen.Bind(wx.EVT_PAINT, self._on_paint)
 
         return splash_screen
 
@@ -113,7 +113,7 @@ class SplashScreen(MSplashScreen, Window):
 
         if self.control is not None:
             # Get the window that the splash image is drawn in.
-            window = self.control.GetSplashWindow()
+            window = self.control  #.GetSplashWindow()
 
             dc = wx.PaintDC(window)
 

--- a/pyface/ui/wx/split_widget.py
+++ b/pyface/ui/wx/split_widget.py
@@ -83,7 +83,7 @@ class SplitWidget(MSplitWidget, HasTraits):
 
         # We respond to the FIRST size event to make sure that the split ratio
         # is correct when the splitter is laid out in its parent.
-        wx.EVT_SIZE(splitter, self._on_size)
+        splitter.Bind(wx.EVT_SIZE, self._on_size)
 
         return splitter
 
@@ -139,7 +139,7 @@ class SplitWidget(MSplitWidget, HasTraits):
         """ Called when the frame is resized. """
 
         splitter = event.GetEventObject()
-        width, height = splitter.GetSize()
+        width, height = splitter.GetSize().Get()
 
         # Make sure that the split ratio is correct.
         if self.direction == 'vertical':

--- a/pyface/ui/wx/system_metrics.py
+++ b/pyface/ui/wx/system_metrics.py
@@ -60,7 +60,7 @@ class SystemMetrics(MSystemMetrics, HasTraits):
             # wx lies.
             color = wx.Colour(232, 232, 232)
         else:
-            color = wx.SystemSettings_GetColour(wx.SYS_COLOUR_MENUBAR).Get()
+            color = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUBAR).Get()
 
         return (color[0]/255., color[1]/255., color[2]/255.)
 

--- a/pyface/ui/wx/tasks/dock_pane.py
+++ b/pyface/ui/wx/tasks/dock_pane.py
@@ -117,7 +117,7 @@ class DockPane(TaskPane, MDockPane):
         """
         if self.control is not None:
             logger.debug("Destroying %s" % self.control)
-            #self.task.window._aui_manager.DetachPane(self.control)
+            self.task.window._aui_manager.DetachPane(self.control)
             
             # Some containers (e.g.  TraitsDockPane) will destroy the control
             # before we get here (e.g.  traitsui.ui.UI.finish by way of

--- a/pyface/ui/wx/tasks/dock_pane.py
+++ b/pyface/ui/wx/tasks/dock_pane.py
@@ -117,7 +117,7 @@ class DockPane(TaskPane, MDockPane):
         """
         if self.control is not None:
             logger.debug("Destroying %s" % self.control)
-            self.task.window._aui_manager.DetachPane(self.control)
+            #self.task.window._aui_manager.DetachPane(self.control)
             
             # Some containers (e.g.  TraitsDockPane) will destroy the control
             # before we get here (e.g.  traitsui.ui.UI.finish by way of
@@ -142,7 +142,7 @@ class DockPane(TaskPane, MDockPane):
 
     def _get_size(self):
         if self.control is not None:
-            return self.control.GetSizeTuple()
+            return self.control.GetSize().Get()
         return (-1, -1)
 
     #### Trait change handlers ################################################

--- a/pyface/ui/wx/timer/timer.py
+++ b/pyface/ui/wx/timer/timer.py
@@ -36,7 +36,7 @@ class Timer(wx.Timer):
         given arguments and keyword args after every `millisecs`
         (milliseconds).
         """
-        wx.Timer.__init__(self, id=wx.NewId())
+        wx.Timer.__init__(self)  #, id=wx.NewId())
         self.callable = callable
         self.args = args
         self.kw_args = kw_args

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -16,6 +16,7 @@
 
 # Major package imports.
 import wx
+from wx.lib.agw import ultimatelistctrl as ULC
 
 # Enthought library imports.
 from traits.api import Color, Event, Instance, Trait
@@ -76,23 +77,20 @@ class TableViewer(ContentViewer):
         wxid = table.GetId()
 
         # Table events.
-        wx.EVT_LIST_ITEM_SELECTED(table, wxid, self._on_item_selected)
-        wx.EVT_LIST_ITEM_ACTIVATED(table, wxid, self._on_item_activated)
-        wx.EVT_LIST_BEGIN_DRAG(table, wxid, self._on_list_begin_drag)
-        wx.EVT_LIST_BEGIN_RDRAG(table, wxid, self._on_list_begin_rdrag)
+        table.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_item_selected)
+        table.Bind(wx.EVT_LIST_ITEM_ACTIVATED, self._on_item_activated)
+        table.Bind(wx.EVT_LIST_BEGIN_DRAG, self._on_list_begin_drag)
+        table.Bind(wx.EVT_LIST_BEGIN_RDRAG, self._on_list_begin_rdrag)
 
-        wx.EVT_LIST_BEGIN_LABEL_EDIT(
-            table, wxid, self._on_list_begin_label_edit
-        )
+        table.Bind(wx.EVT_LIST_BEGIN_LABEL_EDIT,
+                   self._on_list_begin_label_edit)
 
-        wx.EVT_LIST_END_LABEL_EDIT(
-            table, wxid, self._on_list_end_label_edit
-        )
+        table.Bind(wx.EVT_LIST_END_LABEL_EDIT, self._on_list_end_label_edit)
 
         # fixme: Bug[732104] indicates that this event does not get fired
         # in a virtual list control (it *does* get fired in a regular list
         # control 8^().
-        wx.EVT_LIST_ITEM_DESELECTED(table, wxid, self._on_item_deselected)
+        table.Bind(wx.EVT_LIST_ITEM_DESELECTED, self._on_item_deselected)
 
         # Create the widget!
         self._create_widget(parent)
@@ -150,7 +148,7 @@ class TableViewer(ContentViewer):
         """ Called when an item in the list is selected. """
 
         # Get the index of the row that was selected (nice wx interface huh?!).
-        row = event.m_itemIndex
+        row = event.Index
 
         # Trait event notification.
         self.row_selected = row
@@ -171,7 +169,7 @@ class TableViewer(ContentViewer):
         """ Called when an item in the list is activated. """
 
         # Get the index of the row that was activated (nice wx interface!).
-        row = event.m_itemIndex
+        row = event.Index
 
         # Trait event notification.
         self.row_activated = row
@@ -232,7 +230,7 @@ class TableViewer(ContentViewer):
             alignment = self.column_provider.get_alignment(self, index)
             info.m_format = self.FORMAT_MAP.get(alignment, wx.LIST_FORMAT_LEFT)
 
-            self.control.InsertColumnInfo(index, info)
+            self.control.InsertColumn(index, info)  #
 
         # Update the table contents and the column widths.
         self._update_contents()
@@ -295,7 +293,7 @@ class TableViewer(ContentViewer):
         return width
 
 
-class _Table(wx.ListCtrl):
+class _Table(wx.ListCtrl):  #(ULC.UltimateListCtrl):#
     """ The wx control that we use to implement the table viewer. """
 
     # Default style.

--- a/pyface/ui/wx/viewer/tree_viewer.py
+++ b/pyface/ui/wx/viewer/tree_viewer.py
@@ -102,18 +102,18 @@ class TreeViewer(ContentViewer):
         wxid = tree.GetId()
 
         # Wire up the wx tree events.
-        wx.EVT_CHAR(tree, self._on_char)
-        wx.EVT_LEFT_DOWN(tree, self._on_left_down)
-        wx.EVT_RIGHT_DOWN(tree, self._on_right_down)
-        wx.EVT_TREE_ITEM_ACTIVATED(tree, wxid, self._on_tree_item_activated)
-        wx.EVT_TREE_ITEM_COLLAPSED(tree, wxid, self._on_tree_item_collapsed)
-        wx.EVT_TREE_ITEM_COLLAPSING(tree, wxid, self._on_tree_item_collapsing)
-        wx.EVT_TREE_ITEM_EXPANDED(tree, wxid, self._on_tree_item_expanded)
-        wx.EVT_TREE_ITEM_EXPANDING(tree, wxid, self._on_tree_item_expanding)
-        wx.EVT_TREE_BEGIN_LABEL_EDIT(tree, wxid,self._on_tree_begin_label_edit)
-        wx.EVT_TREE_END_LABEL_EDIT(tree, wxid, self._on_tree_end_label_edit)
-        wx.EVT_TREE_BEGIN_DRAG(tree, wxid, self._on_tree_begin_drag)
-        wx.EVT_TREE_SEL_CHANGED(tree, wxid, self._on_tree_sel_changed)
+        tree.Bind(wx.EVT_CHAR, self._on_char)
+        tree.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
+        tree.Bind(wx.EVT_RIGHT_DOWN, self._on_right_down)
+        tree.Bind(wx.EVT_TREE_ITEM_ACTIVATED, self._on_tree_item_activated)
+        tree.Bind(wx.EVT_TREE_ITEM_COLLAPSED, self._on_tree_item_collapsed)
+        tree.Bind(wx.EVT_TREE_ITEM_COLLAPSING, self._on_tree_item_collapsing)
+        tree.Bind(wx.EVT_TREE_ITEM_EXPANDED, self._on_tree_item_expanded)
+        tree.Bind(wx.EVT_TREE_ITEM_EXPANDING, self._on_tree_item_expanding)
+        tree.Bind(wx.EVT_TREE_BEGIN_LABEL_EDIT, self._on_tree_begin_label_edit)
+        tree.Bind(wx.EVT_TREE_END_LABEL_EDIT, self._on_tree_end_label_edit)
+        tree.Bind(wx.EVT_TREE_BEGIN_DRAG, self._on_tree_begin_drag)
+        tree.Bind(wx.EVT_TREE_SEL_CHANGED, self._on_tree_sel_changed)
 
         # The image list is a wxPython-ism that caches all images used in the
         # control.
@@ -262,10 +262,10 @@ class TreeViewer(ContentViewer):
         # element is the actual item data.
         if pid is None:
             if self.show_root:
-                self.control.SetPyData(wxid,  (False, element))
+                self.control.SetItemData(wxid, (False, element))
 
         else:
-            self.control.SetPyData(wxid,  (False, element))
+            self.control.SetItemData(wxid, (False, element))
 
         # Make sure that we can find the element's Id later.
         self._element_to_id_map[self._get_key(element)] = wxid
@@ -345,7 +345,7 @@ class TreeViewer(ContentViewer):
             data = None
 
         else:
-            data = self.control.GetPyData(wxid)
+            data = self.control.GetItemData(wxid)
 
         return data, wxid, flags, point
 
@@ -354,7 +354,7 @@ class TreeViewer(ContentViewer):
 
         elements = []
         for wxid in self.control.GetSelections():
-            data = self.control.GetPyData(wxid)
+            data = self.control.GetItemData(wxid)
             if data is not None:
                 populated, element = data
                 elements.append(element)
@@ -468,7 +468,7 @@ class TreeViewer(ContentViewer):
         # The item data is a tuple. The first element indicates whether or not
         # we have already populated the item with its children.  The second
         # element is the actual item data.
-        populated, element = self.control.GetPyData(wxid)
+        populated, element = self.control.GetItemData(wxid)
 
         # Give the label provider a chance to veto the expansion.
         if self.label_provider.is_expandable(self, element):
@@ -490,7 +490,7 @@ class TreeViewer(ContentViewer):
                         self._add_element(wxid, child)
 
                 # The element is now populated!
-                self.control.SetPyData(wxid, (True, element))
+                self.control.SetItemData(wxid, (True, element))
 
         else:
             event.Veto()
@@ -506,7 +506,7 @@ class TreeViewer(ContentViewer):
         # The item data is a tuple.  The first element indicates whether or not
         # we have already populated the item with its children.  The second
         # element is the actual item data.
-        populated, element = self.control.GetPyData(wxid)
+        populated, element = self.control.GetItemData(wxid)
 
         # Make sure that the element's 'open' icon is displayed etc.
         self._refresh_element(wxid, element)
@@ -542,7 +542,7 @@ class TreeViewer(ContentViewer):
         # The item data is a tuple.  The first element indicates whether or not
         # we have already populated the item with its children.  The second
         # element is the actual item data.
-        populated, element = self.control.GetPyData(wxid)
+        populated, element = self.control.GetItemData(wxid)
 
         # Make sure that the element's 'closed' icon is displayed etc.
         self._refresh_element(wxid, element)
@@ -561,7 +561,7 @@ class TreeViewer(ContentViewer):
         # The item data is a tuple.  The first element indicates whether or not
         # we have already populated the item with its children.  The second
         # element is the actual item data.
-        populated, element = self.control.GetPyData(wxid)
+        populated, element = self.control.GetItemData(wxid)
 
         # Trait notification.
         self.element_activated = element

--- a/pyface/ui/wx/window.py
+++ b/pyface/ui/wx/window.py
@@ -86,11 +86,11 @@ class Window(MWindow, Widget):
     ###########################################################################
 
     def _add_event_listeners(self):
-        wx.EVT_ACTIVATE(self.control, self._wx_on_activate)
-        wx.EVT_CLOSE(self.control, self._wx_on_close)
-        wx.EVT_SIZE(self.control, self._wx_on_control_size)
-        wx.EVT_MOVE(self.control, self._wx_on_control_move)
-        wx.EVT_CHAR(self.control, self._wx_on_char)
+        self.control.Bind(wx.EVT_ACTIVATE, self._wx_on_activate)
+        self.control.Bind(wx.EVT_CLOSE, self._wx_on_close)
+        self.control.Bind(wx.EVT_SIZE, self._wx_on_control_size)
+        self.control.Bind(wx.EVT_MOVE, self._wx_on_control_move)
+        self.control.Bind(wx.EVT_CHAR, self._wx_on_char)
 
     ###########################################################################
     # Protected 'IWidget' interface.
@@ -181,8 +181,12 @@ class Window(MWindow, Widget):
         # call event.GetPosition directly, but that would be wrong.  The pixel
         # reported by that call is the pixel just below the window menu and
         # just right of the Windows-drawn border.
-        self._position = event.GetEventObject().GetPositionTuple()
 
+        try:
+            self._position = event.GetEventObject().GetPosition(
+            ).Get()  #Sizer.GetPosition().Get()
+        except:
+            pass
         event.Skip()
 
     def _wx_on_control_size(self, event):

--- a/pyface/ui/wx/wizard/wizard.py
+++ b/pyface/ui/wx/wizard/wizard.py
@@ -66,31 +66,36 @@ class Wizard(MWizard, Dialog):
 
         # 'Back' button.
         self._back = back = wx.Button(parent, -1, "Back")
-        wx.EVT_BUTTON(parent, back.GetId(), self._on_back)
+        #wx.EVT_BUTTON(parent, back.GetId(), self._on_back)
+        parent.Bind(wx.EVT_BUTTON, self._on_back, back)
         sizer.Add(back, 0)
 
         # 'Next' button.
         self._next = next = wx.Button(parent, -1, "Next")
-        wx.EVT_BUTTON(parent, next.GetId(), self._on_next)
+        #wx.EVT_BUTTON(parent, next.GetId(), self._on_next)
+        parent.Bind(wx.EVT_BUTTON, self._on_next, next)
         sizer.Add(next, 0, wx.LEFT, 5)
         next.SetDefault()
 
         # 'Finish' button.
         self._finish = finish = wx.Button(parent, wx.ID_OK, "Finish")
         finish.Enable(self.controller.complete)
-        wx.EVT_BUTTON(parent, wx.ID_OK, self._wx_on_ok)
+        #wx.EVT_BUTTON(parent, wx.ID_OK, self._wx_on_ok)
+        parent.Bind(wx.EVT_BUTTON, self._wx_on_ok, finish)
         sizer.Add(finish, 0, wx.LEFT, 5)
 
         # 'Cancel' button.
         if self.show_cancel:
             self._cancel = cancel = wx.Button(parent, wx.ID_CANCEL, "Cancel")
-            wx.EVT_BUTTON(parent, wx.ID_CANCEL, self._wx_on_cancel)
+            #wx.EVT_BUTTON(parent, wx.ID_CANCEL, self._wx_on_cancel)
+            parent.Bind(wx.EVT_BUTTON, self._wx_on_cancel, cancel)
             sizer.Add(cancel, 0, wx.LEFT, 10)
 
         # 'Help' button.
         if len(self.help_id) > 0:
             help = wx.Button(parent, wx.ID_HELP, "Help")
-            wx.EVT_BUTTON(parent, wx.ID_HELP, self._wx_on_help)
+            #wx.EVT_BUTTON(parent, wx.ID_HELP, self._wx_on_help)
+            parent.Bind(wx.EVT_BUTTON, self._wx_on_help, help)
             sizer.Add(help, 0, wx.LEFT, 10)
 
         return sizer

--- a/pyface/ui/wx/workbench/workbench_window_layout.py
+++ b/pyface/ui/wx/workbench/workbench_window_layout.py
@@ -429,7 +429,7 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
     def _wx_set_item_size(self, dock_control, size):
         """ Sets the size of a dock control. """
 
-        window_width, window_height = self.window.control.GetSize()
+        window_width, window_height = self.window.control.GetSize().Get()
         width,        height        = size
 
         if width != -1:
@@ -618,11 +618,11 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
         # the passed control is a str object instead of a wx object.
         if on_set_focus is not None:
             #control.Bind(wx.EVT_SET_FOCUS, on_set_focus)
-            wx.EVT_SET_FOCUS(control, on_set_focus)
+            control.Bind(wx.EVT_SET_FOCUS, on_set_focus)
 
         if on_kill_focus is not None:
             #control.Bind(wx.EVT_KILL_FOCUS, on_kill_focus)
-            wx.EVT_KILL_FOCUS(control, on_kill_focus)
+            control.Bind(wx.EVT_KILL_FOCUS, on_kill_focus)
 
         for child in control.GetChildren():
             self._wx_add_focus_listeners(child, on_set_focus, on_kill_focus)
@@ -761,7 +761,7 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
     def _wx_on_editor_area_size_changed(self, new):
         """ Dynamic trait change handler. """
 
-        window_width, window_height = self.window.control.GetSize()
+        window_width, window_height = self.window.control.GetSize().Get()
 
         # Get the dock control that contains the editor dock window.
         control = self._wx_view_dock_window.get_control(self.editor_area_id)

--- a/pyface/ui/wx/xrc_dialog.py
+++ b/pyface/ui/wx/xrc_dialog.py
@@ -75,15 +75,16 @@ class XrcDialog(Dialog):
         if okbutton is not None:
             # Change the ID and set the handler
             okbutton.SetId(wx.ID_OK)
-            wx.EVT_BUTTON(self.control, okbutton.GetId(), self._on_ok)
+            self.control.Bind(wx.EVT_BUTTON, okbutton.GetId(), self._on_ok)
         cancelbutton = self.XRCCTRL("CANCEL")
         if cancelbutton is not None:
             # Change the ID and set the handler
             cancelbutton.SetId(wx.ID_CANCEL)
-            wx.EVT_BUTTON(self.control, cancelbutton.GetId(), self._on_cancel)
+            self.control.Bind(wx.EVT_BUTTON, self._on_cancel,
+                              cancelbutton.GetId())
         helpbutton = self.XRCCTRL("HELP")
         if helpbutton is not None:
-            wx.EVT_BUTTON(self.control, helpbutton.GetId(), self._on_help)
+            self.control.Bind(wx.EVT_BUTTON, self._on_help, helpbutton.GetId())
 
         self._add_handlers()
 
@@ -101,7 +102,7 @@ class XrcDialog(Dialog):
         """
         Returns the control with the given name.
         """
-        return self.control.FindWindowById(self.XRCID(name))
+        return self.control.Window.FindWindowById(self.XRCID(name))
 
     def set_validator(self, name, validator):
         """

--- a/pyface/util/guisupport.py
+++ b/pyface/util/guisupport.py
@@ -81,7 +81,7 @@ def get_app_wx(*args, **kwargs):
     if app is None:
         if not kwargs.has_key('redirect'):
             kwargs['redirect'] = False
-        app = wx.PySimpleApp(*args, **kwargs)
+        app = wx.App(*args, **kwargs)
     return app
 
 def is_event_loop_running_wx(app=None):

--- a/pyface/wx/aui.py
+++ b/pyface/wx/aui.py
@@ -68,7 +68,8 @@ class PyfaceAuiManager(aui.AuiManager):
 
         for part in uiparts:
 
-            part.rect = wx.RectPS(part.sizer_item.GetPosition(), part.sizer_item.GetSize())
+            part.rect = wx.Rect(part.sizer_item.GetPosition(),
+                                part.sizer_item.GetSize())
             if part.type == aui.AuiDockUIPart.typeDock:
                 part.dock.rect = part.rect
 

--- a/pyface/wx/drag_and_drop.py
+++ b/pyface/wx/drag_and_drop.py
@@ -91,7 +91,7 @@ class FileDropTarget(wx.FileDropTarget):
 
 
 # The data format for Python objects!
-PythonObject = wx.CustomDataFormat('PythonObject')
+PythonObject = wx.DataFormat('PythonObject')
 
 
 class PythonDropSource(wx.DropSource):
@@ -162,7 +162,7 @@ class PythonDropSource(wx.DropSource):
         return
 
 
-class PythonDropTarget(wx.PyDropTarget):
+class PythonDropTarget(wx.DropTarget):
     """ Drop target for Python objects. """
 
     def __init__(self, handler):

--- a/pyface/wx/grid/grid.py
+++ b/pyface/wx/grid/grid.py
@@ -61,19 +61,19 @@ class Grid(wxGrid):
         self.SetTable(model._grid_table_base, True)
         model.on_trait_change(self._on_model_changed, 'model_changed')
 
-        wx.grid.EVT_GRID_CELL_CHANGE(self, self._on_cell_change)
-        wx.grid.EVT_GRID_SELECT_CELL(self, self._on_select_cell)
+        self.Bind(wx.grid.EVT_GRID_CELL_CHANGE, self._on_cell_change)
+        self.Bind(wx.grid.EVT_GRID_SELECT_CELL, self._on_select_cell)
 
         # This starts the cell editor on a double-click as well as on a second
         # click.
-        wx.grid.EVT_GRID_CELL_LEFT_DCLICK(self, self._on_cell_left_dclick)
+        self.Bind(wx.grid.EVT_GRID_CELL_LEFT_DCLICK, self._on_cell_left_dclick)
 
         # This pops up a context menu.
         #wx.grid.EVT_GRID_CELL_RIGHT_CLICK(self, self._on_cell_right_click)
 
         # We handle key presses to change the behavior of the <Enter> and
         # <Tab> keys to make manual data entry smoother.
-        wx.EVT_KEY_DOWN(self, self._on_key_down)
+        self.Bind(wx.EVT_KEY_DOWN, self._on_key_down)
 
         # Initialize the row and column models.
         self._initialize_rows(model)
@@ -193,7 +193,7 @@ class Grid(wxGrid):
             # Popup a context menu allowing the user to delete the row.
             menu = wx.Menu()
             menu.Append(101, "Delete Row")
-            wx.EVT_MENU(self, 101, self._on_delete_row)
+            self.Bind(wx.EVT_MENU, self._on_delete_row, id=101)
 
             self.PopupMenu(menu, evt.GetPosition())
 

--- a/pyface/wx/image_list.py
+++ b/pyface/wx/image_list.py
@@ -85,7 +85,7 @@ class ImageList(wx.ImageList):
             icon = filename
 
             # We also force them to be bitmaps!
-            bmp = wx.EmptyBitmap(self._width, self._height)
+            bmp = wx.Bitmap(self._width, self._height)
             bmp.CopyFromIcon(icon)
             # We force all images in the cache to be the same size.
             image = wx.ImageFromBitmap(bmp)

--- a/pyface/wx/progress_meter.py
+++ b/pyface/wx/progress_meter.py
@@ -21,7 +21,7 @@ class ProgressDialog(wx.ProgressDialog):
 
     def SetButtonLabel(self, title):
         """ Change the Cancel button label to something else eg Stop."""
-        button = self.FindWindowById(wx.ID_CANCEL)
+        button = self.Window.FindWindowById(wx.ID_CANCEL)
         button.SetLabel(title)
 
         return

--- a/pyface/wx/python_stc.py
+++ b/pyface/wx/python_stc.py
@@ -114,8 +114,8 @@ class PythonSTC(stc.StyledTextCtrl):
                               stc.STC_MARK_BOXMINUS, "white", "black")
 
 
-        stc.EVT_STC_UPDATEUI(self,    ID, self.OnUpdateUI)
-        stc.EVT_STC_MARGINCLICK(self, ID, self.OnMarginClick)
+        self.Bind(stc.EVT_STC_UPDATEUI, self.OnUpdateUI)
+        self.Bind(stc.EVT_STC_MARGINCLICK, self.OnMarginClick)
 
 
         # Make some styles,  The lexer defines what each style is used for, we
@@ -183,7 +183,7 @@ class PythonSTC(stc.StyledTextCtrl):
 
         self.SetCaretForeground("BLUE")
 
-        wx.EVT_KEY_DOWN(self, self.OnKeyPressed)
+        self.Bind(wx.EVT_KEY_DOWN, self.OnKeyPressed)
 
 
     def OnKeyPressed(self, event):
@@ -302,7 +302,7 @@ class PythonSTC(stc.StyledTextCtrl):
         for lineNum in range(lineCount):
             if self.GetFoldLevel(lineNum) & stc.STC_FOLDLEVELHEADERFLAG:
                 expanding = not self.GetFoldExpanded(lineNum)
-                break;
+                break
 
         lineNum = 0
         while lineNum < lineCount:
@@ -354,7 +354,7 @@ class PythonSTC(stc.StyledTextCtrl):
                     else:
                         line = self.Expand(line, False, force, visLevels-1)
             else:
-                line = line + 1;
+                line = line + 1
 
         return line
 

--- a/pyface/wx/shell.py
+++ b/pyface/wx/shell.py
@@ -21,8 +21,11 @@ __author__ = "Patrick K. O'Brien <pobrien@orbtech.com>"
 __cvsid__ = "$Id: shell.py,v 1.2 2003/06/13 17:59:34 dmorrill Exp $"
 __revision__ = "$Revision: 1.2 $"[11:-2]
 
-from wx.wx import *
+import wx
+import wx.stc
+from wx import *
 from wx.stc import *
+wx.StyledTextCtrl=wx.stc.StyledTextCtrl
 import keyword
 import os
 import sys
@@ -146,14 +149,14 @@ F9                Pop-up window of matching History items.
         return list
 
 
-class Shell(wxStyledTextCtrl):
+class Shell(wx.StyledTextCtrl):
     """PyCrust Shell based on wxStyledTextCtrl."""
 
     name = 'PyCrust Shell'
     revision = __revision__
 
-    def __init__(self, parent, id=-1, pos=wxDefaultPosition, \
-                 size=wxDefaultSize, style=wxCLIP_CHILDREN, introText='', \
+    def __init__(self, parent, id=-1, pos=wx.DefaultPosition, \
+                 size=wx.DefaultSize, style=wx.CLIP_CHILDREN, introText='', \
                  locals=None, InterpClass=None, *args, **kwds):
         """Create a PyCrust Shell instance."""
         wxStyledTextCtrl.__init__(self, parent, id, pos, size, style)
@@ -166,7 +169,7 @@ class Shell(wxStyledTextCtrl):
         # Add the current working directory "." to the search path.
         sys.path.insert(0, os.curdir)
         # Import a default interpreter class if one isn't provided.
-        if InterpClass == None:
+        if InterpClass is None:
             from PyCrust.interpreter import Interpreter
         else:
             Interpreter = InterpClass
@@ -206,26 +209,34 @@ class Shell(wxStyledTextCtrl):
         self.historyIndex = -1
         self.historyPrefix = 0
         # Assign handlers for keyboard events.
-        EVT_KEY_DOWN(self, self.OnKeyDown)
-        EVT_CHAR(self, self.OnChar)
+        self.Bind(EVT_KEY_DOWN, self.OnKeyDown)
+        self.Bind(EVT_CHAR, self.OnChar)
         # Assign handlers for wxSTC events.
-        EVT_STC_UPDATEUI(self, id, self.OnUpdateUI)
-        EVT_STC_USERLISTSELECTION(self, id, self.OnHistorySelected)
+        self.Bind(EVT_STC_UPDATEUI, self.OnUpdateUI)
+        self.Bind(EVT_STC_USERLISTSELECTION, self.OnHistorySelected)
         # Configure various defaults and user preferences.
         self.config()
         # Display the introductory banner information.
-        try: self.showIntro(introText)
-        except: pass
+        try:
+            self.showIntro(introText)
+        except:
+            pass
         # Assign some pseudo keywords to the interpreter's namespace.
-        try: self.setBuiltinKeywords()
-        except: pass
+        try:
+            self.setBuiltinKeywords()
+        except:
+            pass
         # Add 'shell' to the interpreter's local namespace.
-        try: self.setLocalShell()
-        except: pass
+        try:
+            self.setLocalShell()
+        except:
+            pass
         # Do this last so the user has complete control over their
         # environment. They can override anything they want.
-        try: self.execStartupScript(self.interp.startupScript)
-        except: pass
+        try:
+            self.execStartupScript(self.interp.startupScript)
+        except:
+            pass
 
     def destroy(self):
         # del self.interp
@@ -233,10 +244,10 @@ class Shell(wxStyledTextCtrl):
 
     def config(self):
         """Configure shell based on user preferences."""
-        self.SetMarginType(1, wxSTC_MARGIN_NUMBER)
+        self.SetMarginType(1, wx.STC_MARGIN_NUMBER)
         self.SetMarginWidth(1, 40)
 
-        self.SetLexer(wxSTC_LEX_PYTHON)
+        self.SetLexer(wx.STC_LEX_PYTHON)
         self.SetKeyWords(0, ' '.join(keyword.kwlist))
 
         self.setStyles(faces)
@@ -350,7 +361,7 @@ class Shell(wxStyledTextCtrl):
 
         # Check before.
         if charBefore and chr(charBefore) in '[]{}()' \
-        and styleBefore == wxSTC_P_OPERATOR:
+        and styleBefore == wx.STC_P_OPERATOR:
             braceAtCaret = caretPos - 1
 
         # Check after.
@@ -816,7 +827,7 @@ class Shell(wxStyledTextCtrl):
         self.prompt()
         try:
             while not reader.input:
-                wxYield()
+                wx.Yield()
             input = reader.input
         finally:
             reader.input = ''
@@ -831,7 +842,7 @@ class Shell(wxStyledTextCtrl):
 
     def ask(self, prompt='Please enter your response:'):
         """Get response from the user using a dialog box."""
-        dialog = wxTextEntryDialog(None, prompt, \
+        dialog = wx.TextEntryDialog(None, prompt, \
                                    'Input Dialog (Raw)', '')
         try:
             if dialog.ShowModal() == wxID_OK:
@@ -981,8 +992,8 @@ class Shell(wxStyledTextCtrl):
     def CanPaste(self):
         """Return true if a paste should succeed."""
         if self.CanEdit() and \
-           (wxStyledTextCtrl.CanPaste(self) or \
-            wxTheClipboard.IsSupported(PythonObject)):
+           (wx.StyledTextCtrl.CanPaste(self) or \
+            wx.TheClipboard.IsSupported(PythonObject)):
             return 1
         else:
             return 0
@@ -1014,19 +1025,19 @@ class Shell(wxStyledTextCtrl):
             command = command.replace(os.linesep + sys.ps1, os.linesep)
             command = self.lstripPrompt(text=command)
             data = wxTextDataObject(command)
-            if wxTheClipboard.Open():
-                wxTheClipboard.SetData(data)
-                wxTheClipboard.Close()
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(data)
+                wx.TheClipboard.Close()
 
     def CopyWithPrompts(self):
         """Copy selection, including prompts, and place it on the clipboard."""
         if self.CanCopy():
             command = self.GetSelectedText()
 
-            data = wxTextDataObject(command)
-            if wxTheClipboard.Open():
-                wxTheClipboard.SetData(data)
-                wxTheClipboard.Close()
+            data = wx.TextDataObject(command)
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(data)
+                wx.TheClipboard.Close()
 
     def Paste(self):
         """Replace selection with clipboard contents."""
@@ -1034,7 +1045,7 @@ class Shell(wxStyledTextCtrl):
             try:
                 if wxTheClipboard.IsSupported(wxDataFormat(wxDF_TEXT)):
                     data = wxTextDataObject()
-                    if wxTheClipboard.GetData(data):
+                    if wx.TheClipboard.GetData(data):
                         self.ReplaceSelection('')
                         command = data.GetText()
                         command = command.rstrip()
@@ -1044,7 +1055,7 @@ class Shell(wxStyledTextCtrl):
                         command = command.replace(os.linesep, '\n')
                         command = command.replace('\n', os.linesep + sys.ps2)
                         self.write(command)
-                if wxTheClipboard.IsSupported(PythonObject) and \
+                if wx.TheClipboard.IsSupported(PythonObject) and \
                        self.python_obj_paste_handler is not None:
                     # note that the presence of a PythonObject on the
                     # clipboard is really just a signal to grab the data
@@ -1052,15 +1063,15 @@ class Shell(wxStyledTextCtrl):
                     data = enClipboard.data
                     self.python_obj_paste_handler(data)
             finally:
-                wxTheClipboard.Close()
+                wx.TheClipboard.Close()
 
             return
     def PasteAndRun(self):
         """Replace selection with clipboard contents, run commands."""
-        if wxTheClipboard.Open():
-            if wxTheClipboard.IsSupported(wxDataFormat(wxDF_TEXT)):
-                data = wxTextDataObject()
-                if wxTheClipboard.GetData(data):
+        if wx.TheClipboard.Open():
+            if wx.TheClipboard.IsSupported(wxDataFormat(wxDF_TEXT)):
+                data = wx.TextDataObject()
+                if wx.TheClipboard.GetData(data):
                     endpos = self.GetTextLength()
                     self.SetCurrentPos(endpos)
                     startpos = self.promptPosEnd
@@ -1093,7 +1104,7 @@ class Shell(wxStyledTextCtrl):
                         command = command.replace('\n', os.linesep + sys.ps2)
                         self.write(command)
                         self.processLine()
-            wxTheClipboard.Close()
+            wx.TheClipboard.Close()
 
     def wrap(self, wrap=1):
         """Sets whether text is word wrapped."""
@@ -1110,22 +1121,22 @@ class Shell(wxStyledTextCtrl):
         self.SetZoom(points)
 
 
-wxID_SELECTALL = wxNewId()
-ID_AUTOCOMP = wxNewId()
-ID_AUTOCOMP_SHOW = wxNewId()
-ID_AUTOCOMP_INCLUDE_MAGIC = wxNewId()
-ID_AUTOCOMP_INCLUDE_SINGLE = wxNewId()
-ID_AUTOCOMP_INCLUDE_DOUBLE = wxNewId()
-ID_CALLTIPS = wxNewId()
-ID_CALLTIPS_SHOW = wxNewId()
+wxID_SELECTALL = wx.NewId()
+ID_AUTOCOMP = wx.NewId()
+ID_AUTOCOMP_SHOW = wx.NewId()
+ID_AUTOCOMP_INCLUDE_MAGIC = wx.NewId()
+ID_AUTOCOMP_INCLUDE_SINGLE = wx.NewId()
+ID_AUTOCOMP_INCLUDE_DOUBLE = wx.NewId()
+ID_CALLTIPS = wx.NewId()
+ID_CALLTIPS_SHOW = wx.NewId()
 
-ID_FILLING = wxNewId()
-ID_FILLING_AUTO_UPDATE = wxNewId()
-ID_FILLING_SHOW_METHODS = wxNewId()
-ID_FILLING_SHOW_CLASS = wxNewId()
-ID_FILLING_SHOW_DICT = wxNewId()
-ID_FILLING_SHOW_DOC = wxNewId()
-ID_FILLING_SHOW_MODULE = wxNewId()
+ID_FILLING = wx.NewId()
+ID_FILLING_AUTO_UPDATE = wx.NewId()
+ID_FILLING_SHOW_METHODS = wx.NewId()
+ID_FILLING_SHOW_CLASS = wx.NewId()
+ID_FILLING_SHOW_DICT = wx.NewId()
+ID_FILLING_SHOW_DOC = wx.NewId()
+ID_FILLING_SHOW_MODULE = wx.NewId()
 
 
 class ShellMenu:
@@ -1194,51 +1205,55 @@ class ShellMenu:
         b.Append(self.helpMenu, '&Help')
         self.SetMenuBar(b)
 
-        EVT_MENU(self, wxID_EXIT, self.OnExit)
-        EVT_MENU(self, wxID_UNDO, self.OnUndo)
-        EVT_MENU(self, wxID_REDO, self.OnRedo)
-        EVT_MENU(self, wxID_CUT, self.OnCut)
-        EVT_MENU(self, wxID_COPY, self.OnCopy)
-        EVT_MENU(self, wxID_PASTE, self.OnPaste)
-        EVT_MENU(self, wxID_CLEAR, self.OnClear)
-        EVT_MENU(self, wxID_SELECTALL, self.OnSelectAll)
-        EVT_MENU(self, wxID_ABOUT, self.OnAbout)
-        EVT_MENU(self, ID_AUTOCOMP_SHOW, \
-                 self.OnAutoCompleteShow)
-        EVT_MENU(self, ID_AUTOCOMP_INCLUDE_MAGIC, \
-                 self.OnAutoCompleteIncludeMagic)
-        EVT_MENU(self, ID_AUTOCOMP_INCLUDE_SINGLE, \
-                 self.OnAutoCompleteIncludeSingle)
-        EVT_MENU(self, ID_AUTOCOMP_INCLUDE_DOUBLE, \
-                 self.OnAutoCompleteIncludeDouble)
-        EVT_MENU(self, ID_CALLTIPS_SHOW, \
-                 self.OnCallTipsShow)
+        self.Bind(EVT_MENU, self.OnExit, id=wx.ID_EXIT)
+        self.Bind(EVT_MENU, self.OnUndo, id=wx.ID_UNDO)
+        self.Bind(EVT_MENU, self.OnRedo, id=wx.ID_REDO)
+        self.Bind(EVT_MENU, self.OnCut, id=wx.ID_CUT)
+        self.Bind(EVT_MENU, self.OnCopy, id=wx.ID_COPY)
+        self.Bind(EVT_MENU, self.OnPaste, id=wx.ID_PASTE)
+        self.Bind(EVT_MENU, self.OnClear, id=wx.ID_CLEAR)
+        self.Bind(EVT_MENU, self.OnSelectAll, id=wx.ID_SELECTALL)
+        self.Bind(EVT_MENU, self.OnAbout, id=wx.ID_ABOUT)
+        self.Bind(EVT_MENU, \
+                 self.OnAutoCompleteShow, ID_AUTOCOMP_SHOW)
+        self.Bind(EVT_MENU, \
+                 self.OnAutoCompleteIncludeMagic, id=ID_AUTOCOMP_INCLUDE_MAGIC)
+        self.Bind(EVT_MENU, \
+                 self.OnAutoCompleteIncludeSingle, id=ID_AUTOCOMP_INCLUDE_SINGLE)
+        self.Bind(EVT_MENU, \
+                 self.OnAutoCompleteIncludeDouble, id=ID_AUTOCOMP_INCLUDE_DOUBLE)
+        self.Bind(EVT_MENU, \
+                 self.OnCallTipsShow, id=ID_CALLTIPS_SHOW)
 
-        EVT_UPDATE_UI(self, wxID_UNDO, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, wxID_REDO, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, wxID_CUT, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, wxID_COPY, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, wxID_PASTE, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, wxID_CLEAR, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, ID_AUTOCOMP_SHOW, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, ID_AUTOCOMP_INCLUDE_MAGIC, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, ID_AUTOCOMP_INCLUDE_SINGLE, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, ID_AUTOCOMP_INCLUDE_DOUBLE, self.OnUpdateMenu)
-        EVT_UPDATE_UI(self, ID_CALLTIPS_SHOW, self.OnUpdateMenu)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=wx.ID_UNDO)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=wx.ID_REDO)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=wx.ID_CUT)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=wx.ID_COPY)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=wx.ID_PASTE)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=wx.ID_CLEAR)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_AUTOCOMP_SHOW)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_AUTOCOMP_INCLUDE_MAGIC)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_AUTOCOMP_INCLUDE_SINGLE)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_AUTOCOMP_INCLUDE_DOUBLE)
+        self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_CALLTIPS_SHOW)
 
         if hasattr( self, 'crust' ):
-            EVT_MENU(self, ID_FILLING_AUTO_UPDATE, self.OnFillingAutoUpdate)
-            EVT_MENU(self, ID_FILLING_SHOW_METHODS, self.OnFillingShowMethods)
-            EVT_MENU(self, ID_FILLING_SHOW_CLASS, self.OnFillingShowClass)
-            EVT_MENU(self, ID_FILLING_SHOW_DICT, self.OnFillingShowDict)
-            EVT_MENU(self, ID_FILLING_SHOW_DOC, self.OnFillingShowDoc)
-            EVT_MENU(self, ID_FILLING_SHOW_MODULE, self.OnFillingShowModule)
-            EVT_UPDATE_UI(self, ID_FILLING_AUTO_UPDATE, self.OnUpdateMenu)
-            EVT_UPDATE_UI(self, ID_FILLING_SHOW_METHODS, self.OnUpdateMenu)
-            EVT_UPDATE_UI(self, ID_FILLING_SHOW_CLASS, self.OnUpdateMenu)
-            EVT_UPDATE_UI(self, ID_FILLING_SHOW_DICT, self.OnUpdateMenu)
-            EVT_UPDATE_UI(self, ID_FILLING_SHOW_DOC, self.OnUpdateMenu)
-            EVT_UPDATE_UI(self, ID_FILLING_SHOW_MODULE, self.OnUpdateMenu)
+            self.Bind(EVT_MENU, self.OnFillingAutoUpdate,
+                      id=ID_FILLING_AUTO_UPDATE)
+            self.Bind(EVT_MENU, self.OnFillingShowMethods,
+                      id=ID_FILLING_SHOW_METHODS)
+            self.Bind(EVT_MENU, self.OnFillingShowClass, id=ID_FILLING_SHOW_CLASS)
+            self.Bind(EVT_MENU, self.OnFillingShowDict, id=ID_FILLING_SHOW_DICT)
+            self.Bind(EVT_MENU, self.OnFillingShowDoc, id=ID_FILLING_SHOW_DOC)
+            self.Bind(EVT_MENU, self.OnFillingShowModule,
+                      id=ID_FILLING_SHOW_MODULE)
+            self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_FILLING_AUTO_UPDATE)
+            self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu,
+                      id=ID_FILLING_SHOW_METHODS)
+            self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_FILLING_SHOW_CLASS)
+            self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_FILLING_SHOW_DICT)
+            self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_FILLING_SHOW_DOC)
+            self.Bind(EVT_UPDATE_UI, self.OnUpdateMenu, id=ID_FILLING_SHOW_MODULE)
 
     def OnExit(self, event):
         self.Close(True)

--- a/pyface/wx/spreadsheet/abstract_grid_view.py
+++ b/pyface/wx/spreadsheet/abstract_grid_view.py
@@ -32,7 +32,7 @@ class ComboboxFocusHandler(wx.EvtHandler):
 
     def __init__(self):
         wx.EvtHandler.__init__(self)
-        wx.EVT_KILL_FOCUS(self, self._on_kill_focus)
+        self.Bind(wx.EVT_KILL_FOCUS, self._on_kill_focus)
         return
 
     def _on_kill_focus(self, evt):
@@ -69,14 +69,14 @@ class AbstractGridView(Grid):
         self.edit = False
 
         # this seems like a busy idle ...
-        wx.EVT_IDLE(self, self.OnIdle)
+        self.Bind(wx.EVT_IDLE, self.OnIdle)
 
         # Enthought specific display controls ...
         self.init_labels()
         self.init_data_types()
         self.init_handlers()
 
-        wx.grid.EVT_GRID_EDITOR_CREATED(self, self._on_editor_created)
+        self.Bind(wx.grid.EVT_GRID_EDITOR_CREATED, self._on_editor_created)
 
         return
 
@@ -85,7 +85,7 @@ class AbstractGridView(Grid):
     def _on_editor_created(self, evt):
 
         editor = evt.GetControl()
-        editor.PushEventHandler(ComboboxFocusHandler())
+        #editor.PushEventHandler(ComboboxFocusHandler())
 
         evt.Skip()
         return
@@ -109,26 +109,26 @@ class AbstractGridView(Grid):
 
     def init_handlers(self):
 
-        wx.grid.EVT_GRID_CELL_LEFT_CLICK(self, self.OnCellLeftClick)
-        wx.grid.EVT_GRID_CELL_RIGHT_CLICK(self, self.OnCellRightClick)
-        wx.grid.EVT_GRID_CELL_LEFT_DCLICK(self, self.OnCellLeftDClick)
-        wx.grid.EVT_GRID_CELL_RIGHT_DCLICK(self, self.OnCellRightDClick)
+        self.Bind(wx.grid.EVT_GRID_CELL_LEFT_CLICK, self.OnCellLeftClick)
+        self.Bind(wx.grid.EVT_GRID_CELL_RIGHT_CLICK, self.OnCellRightClick)
+        self.Bind(wx.grid.EVT_GRID_CELL_LEFT_DCLICK, self.OnCellLeftDClick)
+        self.Bind(wx.grid.EVT_GRID_CELL_RIGHT_DCLICK, self.OnCellRightDClick)
 
-        wx.grid.EVT_GRID_LABEL_LEFT_CLICK(self, self.OnLabelLeftClick)
-        wx.grid.EVT_GRID_LABEL_RIGHT_CLICK(self, self.OnLabelRightClick)
-        wx.grid.EVT_GRID_LABEL_LEFT_DCLICK(self, self.OnLabelLeftDClick)
-        wx.grid.EVT_GRID_LABEL_RIGHT_DCLICK(self, self.OnLabelRightDClick)
+        self.Bind(wx.grid.EVT_GRID_LABEL_LEFT_CLICK, self.OnLabelLeftClick)
+        self.Bind(wx.grid.EVT_GRID_LABEL_RIGHT_CLICK, self.OnLabelRightClick)
+        self.Bind(wx.grid.EVT_GRID_LABEL_LEFT_DCLICK, self.OnLabelLeftDClick)
+        self.Bind(wx.grid.EVT_GRID_LABEL_RIGHT_DCLICK, self.OnLabelRightDClick)
 
-        wx.grid.EVT_GRID_ROW_SIZE(self, self.OnRowSize)
-        wx.grid.EVT_GRID_COL_SIZE(self, self.OnColSize)
+        self.Bind(wx.grid.EVT_GRID_ROW_SIZE, self.OnRowSize)
+        self.Bind(wx.grid.EVT_GRID_COL_SIZE, self.OnColSize)
 
-        wx.grid.EVT_GRID_RANGE_SELECT(self, self.OnRangeSelect)
-        wx.grid.EVT_GRID_CELL_CHANGE(self, self.OnCellChange)
-        wx.grid.EVT_GRID_SELECT_CELL(self, self.OnSelectCell)
+        self.Bind(wx.grid.EVT_GRID_RANGE_SELECT, self.OnRangeSelect)
+        self.Bind(wx.grid.EVT_GRID_CELL_CHANGE, self.OnCellChange)
+        self.Bind(wx.grid.EVT_GRID_SELECT_CELL, self.OnSelectCell)
 
-        wx.grid.EVT_GRID_EDITOR_SHOWN(self, self.OnEditorShown)
-        wx.grid.EVT_GRID_EDITOR_HIDDEN(self, self.OnEditorHidden)
-        wx.grid.EVT_GRID_EDITOR_CREATED(self, self.OnEditorCreated)
+        self.Bind(wx.grid.EVT_GRID_EDITOR_SHOWN, self.OnEditorShown)
+        self.Bind(wx.grid.EVT_GRID_EDITOR_HIDDEN, self.OnEditorHidden)
+        self.Bind(wx.grid.EVT_GRID_EDITOR_CREATED, self.OnEditorCreated)
 
         return
 
@@ -223,7 +223,7 @@ class AbstractGridView(Grid):
                 self.EnableCellEditControl()
             self.edit = False
 
-        if self.moveTo != None:
+        if self.moveTo is not None:
             self.SetGridCursor(self.moveTo[0], self.moveTo[1])
             self.moveTo = None
 

--- a/pyface/wx/spreadsheet/default_renderer.py
+++ b/pyface/wx/spreadsheet/default_renderer.py
@@ -46,8 +46,8 @@ class DefaultRenderer(PyGridCellRenderer):
         return DefaultRenderer(self.color, self.foundary, self.fontsize)
 
     def Draw(self, grid, attr, dc, rect, row, col, isSelected):
-        self.DrawBackground(grid, attr, dc, rect, row, col, isSelected);
-        self.DrawForeground(grid, attr, dc, rect, row, col, isSelected);
+        self.DrawBackground(grid, attr, dc, rect, row, col, isSelected)
+        self.DrawForeground(grid, attr, dc, rect, row, col, isSelected)
         dc.DestroyClippingRegion()
         return
 
@@ -56,7 +56,7 @@ class DefaultRenderer(PyGridCellRenderer):
         """
         # We have to set the clipping region on the grid's DC,
         # otherwise the text will spill over to the next cell
-        dc.SetClippingRect(rect)
+        dc.SetClippingRegion(rect)
 
         # overwrite anything currently in the cell ...
         dc.SetBackgroundMode(wx.SOLID)
@@ -82,7 +82,7 @@ class DefaultRenderer(PyGridCellRenderer):
         dc.SetFont(self.font)
         dc.DrawText(self.FormatText(text), rect.x+1, rect.y+1)
 
-        self.DrawEllipses(grid, attr, dc, rect, row, col, isSelected);
+        self.DrawEllipses(grid, attr, dc, rect, row, col, isSelected)
         return
 
     def FormatText(self, text):

--- a/pyface/wx/spreadsheet/font_renderer.py
+++ b/pyface/wx/spreadsheet/font_renderer.py
@@ -32,7 +32,7 @@ class FontRenderer(DefaultRenderer):
         # and colors.  We have to set the clipping region on
         # the grid's DC, otherwise the text will spill over
         # to the next cell
-        dc.SetClippingRect(rect)
+        dc.SetClippingRegion(rect)
 
         # clear the background
         dc.SetBackgroundMode(wx.SOLID)

--- a/pyface/wx/spreadsheet/unit_renderer.py
+++ b/pyface/wx/spreadsheet/unit_renderer.py
@@ -36,7 +36,7 @@ class UnitRenderer(DefaultRenderer):
         """
         # We have to set the clipping region on the grid's DC,
         # otherwise the text will spill over to the next cell
-        dc.SetClippingRect(rect)
+        dc.SetClippingRegion(rect)
 
         # overwrite anything currently in the cell ...
         dc.SetBackgroundMode(wx.SOLID)
@@ -77,7 +77,7 @@ class MultiUnitRenderer(DefaultRenderer):
         """
         # We have to set the clipping region on the grid's DC,
         # otherwise the text will spill over to the next cell
-        dc.SetClippingRect(rect)
+        dc.SetClippingRegion(rect)
 
         # overwrite anything currently in the cell ...
         dc.SetBackgroundMode(wx.SOLID)

--- a/pyface/wx/switcher.py
+++ b/pyface/wx/switcher.py
@@ -144,7 +144,7 @@ class SwitcherControl(wx.Panel):
                 combo.Append(name, data)
 
         # Listen for changes to the selected item.
-        wx.EVT_COMBOBOX(self, combo.GetId(), self._on_combobox)
+        combo.Bind(wx.EVT_COMBOBOX, self._on_combobox)
 
         # If the model's selected variable has been set ...
         if model.selected != -1:


### PR DESCRIPTION
Merging this would break compatibility with wxPython 3, so I was wondering what the upgrade strategy might be?

I was thinking about trying to add a new toolkit called "wx4" where the normal "wx" would then refer to wxPython 3, but there is stuff that doesn't lie behind the pyface/wx and pyface/ui/wx, like pyface/dock/*, pyface/sizers/flow.py, and pyface/tree/node_tree.py. I'm not sure how to deal with that.

Note: a lot of this work was done by Eric Carlson here: https://github.com/braidedlogix/ETS_py3 but that code had some python 3 specific stuff as well as a bunch of whitespace/styling changes that I left out in this.

There are also some changes needed in the traitsui package, so if you have a different way you'd like me to show those changes, let me know, otherwise I can submit a "pull request" that I'm not intending for you to actually pull.