### PR TITLE
Fix: Ordering of items being appended to the default group of ActionManager

### DIFF
--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -332,7 +332,7 @@ class ActionManager(HasTraits):
 
         Parameters
         ----------
-        item : Group instance or ActionManagerItem instance
+        item : string, Group instance or ActionManagerItem instance
             The item to be added to this ActionManager
 
         Returns

--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -162,8 +162,9 @@ class ActionManager(HasTraits):
         of groups.  If the item is an ActionManagerItem then the item is
         appended to the manager's defualt group.
         """
+        item = self._prepare_item(item)
         group = self._get_target_group(item)
-        group.append(self._prepare_item(item))
+        group.append(item)
         return group
 
     def destroy(self):
@@ -194,8 +195,9 @@ class ActionManager(HasTraits):
         of groups.  If the item is an ActionManagerItem then the item is
         inserted into the manager's defualt group.
         """
+        item = self._prepare_item(item)
         group = self._get_target_group(item)
-        group.insert(index, self._prepare_item(item))
+        group.insert(index, item)
         return group
 
     def find_group(self, id):

--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -322,8 +322,7 @@ class ActionManager(HasTraits):
         """
         group = self.find_group(self.DEFAULT_GROUP)
         if group is None:
-            group = Group(id=self.DEFAULT_GROUP)
-            group.parent = self
+            group = self._prepare_item(self.DEFAULT_GROUP)
             self._groups.append(group)
 
         return group

--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -163,7 +163,12 @@ class ActionManager(HasTraits):
         appended to the manager's defualt group.
         """
         item = self._prepare_item(item)
-        group = self._get_target_group(item)
+        if isinstance(item, Group):
+            group = self._groups
+
+        else:
+            group = self._get_default_group()
+
         group.append(item)
         return group
 
@@ -196,7 +201,13 @@ class ActionManager(HasTraits):
         inserted into the manager's defualt group.
         """
         item = self._prepare_item(item)
-        group = self._get_target_group(item)
+
+        if isinstance(item, Group):
+            group = self._groups
+
+        else:
+            group = self._get_default_group()
+
         group.insert(index, item)
         return group
 
@@ -316,24 +327,6 @@ class ActionManager(HasTraits):
             self._groups.append(group)
 
         return group
-
-    def _get_target_group(self, item):
-        """ Return the target group for adding an item.
-
-        Parameters
-        ----------
-        item : Group instance or ActionManagerItem instance
-            The item to append.
-
-        Returns
-        -------
-        group : Group instance
-            The group for an item should belong by default.
-        """
-        if isinstance(item, Group):
-            return self._groups
-
-        return self._get_default_group()
 
     def _prepare_item(self, item):
         """ Prepare an item to be added to this ActionManager.

--- a/pyface/action/tests/test_action_manager.py
+++ b/pyface/action/tests/test_action_manager.py
@@ -101,6 +101,20 @@ class TestActionItem(unittest.TestCase, UnittestTools):
         self.assertEqual(action_manager.groups, [default_group, self.group])
         self.assertEqual(default_group.items, [self.action_item])
 
+    def test_append_item_order(self):
+        # Regression test for enthought/pyface#289
+        expected = [
+            self.action_item,
+            ActionItem(action=Action(name="Test2")),
+            ActionItem(action=Action(name="Test3")),
+        ]
+        action_manager = ActionManager()
+        for item in expected:
+            action_manager.append(item)
+
+        default_group = action_manager._get_default_group()
+        self.assertEqual(default_group.items, expected)
+
     def test_destroy(self):
         action_manager = ActionManager(self.group)
         # XXX items doesn't fire a change event.  Should it?


### PR DESCRIPTION
Fix #289 

When item that is not a `Group` is being added to `ActionManager` using `append`, the index is computed from the number of groups (by default there is one Group) rather than the number of items in the default group.  So items were being inserted before index 1, hence the order was wrong.

This PR fixes this.

(Note: `Group` does not provide `__len__`, it would be nice if it did.)