### PR TITLE
Add 'qt' as a synonym for 'qt4' for ETS_TOOLKIT

### DIFF
--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -20,15 +20,22 @@ class Toolkit(HasTraits):
     class that raises NotImplementedError when it is instantiated.
     """
 
+    #: The name of the package (eg. pyface)
+    package = ReadOnly
+
     #: The name of the toolkit
     toolkit = ReadOnly
 
     #: The packages to look in for widget implementations.
-    package = List(Str)
+    packages = List(Str)
 
-    def __init__(self, toolkit, *packages, **traits):
-        super(Toolkit, self).__init__(toolkit=toolkit, packages=list(packages),
-                                      **traits)
+    def __init__(self, package, toolkit, *packages, **traits):
+        super(Toolkit, self).__init__(
+            package=package,
+            toolkit=toolkit,
+            packages=list(packages),
+            **traits
+        )
 
     def __call__(self, name):
         """ Return the toolkit specific object with the given name.
@@ -77,7 +84,7 @@ class Toolkit(HasTraits):
             """
 
             def __init__(self, *args, **kwargs):
-                msg = "the %s pyface backend doesn't implement %s"
-                raise NotImplementedError(msg % (toolkit, name))
+                msg = "the %s %s backend doesn't implement %s"
+                raise NotImplementedError(msg % (toolkit, package, name))
 
         return Unimplemented

--- a/pyface/tests/test_new_toolkit/init.py
+++ b/pyface/tests/test_new_toolkit/init.py
@@ -2,4 +2,4 @@
 
 from pyface.base_toolkit import Toolkit
 
-toolkit_object = Toolkit('test', 'pyface.tests.test_new_toolkit')
+toolkit_object = Toolkit('pyface', 'test', 'pyface.tests.test_new_toolkit')

--- a/pyface/ui/null/init.py
+++ b/pyface/ui/null/init.py
@@ -12,4 +12,4 @@
 
 from pyface.base_toolkit import Toolkit
 
-toolkit_object = Toolkit('null', 'pyface.ui.null')
+toolkit_object = Toolkit('pyface', 'null', 'pyface.ui.null')

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -38,4 +38,4 @@ if _app is None:
 
 
 # create the toolkit object
-toolkit_object = Toolkit('qt4', 'pyface.ui.qt4')
+toolkit_object = Toolkit('pyface', 'qt4', 'pyface.ui.qt4')

--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -36,4 +36,4 @@ wx.Log.SetActiveTarget(_log)
 
 
 # create the toolkit object
-toolkit_object = Toolkit('wx', 'pyface.ui.wx')
+toolkit_object = Toolkit('pyface', 'wx', 'pyface.ui.wx')

--- a/setup.py
+++ b/setup.py
@@ -171,6 +171,7 @@ if __name__ == "__main__":
           entry_points = {
               'pyface.toolkits': [
                   'qt4 = pyface.ui.qt4.init:toolkit_object',
+                  'qt = pyface.ui.qt4.init:toolkit_object',
                   'wx = pyface.ui.wx.init:toolkit_object',
                   'null = pyface.ui.null.init:toolkit_object',
               ],


### PR DESCRIPTION
This is the first step in allowing setting `ETS_TOOLKIT=qt` instead of `qt4`.  Currently wont work because TraitsUI will break

Also generalize `Toolkit` for use in other packages (eg. TraitsUI, Enable, etc.), as this will be useful in rolling out support for `pkg_resource`-based toolkit discovery.