### PR TITLE
Small documentation fixes

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ pygments_style = 'sphinx'
 # The name of an image file (within the static path) to use as favicon of the
 # docs.  This file should be a Windows icon file (.ico) being 16x16 or 32x32
 # pixels large.
-html_favicon = "favicon.ico"
+#html_favicon = "favicon.ico"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/setup.py
+++ b/setup.py
@@ -126,7 +126,7 @@ if __name__ == "__main__":
 
     setup(name='pyface',
           version=__version__,
-          url='https://docs.enthought.com/pyface',
+          url='http://docs.enthought.com/pyface',
           author='David C. Morrill, et al.',
           author_email='dmorrill@enthought.com',
           classifiers=[c.strip() for c in """\
@@ -150,7 +150,7 @@ if __name__ == "__main__":
               """.splitlines() if len(c.split()) > 0],
           description='traits-capable windowing framework',
           long_description=open('README.rst').read(),
-          download_url=('https://github.com/enthought/pyface'),
+          download_url='https://github.com/enthought/pyface',
           install_requires=__requires__,
           extras_require=__extras_require__,
           license='BSD',


### PR DESCRIPTION
This consists of:

- use HTTP instead of HTTPS for docs in setup.py because of limitations of github pages.
- use default favicon from enthought-sphinx-theme