### PR TITLE
qt: Actually raise if we can't find at QT api

### DIFF
--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -66,8 +66,8 @@ if qt_api is None:
             break
         except ImportError:
             continue
-        else:
-            raise ImportError('Cannot import PySide, PySide2, PyQt5 or PyQt4')
+    else:
+        raise ImportError('Cannot import PySide, PySide2, PyQt5 or PyQt4')
 
 # otherwise check QT_API value is valid
 elif qt_api not in {api_name for api_name, module in QtAPIs}:


### PR DESCRIPTION
I am writing a package where I would like the Qt GUI to be optional.  I expect that saying `import pyface.qt` without a Qt API will fail -- but it seems that the `else` clause is attached to the `try / except` construct, not the `for` loop.

This PR removes 8 spaces and restores the expected behavior.