### PR TITLE
fix: add deprecated QStyleOption names in the Qt5 interfaces

### DIFF
--- a/pyface/qt/QtGui.py
+++ b/pyface/qt/QtGui.py
@@ -12,6 +12,9 @@ elif qt_api == 'pyqt5':
         QAbstractProxyModel, QItemSelection, QItemSelectionModel,
         QItemSelectionRange, QSortFilterProxyModel, QStringListModel
     )
+    QStyleOptionTabV2 = QStyleOptionTab
+    QStyleOptionTabV3 = QStyleOptionTab
+    QStyleOptionTabBarBaseV2 = QStyleOptionTabBarBase
 
 elif qt_api == 'pyside2':
     from PySide2.QtGui import *
@@ -21,6 +24,9 @@ elif qt_api == 'pyside2':
         QAbstractProxyModel, QItemSelection, QItemSelectionModel,
         QItemSelectionRange, QSortFilterProxyModel
     )
+    QStyleOptionTabV2 = QStyleOptionTab
+    QStyleOptionTabV3 = QStyleOptionTab
+    QStyleOptionTabBarBaseV2 = QStyleOptionTabBarBase
 
 else:
     from PySide.QtGui import *


### PR DESCRIPTION
This PR resolves a crash in Mayavi when using pyface 6.0 and PyQt 5.6. 

The crash can be reproduced by trying to drag the Tab labeled "Mayavi Scene 1" in the screen shot below:
<img width="799" alt="mayavi_screenshot" src="https://user-images.githubusercontent.com/6528957/40260009-8d253148-5ac6-11e8-9752-f2fc45b0e208.png">

Trying to drag the tab crashes the application with the following traceback.
```
Traceback (most recent call last):
  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/pyface/ui/qt4/workbench/split_tab_widget.py", line 897, in mouseDoubleClickEvent
    self._resize_title_edit_to_current_tab()
  File "/Users/lee8rx/anaconda/lib/python3.5/site-packages/pyface/ui/qt4/workbench/split_tab_widget.py", line 985, in _resize_title_edit_to_current_tab
    tab = QtGui.QStyleOptionTabV3()
AttributeError: module 'pyface.qt.QtGui' has no attribute 'QStyleOptionTabV3'
```

The names QStyleOptionTabV3, QStyleOptionTabV2 and QStyleOptionTabBarBaseV2 have been deprecated and do not exist in the PyQt5 or PySide2 namespaces.  This PR adds them to the pyface.qt.QtGui namespace. Relevant Qt documentation:
https://doc.qt.io/qt-5.10/qstyleoptiontab-obsolete.html
https://doc.qt.io/qt-5/qstyleoptiontabbarbase-obsolete.html

