### PR TITLE
Fix ResourceWarnings from test suite.

### DIFF
--- a/pyface/ui/qt4/util/testing.py
+++ b/pyface/ui/qt4/util/testing.py
@@ -55,27 +55,38 @@ def delete_widget(widget, timeout=1.0):
 
 
 @contextmanager
+def _convert_none_to_null_handle(stream):
+    """ If 'stream' is not None, provide a temporary handle to /dev/null. """
+
+    if stream is None:
+        out = open(os.devnull, 'w')
+        try:
+            yield out
+        finally:
+            out.close()
+    else:
+        yield stream
+
+
+@contextmanager
 def silence_output(out=None, err=None):
     """ Re-direct the stderr and stdout streams while in the block. """
 
-    if out is None:
-        out = open(os.devnull, 'w')
-    if err is None:
-        err = open(os.devnull, 'w')
+    with _convert_none_to_null_handle(out) as out:
+        with _convert_none_to_null_handle(err) as err:
+            _old_stderr = sys.stderr
+            _old_stderr.flush()
 
-    _old_stderr = sys.stderr
-    _old_stderr.flush()
+            _old_stdout = sys.stdout
+            _old_stdout.flush()
 
-    _old_stdout = sys.stdout
-    _old_stdout.flush()
-
-    try:
-        sys.stdout = out
-        sys.stderr = err
-        yield
-    finally:
-        sys.stdout = _old_stdout
-        sys.stderr = _old_stderr
+            try:
+                sys.stdout = out
+                sys.stderr = err
+                yield
+            finally:
+                sys.stdout = _old_stdout
+                sys.stderr = _old_stderr
 
 
 def print_qt_widget_tree(widget, level=0):


### PR DESCRIPTION
On Python 3.6, there are `ResourceWarning`s due to unclosed files reported by the test suite. For example:

```
test_capture_errors_on_error (pyface.ui.qt4.util.tests.test_modal_dialog_tester.TestModalDialogTester) ... /Users/mdickinson/.edm/envs/pyface-test-3.6-pyqt/lib/python3.6/site-packages/pyface-6.1.0.dev13-py3.6.egg/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py:143: ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='UTF-8'>
  tester.open_and_run(when_opened=raise_error)
ok
test_capture_errors_on_failure (pyface.ui.qt4.util.tests.test_modal_dialog_tester.TestModalDialogTester) ... /Users/mdickinson/.edm/envs/pyface-test-3.6-pyqt/lib/python3.6/site-packages/pyface-6.1.0.dev13-py3.6.egg/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py:124: ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='UTF-8'>
  tester.open_and_run(when_opened=failure)
ok
```

This PR fixes (at least some of) those warnings.