### PR TITLE
Fix toolbar and statusbar issues

### DIFF
--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -13,7 +13,6 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = ApplicationWindow()
@@ -131,15 +130,46 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
 
     def test_toolbar(self):
         # test that toolbar gets created as expected
-        self.window.tool_bar_manager = ToolBarManager(
-            Action(name="New", image=ImageResource('core')),
-            Action(name="Open", image=ImageResource('core')),
-            Action(name="Save", image=ImageResource('core')),
-            Action(name="Close", image=ImageResource('core')),
-            Action(name="Quit", image=ImageResource('core')),
-        )
+        self.window.tool_bar_managers = [
+            ToolBarManager(
+                Action(name="New", image=ImageResource('core')),
+                Action(name="Open", image=ImageResource('core')),
+                Action(name="Save", image=ImageResource('core')),
+                Action(name="Close", image=ImageResource('core')),
+                Action(name="Quit", image=ImageResource('core')),
+            )
+        ]
         self.window._create()
         self.window.show(True)
+        self.event_loop()
+        self.window.show(False)
+        self.event_loop()
+        self.window.close()
+        self.event_loop()
+
+    def test_toolbar_changed(self):
+        # test that toolbar gets changed as expected
+        self.window.tool_bar_managers = [
+            ToolBarManager(
+                Action(name="New", image=ImageResource('core')),
+                Action(name="Open", image=ImageResource('core')),
+                Action(name="Save", image=ImageResource('core')),
+                Action(name="Close", image=ImageResource('core')),
+                Action(name="Quit", image=ImageResource('core')),
+            )
+        ]
+        self.window._create()
+        self.window.show(True)
+        self.event_loop()
+        self.window.tool_bar_managers = [
+            ToolBarManager(
+                Action(name="New", image=ImageResource('core')),
+                Action(name="Open", image=ImageResource('core')),
+                Action(name="Save", image=ImageResource('core')),
+                Action(name="Close", image=ImageResource('core')),
+                Action(name="Quit", image=ImageResource('core')),
+            )
+        ]
         self.event_loop()
         self.window.show(False)
         self.event_loop()
@@ -153,6 +183,23 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         )
         self.window._create()
         self.window.show(True)
+        self.event_loop()
+        self.window.show(False)
+        self.event_loop()
+        self.window.close()
+        self.event_loop()
+
+    def test_statusbar_changed(self):
+        # test that status bar gets changed as expected
+        self.window.status_bar_manager = StatusBarManager(
+            message="hello world",
+        )
+        self.window._create()
+        self.window.show(True)
+        self.event_loop()
+        self.window.status_bar_manager = StatusBarManager(
+            message="goodbye world",
+        )
         self.event_loop()
         self.window.show(False)
         self.event_loop()

--- a/pyface/ui/qt4/action/status_bar_manager.py
+++ b/pyface/ui/qt4/action/status_bar_manager.py
@@ -52,6 +52,12 @@ class StatusBarManager(HasTraits):
 
         return self.status_bar
 
+    def destroy_status_bar(self):
+        """ Creates a status bar. """
+        if self.status_bar is not None:
+            self.status_bar.deleteLater()
+            self.status_bar = None
+
     ###########################################################################
     # Property handlers.
     ###########################################################################
@@ -116,5 +122,6 @@ class StatusBarManager(HasTraits):
         # probably also need to extend the API to allow a "message" to be a
         # widget - depends on what wx is capable of.
         self.status_bar.showMessage("  ".join(self.messages))
+
 
 #### EOF ######################################################################

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -10,6 +10,8 @@
 # Description: <Enthought pyface package component>
 #------------------------------------------------------------------------------
 
+import sys
+
 # Major package imports.
 from pyface.qt import QtGui
 
@@ -19,8 +21,9 @@ from pyface.action.api import ToolBarManager
 from traits.api import Instance, List, on_trait_change, provides, Unicode
 
 # Local imports.
-from pyface.i_application_window import IApplicationWindow, \
-     MApplicationWindow
+from pyface.i_application_window import (
+    IApplicationWindow, MApplicationWindow
+)
 from pyface.image_resource import ImageResource
 from .window import Window
 
@@ -31,21 +34,26 @@ class ApplicationWindow(MApplicationWindow, Window):
     IApplicationWindow interface for the API documentation.
     """
 
-
     #### 'IApplicationWindow' interface #######################################
 
+    #: The icon to display in the application window title bar.
     icon = Instance(ImageResource)
 
+    #: The menu bar manager for the window.
     menu_bar_manager = Instance(MenuBarManager)
 
+    #: The status bar manager for the window.
     status_bar_manager = Instance(StatusBarManager)
 
+    #: DEPRECATED: The tool bar manager for the window.
     tool_bar_manager = Instance(ToolBarManager)
 
+    #: The collection of tool bar managers for the window.
     tool_bar_managers = List(ToolBarManager)
 
     #### 'IWindow' interface ##################################################
 
+    #: The window title.
     title = Unicode("Pyface")
 
     ###########################################################################
@@ -89,10 +97,11 @@ class ApplicationWindow(MApplicationWindow, Window):
             if len(tool_bar.objectName()) == 0:
                 tool_bar.setObjectName(tool_bar_manager.name)
 
-        # Work around bug in Qt on OS X where creating a tool bar with a
-        # QMainWindow parent hides the window. See
-        # http://bugreports.qt.nokia.com/browse/QTBUG-5069 for more info.
-        self.control.setVisible(visible)
+        if sys.platform == 'darwin':
+            # Work around bug in Qt on OS X where creating a tool bar with a
+            # QMainWindow parent hides the window. See
+            # http://bugreports.qt.nokia.com/browse/QTBUG-5069 for more info.
+            self.control.setVisible(visible)
 
     def _set_window_icon(self):
         if self.icon is None:
@@ -158,8 +167,10 @@ class ApplicationWindow(MApplicationWindow, Window):
         if self.control is not None:
             self._create_menu_bar(self.control)
 
-    def _status_bar_manager_changed(self):
+    def _status_bar_manager_changed(self, old, new):
         if self.control is not None:
+            if old is not None:
+                old.destroy_status_bar()
             self._create_status_bar(self.control)
 
     @on_trait_change('tool_bar_manager, tool_bar_managers')

--- a/pyface/ui/qt4/tasks/task_window_backend.py
+++ b/pyface/ui/qt4/tasks/task_window_backend.py
@@ -11,10 +11,12 @@ from .dock_pane import AREA_MAP, INVERSE_AREA_MAP
 from .main_window_layout import MainWindowLayout
 
 # Constants.
-CORNER_MAP = { 'top_left'     : QtCore.Qt.TopLeftCorner,
-               'top_right'    : QtCore.Qt.TopRightCorner,
-               'bottom_left'  : QtCore.Qt.BottomLeftCorner,
-               'bottom_right' : QtCore.Qt.BottomRightCorner }
+CORNER_MAP = {
+    'top_left': QtCore.Qt.TopLeftCorner,
+    'top_right': QtCore.Qt.TopRightCorner,
+    'bottom_left': QtCore.Qt.BottomLeftCorner,
+    'bottom_right': QtCore.Qt.BottomRightCorner
+}
 
 
 class TaskWindowBackend(MTaskWindowBackend):
@@ -34,15 +36,15 @@ class TaskWindowBackend(MTaskWindowBackend):
     def create_contents(self, parent):
         """ Create and return the TaskWindow's contents.
         """
-        QtGui.QApplication.instance().focusChanged.connect(
-            self._focus_changed_signal)
+        app = QtGui.QApplication.instance()
+        app.focusChanged.connect(self._focus_changed_signal)
         return QtGui.QStackedWidget(parent)
 
     def destroy(self):
         """ Destroy the backend.
         """
-        QtGui.QApplication.instance().focusChanged.disconnect(
-            self._focus_changed_signal)
+        app = QtGui.QApplication.instance()
+        app.focusChanged.disconnect(self._focus_changed_signal)
         # signal to layout we don't need it any more
         self._main_window_layout.control = None
 
@@ -69,12 +71,6 @@ class TaskWindowBackend(MTaskWindowBackend):
 
         # Show the dock panes.
         self._layout_state(state)
-
-        # OSX-specific: if there is only a single tool bar, it doesn't matter if
-        # the user can drag it around or not. Therefore, we can combine it with
-        # the title bar, which is idiomatic on the Mac.
-        self.control.setUnifiedTitleAndToolBarOnMac(
-            len(state.tool_bar_managers) <= 1)
 
     #### Methods for saving and restoring the layout ##########################
 
@@ -120,8 +116,8 @@ class TaskWindowBackend(MTaskWindowBackend):
         # Add all panes not assigned an area by the TaskLayout.
         for dock_pane in state.dock_panes:
             if dock_pane.control not in self._main_window_layout.consumed:
-                self.control.addDockWidget(AREA_MAP[dock_pane.dock_area],
-                                           dock_pane.control)
+                dock_area = AREA_MAP[dock_pane.dock_area]
+                self.control.addDockWidget(dock_area, dock_pane.control)
                 # By default, these panes are not visible. However, if a pane
                 # has been explicitly set as visible, honor that setting.
                 if dock_pane.visible:
@@ -136,7 +132,7 @@ class TaskWindowBackend(MTaskWindowBackend):
 
     def _focus_changed_signal(self, old, new):
         if self.window.active_task:
-            panes = [ self.window.central_pane ] + self.window.dock_panes
+            panes = [self.window.central_pane] + self.window.dock_panes
             for pane in panes:
                 if new and pane.control.isAncestorOf(new):
                     pane.has_focus = True


### PR DESCRIPTION
This PR does two things:

- adds explicit destruction of statusbar widgets for the Qt backend.
- removes the unification of the toolbar with the titlebar on Mac OS, which was problematic when changing the toolbar.
- adds tests for changing statusbar and toolbar widgets.

Fixes #331 and #329.