### PR TITLE
Fix usage of event_loop() in tests

### DIFF
--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -11,13 +11,14 @@ from ..window import Window
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = AboutDialog()
@@ -31,29 +32,28 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
         parent = Window()
         self.dialog.parent = parent.control
-        parent._create()
-        self.dialog._create()
-        self.event_loop()
+        with self.event_loop():
+            parent._create()
+            self.dialog._create()
 
-        with self.delete_widget(self.dialog.control):
+        with self.event_loop():
             self.dialog.destroy()
-        with self.delete_widget(parent.control):
+        with self.event_loop():
             parent.destroy()
-        self.event_loop()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
@@ -81,8 +81,8 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         parent.open()
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
-        parent.close()
-        self.event_loop()
+        with self.event_loop():
+            parent.close()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)

--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -31,82 +31,81 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         # test that opening and closing works as expected
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_show(self):
         # test that show and hide works as expected
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
 
     def test_activate(self):
         # test that activation works as expected
-        self.window.open()
-        self.event_loop()
-        self.window.activate()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.activate()
+        with self.event_loop():
+            self.window.close()
 
     def test_position(self):
         # test that default position works as expected
         self.window.position = (100, 100)
-        self.window.open()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.close()
 
     def test_reposition(self):
         # test that changing position works as expected
-        self.window.open()
-        self.event_loop()
-        self.window.position = (100, 100)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.position = (100, 100)
+        with self.event_loop():
+            self.window.close()
 
     def test_size(self):
         # test that default size works as expected
         self.window.size = (100, 100)
-        self.window.open()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.close()
 
     def test_resize(self):
         # test that changing size works as expected
         self.window.open()
-        self.event_loop()
-        self.window.size = (100, 100)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.size = (100, 100)
+        with self.event_loop():
+            self.window.close()
 
     def test_title(self):
         # test that default title works as expected
         self.window.title = "Test Title"
-        self.window.open()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.close()
 
     def test_retitle(self):
         # test that changing title works as expected
-        self.window.open()
-        self.event_loop()
-        self.window.title = "Test Title"
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.title = "Test Title"
+        with self.event_loop():
+            self.window.close()
 
     def test_menubar(self):
         # test that menubar gets created as expected
@@ -120,13 +119,14 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
                 name='File',
             )
         )
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
 
     def test_toolbar(self):
         # test that toolbar gets created as expected
@@ -139,13 +139,14 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
                 Action(name="Quit", image=ImageResource('core')),
             )
         ]
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
 
     def test_toolbar_changed(self):
         # test that toolbar gets changed as expected
@@ -158,61 +159,65 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
                 Action(name="Quit", image=ImageResource('core')),
             )
         ]
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.tool_bar_managers = [
-            ToolBarManager(
-                Action(name="New", image=ImageResource('core')),
-                Action(name="Open", image=ImageResource('core')),
-                Action(name="Save", image=ImageResource('core')),
-                Action(name="Close", image=ImageResource('core')),
-                Action(name="Quit", image=ImageResource('core')),
-            )
-        ]
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.tool_bar_managers = [
+                ToolBarManager(
+                    Action(name="New", image=ImageResource('core')),
+                    Action(name="Open", image=ImageResource('core')),
+                    Action(name="Save", image=ImageResource('core')),
+                    Action(name="Close", image=ImageResource('core')),
+                    Action(name="Quit", image=ImageResource('core')),
+                )
+            ]
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
 
     def test_statusbar(self):
         # test that status bar gets created as expected
         self.window.status_bar_manager = StatusBarManager(
             message="hello world",
         )
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
 
     def test_statusbar_changed(self):
         # test that status bar gets changed as expected
         self.window.status_bar_manager = StatusBarManager(
             message="hello world",
         )
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.status_bar_manager = StatusBarManager(
-            message="goodbye world",
-        )
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.status_bar_manager = StatusBarManager(
+                message="goodbye world",
+            )
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
 
     def test_icon(self):
         # test that status bar gets created as expected
         self.window.icon = ImageResource('core')
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -17,7 +17,9 @@ if is_qt:
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 is_pyqt5 = (is_qt and qt_api == 'pyqt5')
@@ -26,7 +28,6 @@ is_pyqt4_linux = (is_qt and qt_api == 'pyqt' and platform.system() == 'Linux')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = ConfirmationDialog()
@@ -40,100 +41,102 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_size(self):
         # test that size works as expected
         self.dialog.size = (100, 100)
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_position(self):
         # test that position works as expected
         self.dialog.position = (100, 100)
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
-        parent = Window()
-        self.dialog.parent = parent.control
-        parent._create()
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        parent.destroy()
-        self.event_loop()
+        with self.event_loop():
+            parent = Window()
+            self.dialog.parent = parent.control
+            parent._create()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
+        with self.event_loop():
+            parent.destroy()
 
     def test_create_yes_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.yes_label = u"Sure"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_no_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.no_label = u"No Way"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_yes_default(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.default = YES
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_cancel(self):
         # test that creation and destruction works with cancel button
         self.dialog.cancel = True
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_cancel_renamed(self):
         # test that creation and destruction works with cancel button
         self.dialog.cancel = True
         self.dialog.cancel_label = "Back"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_cancel_default(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.cancel = True
         self.dialog.default = CANCEL
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_image(self):
         # test that creation and destruction works with a non-standard image
         self.dialog.image = ImageResource('core')
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_close(self):
@@ -141,7 +144,6 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # XXX duplicate of Dialog test, not needed?
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
-        self.event_loop()
 
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
@@ -152,76 +154,100 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.cancel = True
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
-        self.event_loop()
 
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_yes(self):
         # test that Yes works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(YES))
-        self.event_loop()
 
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_yes(self):
         self.dialog.yes_label = u"Sure"
         # test that Yes works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
-        self.event_loop()
 
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_no(self):
         # test that No works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(NO))
-        self.event_loop()
 
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_no(self):
         self.dialog.no_label = u"No way"
         # test that No works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"No way"))
-        self.event_loop()
 
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         self.dialog.cancel = True
         # test that Cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(CANCEL))
-        self.event_loop()
 
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel_renamed(self):
         self.dialog.cancel = True
@@ -229,7 +255,6 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that Cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Back"))
-        self.event_loop()
 
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
@@ -239,11 +264,12 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that lifecycle works with a parent
         parent = Window()
         self.dialog.parent = parent.control
-        parent.open()
+        with self.event_loop():
+            parent.open()
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
-        parent.close()
-        self.event_loop()
+        with self.event_loop():
+            parent.close()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
@@ -251,7 +277,6 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestConfirm(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
 
@@ -261,69 +286,107 @@ class TestConfirm(unittest.TestCase, GuiTestAssistant):
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_reject(self):
         # test that cancel works as expected
-        tester = ModalDialogTester(lambda: confirm(None, "message", cancel=True))
+        tester = ModalDialogTester(
+            lambda: confirm(None, "message", cancel=True)
+        )
         tester.open_and_run(when_opened=lambda x: x.close(accept=False))
-        self.event_loop()
+
         self.assertEqual(tester.result, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_yes(self):
         # test that yes works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(YES))
-        self.event_loop()
+
         self.assertEqual(tester.result, YES)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_no(self):
         # test that yes works as expected
         tester = ModalDialogTester(lambda: confirm(None, "message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(NO))
-        self.event_loop()
+
         self.assertEqual(tester.result, NO)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         # test that cancel works as expected
-        tester = ModalDialogTester(lambda: confirm(None, "message", cancel=True))
+        tester = ModalDialogTester(
+            lambda: confirm(None, "message", cancel=True)
+        )
         tester.open_and_wait(when_opened=lambda x: x.click_button(CANCEL))
-        self.event_loop()
+
         self.assertEqual(tester.result, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_title(self):
         # test that title works as expected
-        tester = ModalDialogTester(lambda: confirm(None, "message",
-                                   title='Title'))
+        tester = ModalDialogTester(
+            lambda: confirm(None, "message", title='Title')
+        )
         tester.open_and_run(when_opened=lambda x: x.click_button(NO))
-        self.event_loop()
+
         self.assertEqual(tester.result, NO)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_default_yes(self):
         # test that default works as expected
-        tester = ModalDialogTester(lambda: confirm(None, "message", default=YES))
+        tester = ModalDialogTester(
+            lambda: confirm(None, "message", default=YES)
+        )
         tester.open_and_run(when_opened=lambda x: x.click_button(YES))
-        self.event_loop()
+
         self.assertEqual(tester.result, YES)
 
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_default_cancel(self):
         # test that default works as expected
-        tester = ModalDialogTester(lambda: confirm(None, "message",
-                                                   cancel=True, default=YES))
+        tester = ModalDialogTester(
+            lambda: confirm(None, "message", cancel=True, default=YES)
+        )
         tester.open_and_run(when_opened=lambda x: x.click_button(CANCEL))
-        self.event_loop()
+
         self.assertEqual(tester.result, CANCEL)

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -8,7 +8,6 @@ from ..dialog import Dialog
 from ..constant import OK, CANCEL
 from ..toolkit import toolkit_object
 
-
 is_qt = toolkit_object.toolkit == 'qt4'
 if is_qt:
     from pyface.qt import qt_api
@@ -16,7 +15,9 @@ if is_qt:
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 is_pyqt5 = (is_qt and qt_api == 'pyqt5')
@@ -25,7 +26,6 @@ is_pyqt4_linux = (is_qt and qt_api == 'pyqt' and platform.system() == 'Linux')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = Dialog()
@@ -39,69 +39,71 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_size(self):
         # test that size works as expected
         self.dialog.size = (100, 100)
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_position(self):
         # test that position works as expected
         self.dialog.position = (100, 100)
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.ok_label = u"Sure"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_cancel_renamed(self):
         # test that creation and destruction works as expected with cancel_label
         self.dialog.cancel_label = u"I Don't Think So"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_help(self):
         # test that creation and destruction works as expected with help
         self.dialog.help_id = "test_help"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_help_label(self):
         # test that creation and destruction works as expected with help
         self.dialog.help_id = "test_help"
         self.dialog.help_label = u"Assistance"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
         # test that accept works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
@@ -110,6 +112,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         # test that reject works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=False))
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
@@ -118,53 +121,85 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         # test that closing works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: self.dialog.close())
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_ok(self):
         # test that OK works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_button(OK))
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_cancel(self):
         # test that cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.click_button(CANCEL))
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_ok(self):
         self.dialog.ok_label = u"Sure"
         # test that OK works as expected if renames
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_cancel(self):
         self.dialog.cancel_label = u"I Don't Think So"
         # test that OK works as expected if renames
         tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_widget(u"I Don't Think So"))
+        tester.open_and_wait(
+            when_opened=lambda x: x.click_widget(u"I Don't Think So")
+        )
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
 
-    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_help(self):
         def click_help_and_close(tester):
@@ -175,11 +210,17 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         # test that OK works as expected if renames
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=click_help_and_close)
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_renamed_help(self):
         def click_help_and_close(tester):
@@ -191,6 +232,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         # test that OK works as expected if renames
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=click_help_and_close)
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
@@ -198,9 +240,10 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         # test that closing works as expected
         self.dialog.style = 'nonmodal'
         result = self.dialog.open()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+
+        with self.event_loop():
+            self.dialog.close()
+
         self.assertEqual(result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
@@ -209,9 +252,10 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
         # XXX use nonmodal for better cross-platform coverage
         self.dialog.style = 'nonmodal'
         self.dialog.resizable = False
-        result = self.dialog.open()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            result = self.dialog.open()
+        with self.event_loop():
+            self.dialog.close()
+
         self.assertEqual(result, OK)
         self.assertEqual(self.dialog.return_code, OK)

--- a/pyface/tests/test_directory_dialog.py
+++ b/pyface/tests/test_directory_dialog.py
@@ -11,13 +11,14 @@ from ..toolkit import toolkit_object
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = DirectoryDialog()
@@ -31,45 +32,45 @@ class TestDirectoryDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_close(self):
         # test that close works
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     def test_default_path(self):
         # test that default path works
         self.dialog.default_path = os.path.join('images', 'core.png')
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     def test_no_new_directory(self):
         # test that block on new directories works
         self.dialog.new_directory = False
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     def test_message(self):
         # test that message setting works
         self.dialog.message = 'Select a directory'
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     #XXX would be nice to actually test with an open dialog, but not right now

--- a/pyface/tests/test_file_dialog.py
+++ b/pyface/tests/test_file_dialog.py
@@ -11,13 +11,14 @@ from ..toolkit import toolkit_object
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestFileDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = FileDialog()
@@ -35,59 +36,60 @@ class TestFileDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create_wildcard_multiple(self):
         wildcard = FileDialog.create_wildcard(
-            'Python', ['*.py', '*.pyo', '*.pyc', '*.pyd'])
+            'Python', ['*.py', '*.pyo', '*.pyc', '*.pyd']
+        )
         self.assertTrue(len(wildcard) != 0)
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_close(self):
         # test that close works
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     def test_default_path(self):
         # test that default path works
         self.dialog.default_path = os.path.join('images', 'core.png')
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     def test_default_dir_and_file(self):
         # test that default dir and path works
         self.dialog.default_directory = 'images'
         self.dialog.default_filename = 'core.png'
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     def test_open_files(self):
         # test that open files action works
         self.dialog.action = 'open files'
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     def test_save_as(self):
         # test that open files action works
         self.dialog.action = 'save as'
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.close()
 
     #XXX would be nice to actually test with an open dialog, but not right now

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -13,7 +13,6 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestHeadingText(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = Window()
@@ -34,32 +33,34 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
 
     def test_lifecycle(self):
         # test that destroy works
-        self.widget = HeadingText(self.window.control)
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = HeadingText(self.window.control)
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_message(self):
         # test that create works with message
-        self.widget = HeadingText(self.window.control, text="Hello")
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = HeadingText(self.window.control, text="Hello")
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_image(self):
         # test that image works
         # XXX this image doesn't make sense here, but that's fine
         # XXX this isn't implemented in qt4 backend, but shouldn't fail
-        self.widget = HeadingText(self.window.control, image=ImageResource('core.png'))
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = HeadingText(
+                self.window.control, image=ImageResource('core.png')
+            )
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_level(self):
         # test that create works with level
         # XXX this image doesn't make sense here, but that's fine
         # XXX this isn't implemented in qt4 backend, but shouldn't fail
-        self.widget = HeadingText(self.window.control, level=2)
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = HeadingText(self.window.control, level=2)
+        with self.event_loop():
+            self.widget.destroy()

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -9,7 +9,6 @@ from ..constant import OK
 from ..toolkit import toolkit_object
 from ..window import Window
 
-
 is_qt = toolkit_object.toolkit == 'qt4'
 if is_qt:
     from pyface.qt import qt_api
@@ -17,7 +16,9 @@ if is_qt:
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 is_pyqt5 = (is_qt and qt_api == 'pyqt5')
@@ -28,7 +29,6 @@ USING_QT = is_qt
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = MessageDialog()
@@ -42,93 +42,93 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_size(self):
         # test that size works as expected
         self.dialog.size = (100, 100)
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_position(self):
         # test that position works as expected
         self.dialog.position = (100, 100)
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
         parent = Window()
         self.dialog.parent = parent.control
-        parent._create()
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        parent.destroy()
-        self.event_loop()
+        with self.event_loop():
+            parent._create()
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
+            parent.destroy()
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
         self.dialog.ok_label = u"Sure"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_message(self):
         # test that creation and destruction works as expected with message
         self.dialog.message = u"This is the message"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_informative(self):
         # test that creation and destruction works with informative
         self.dialog.message = u"This is the message"
         self.dialog.informative = u"This is the additional message"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_detail(self):
         # test that creation and destruction works with detail
         self.dialog.message = u"This is the message"
         self.dialog.informative = u"This is the additional message"
         self.dialog.detail = u"This is the detail"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_warning(self):
         # test that creation and destruction works with warning message
         self.dialog.severity = "warning"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_error(self):
         # test that creation and destruction works with error message
         self.dialog.severity = "error"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_accept(self):
@@ -148,8 +148,13 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Message dialog click tests don't work on pyqt5."
+    )
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Message dialog click tests don't work reliably on linux.  Issue #282."
+    )
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_ok(self):
         # test that OK works as expected
@@ -168,8 +173,13 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 
-    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Message dialog click tests don't work on pyqt5."
+    )
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Message dialog click tests don't work reliably on linux.  Issue #282."
+    )
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
     def test_parent(self):
         # test that lifecycle works with a parent
@@ -178,8 +188,9 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         parent.open()
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
-        parent.close()
-        self.event_loop()
+
+        with self.event_loop():
+            parent.close()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
@@ -188,7 +199,6 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
 class TestMessageDialogHelpers(unittest.TestCase, GuiTestAssistant):
-
     def test_information(self):
         self._check_dialog(information)
 
@@ -215,7 +225,8 @@ class TestMessageDialogHelpers(unittest.TestCase, GuiTestAssistant):
         parent = Window()
         parent.open()
 
-        when_opened = lambda x: x.close(accept=True)
+        def when_opened(x):
+            x.close(accept=True)
 
         tester = ModalDialogTester(helper)
         tester.open_and_wait(when_opened, parent.control, message, **kwargs)

--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -8,13 +8,14 @@ from ..toolkit import toolkit_object
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = ProgressDialog()
@@ -28,48 +29,49 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_can_cancel(self):
         # test that creation works with can_cancel
-        self.dialog.can_cancel =  True
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        self.dialog.can_cancel = True
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_show_time(self):
         # test that creation works with show_time
-        self.dialog.show_time =  True
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        self.dialog.show_time = True
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     @unittest.skip("not implemented in any backend")
     def test_show_percent(self):
         # test that creation works with show_percent
-        self.dialog.show_percent =  True
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        self.dialog.show_percent = True
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_update(self):
         self.dialog.min = 0
         self.dialog.max = 10
         self.dialog.open()
         for i in range(11):
-            result = self.dialog.update(i)
-            self.event_loop()
+            with self.event_loop():
+                result = self.dialog.update(i)
+
             self.assertEqual(result, (True, False))
 
         self.assertIsNone(self.dialog.control)
@@ -78,7 +80,8 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
     def test_update_no_control(self):
         self.dialog.min = 0
         self.dialog.max = 10
-        result = self.dialog.update(1)
+        with self.event_loop():
+            result = self.dialog.update(1)
         self.assertEqual(result, (None, None))
 
     def test_incomplete_update(self):
@@ -87,12 +90,12 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.can_cancel = True
         self.dialog.open()
         for i in range(5):
-            result = self.dialog.update(i)
-            self.event_loop()
+            with self.event_loop():
+                result = self.dialog.update(i)
             self.assertEqual(result, (True, False))
         self.assertIsNotNone(self.dialog.control)
-        self.dialog.close()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.close()
 
         self.assertIsNone(self.dialog.control)
 
@@ -101,9 +104,10 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.max = 10
         self.dialog.open()
         for i in range(11):
-            self.dialog.change_message('Updating {}'.format(i))
-            result = self.dialog.update(i)
-            self.event_loop()
+            with self.event_loop():
+                self.dialog.change_message('Updating {}'.format(i))
+                result = self.dialog.update(i)
+
             self.assertEqual(result, (True, False))
             self.assertEqual(self.dialog.message, 'Updating {}'.format(i))
         self.assertIsNone(self.dialog.control)
@@ -114,8 +118,9 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.show_time = True
         self.dialog.open()
         for i in range(11):
-            result = self.dialog.update(i)
-            self.event_loop()
+            with self.event_loop():
+                result = self.dialog.update(i)
+
             self.assertEqual(result, (True, False))
         self.assertIsNone(self.dialog.control)
 
@@ -124,18 +129,20 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         self.dialog.max = 0
         self.dialog.open()
         for i in range(10):
-            result = self.dialog.update(i)
-            self.event_loop()
+            with self.event_loop():
+                result = self.dialog.update(i)
+
             self.assertEqual(result, (True, False))
-        self.dialog.close()
-        self.event_loop()
+
+        with self.event_loop():
+            self.dialog.close()
         # XXX not really sure what correct behaviour is here
 
     def test_update_negative(self):
         self.dialog.min = 0
         self.dialog.max = -10
         with self.assertRaises(AttributeError):
-            self.dialog.open()
-            self.event_loop()
+            with self.event_loop():
+                self.dialog.open()
 
         self.assertIsNone(self.dialog.control)

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -12,13 +12,13 @@ from ..window import Window
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-
-PYTHON_SCRIPT = os.path.join(os.path.dirname(__file__), 'python_shell_script.py')
+PYTHON_SCRIPT = os.path.join(
+    os.path.dirname(__file__), 'python_shell_script.py'
+)
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = Window()
@@ -37,37 +37,47 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
 
     def test_lifecycle(self):
         # test that destroy works
-        self.widget = PythonEditor(self.window.control)
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonEditor(self.window.control)
+
         self.assertFalse(self.widget.dirty)
-        self.widget.destroy()
-        self.event_loop()
+
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_show_line_numbers(self):
         # test that destroy works
-        self.widget = PythonEditor(self.window.control, show_line_numbers=False)
-        self.event_loop()
-        self.widget.show_line_numbers = True
-        self.event_loop()
-        self.widget.show_line_numbers = False
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonEditor(
+                self.window.control, show_line_numbers=False
+            )
+        with self.event_loop():
+            self.widget.show_line_numbers = True
+        with self.event_loop():
+            self.widget.show_line_numbers = False
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_load(self):
         # test that destroy works
-        self.widget = PythonEditor(self.window.control)
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonEditor(self.window.control)
+
         with self.assertTraitChanges(self.widget, 'changed', count=1):
-            self.widget.path = PYTHON_SCRIPT
+            with self.event_loop():
+                self.widget.path = PYTHON_SCRIPT
         self.assertFalse(self.widget.dirty)
-        self.widget.destroy()
-        self.event_loop()
+
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_select_line(self):
         # test that destroy works
-        self.widget = PythonEditor(self.window.control, path=PYTHON_SCRIPT)
-        self.event_loop()
-        self.widget.select_line(3)
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonEditor(self.window.control, path=PYTHON_SCRIPT)
+
+        with self.event_loop():
+            self.widget.select_line(3)
+
+        with self.event_loop():
+            self.widget.destroy()

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -12,14 +12,13 @@ from ..window import Window
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-
-PYTHON_SCRIPT = os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                'python_shell_script.py'))
+PYTHON_SCRIPT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), 'python_shell_script.py')
+)
 
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestPythonShell(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = Window()
@@ -38,92 +37,110 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
 
     def test_lifecycle(self):
         # test that destroy works
-        self.widget = PythonShell(self.window.control)
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_bind(self):
         # test that binding a variable works
-        self.widget = PythonShell(self.window.control)
-        self.event_loop()
-        self.widget.bind('x', 1)
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
+        with self.event_loop():
+            self.widget.bind('x', 1)
+
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
-        self.widget.destroy()
-        self.event_loop()
+
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_execute_command(self):
         # test that executing a command works
-        self.widget = PythonShell(self.window.control)
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
+
         with self.assertTraitChanges(self.widget, 'command_executed', count=1):
-            self.widget.execute_command('x = 1')
-            self.event_loop()
+            with self.event_loop():
+                self.widget.execute_command('x = 1')
+
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
-        self.widget.destroy()
-        self.event_loop()
+
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_execute_command_not_hidden(self):
         # test that executing a non-hidden command works
-        self.widget = PythonShell(self.window.control)
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
+
         with self.assertTraitChanges(self.widget, 'command_executed', count=1):
-            self.widget.execute_command('x = 1', hidden=False)
-            self.event_loop()
+            with self.event_loop():
+                self.widget.execute_command('x = 1', hidden=False)
+
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
-        self.widget.destroy()
-        self.event_loop()
+
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_execute_file(self):
         # test that executing a file works
-        self.widget = PythonShell(self.window.control)
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
+
         # XXX inconsistent behaviour between backends
         #with self.assertTraitChanges(self.widget, 'command_executed', count=1):
-        self.widget.execute_file(PYTHON_SCRIPT)
-        self.event_loop()
+        with self.event_loop():
+            self.widget.execute_file(PYTHON_SCRIPT)
+
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
         self.assertEqual(self.widget.interpreter().locals.get('sys'), sys)
-        self.widget.destroy()
-        self.event_loop()
+
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_execute_file_not_hidden(self):
         # test that executing a file works
-        self.widget = PythonShell(self.window.control)
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
+
         # XXX inconsistent behaviour between backends
         #with self.assertTraitChanges(self.widget, 'command_executed', count=1):
-        self.widget.execute_file(PYTHON_SCRIPT, hidden=False)
-        self.event_loop()
+        with self.event_loop():
+            self.widget.execute_file(PYTHON_SCRIPT, hidden=False)
+
         self.assertEqual(self.widget.interpreter().locals.get('x'), 1)
         self.assertEqual(self.widget.interpreter().locals.get('sys'), sys)
-        self.widget.destroy()
-        self.event_loop()
+
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_get_history(self):
         # test that executing a command works
-        self.widget = PythonShell(self.window.control)
-        self.event_loop()
-        self.widget.execute_command('x = 1', hidden=False)
-        self.event_loop()
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
+
+        with self.event_loop():
+            self.widget.execute_command('x = 1', hidden=False)
 
         history, history_index = self.widget.get_history()
 
         self.assertEqual(history, ['x = 1'])
         self.assertEqual(history_index, 1)
 
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_set_history(self):
         # test that executing a command works
-        self.widget = PythonShell(self.window.control)
+        with self.event_loop():
+            self.widget = PythonShell(self.window.control)
 
-        self.widget.set_history(['x = 1', 'y = x + 1'], 1)
+        with self.event_loop():
+            self.widget.set_history(['x = 1', 'y = x + 1'], 1)
+
         history, history_index = self.widget.get_history()
-
         self.assertEqual(history, ['x = 1', 'y = x + 1'])
         self.assertEqual(history_index, 1)
 
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget.destroy()

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -28,7 +28,9 @@ from ..window import Window
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')  # noqa: E501
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)  # noqa: E501
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 USING_QT = ETSConfig.toolkit not in ['', 'wx']
@@ -36,7 +38,6 @@ USING_QT = ETSConfig.toolkit not in ['', 'wx']
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = SingleChoiceDialog(choices=['red', 'blue', 'green'])
@@ -50,47 +51,50 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_cancel(self):
         # test that creation and destruction works no cancel button
         self.dialog.cancel = False
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
-        parent = Window()
-        self.dialog.parent = parent.control
-        parent._create()
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        parent.destroy()
-        self.event_loop()
+        with self.event_loop():
+            parent = Window()
+            self.dialog.parent = parent.control
+            parent._create()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
+        with self.event_loop():
+            parent.destroy()
 
     def test_message(self):
         # test that creation and destruction works as expected with message
         self.dialog.message = u"This is the message"
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_choice_strings(self):
         # test that choice strings work using simple strings
-        self.assertEqual(self.dialog._choice_strings(),
-                         ['red', 'blue', 'green'])
+        self.assertEqual(
+            self.dialog._choice_strings(), ['red', 'blue', 'green']
+        )
 
     def test_choice_strings_convert(self):
         # test that choice strings work using simple strings
@@ -103,11 +107,11 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
             def __init__(self, description):
                 self.description = description
 
-        self.dialog.choices = [Item(name)
-                               for name in ['red', 'blue', 'green']]
+        self.dialog.choices = [Item(name) for name in ['red', 'blue', 'green']]
         self.dialog.name_attribute = 'description'
-        self.assertEqual(self.dialog._choice_strings(),
-                         ['red', 'blue', 'green'])
+        self.assertEqual(
+            self.dialog._choice_strings(), ['red', 'blue', 'green']
+        )
 
     def test_choice_strings_name_attribute_convert(self):
         # test that choice strings work using attribute name of objects
@@ -145,6 +149,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         # test that accept works as expected
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=False))
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
         self.assertIsNone(self.dialog.choice)
@@ -169,8 +174,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
         parent.open()
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
-        parent.close()
-        self.event_loop()
+        with self.event_loop():
+            parent.close()
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
@@ -185,6 +190,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=select_green_and_ok)
+
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
         self.assertEqual(self.dialog.choice, 'green')
@@ -199,6 +205,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=select_green_and_cancel)
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
         self.assertIsNone(self.dialog.choice)
@@ -213,6 +220,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_run(when_opened=select_green_and_close)
+
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)
         self.assertIsNone(self.dialog.choice)

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -13,7 +13,6 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestWindow(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = SplashScreen()
@@ -28,53 +27,56 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.window.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.window.destroy()
 
     def test_open_close(self):
         # test that opening and closing works as expected
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_show(self):
         # test that show works as expected
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.destroy()
 
     def test_image(self):
         # test that images work
         self.window.image = ImageResource('core')
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_text(self):
         # test that images work
         self.window.text = "Splash screen"
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_text_changed(self):
         # test that images work
@@ -82,11 +84,13 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         #     - probably the way the test is written.
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
-        self.window.text = "Splash screen"
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
+        with self.event_loop():
+            self.window.text = "Splash screen"
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()

--- a/pyface/tests/test_split_application_window.py
+++ b/pyface/tests/test_split_application_window.py
@@ -12,7 +12,6 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = SplitApplicationWindow()
@@ -26,30 +25,33 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.window.destroy()
+        with self.event_loop():
+            self.window.destroy()
 
     def test_open_close(self):
         # test that opening and closing works as expected
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_horizontal_split(self):
         # test that horizontal split works
         self.window.direction = 'horizontal'
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_contents(self):
         # test that contents works
@@ -57,21 +59,23 @@ class TestSplitApplicationWindow(unittest.TestCase, GuiTestAssistant):
         self.window.rhs = HeadingText
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_ratio(self):
         # test that ratio split works
         self.window.ratio = 0.25
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()

--- a/pyface/tests/test_split_dialog.py
+++ b/pyface/tests/test_split_dialog.py
@@ -12,7 +12,6 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestDialog(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.dialog = SplitDialog()
@@ -26,37 +25,37 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create(self):
         # test that creation and destruction works as expected
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_horizontal(self):
         # test that horizontal split works
         self.dialog.direction = 'horizontal'
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_ratio(self):
         # test that ratio works
         self.dialog.ratio = 0.25
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
 
     def test_contents(self):
         # test that contents works
         self.dialog.lhs = HeadingText
         self.dialog.rhs = HeadingText
-        self.dialog._create()
-        self.event_loop()
-        self.dialog.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -13,7 +13,6 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestHeadingText(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = Window()
@@ -34,29 +33,32 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
 
     def test_lifecycle(self):
         # test that destroy works
-        self.widget = SplitPanel(self.window.control)
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = SplitPanel(self.window.control)
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_horizontal(self):
         # test that horizontal split works
-        self.widget = SplitPanel(self.window.control, direction='horizontal')
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = SplitPanel(
+                self.window.control, direction='horizontal'
+            )
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_ratio(self):
         # test that ratio works
-        self.widget = SplitPanel(self.window.control, ratio=0.25)
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = SplitPanel(self.window.control, ratio=0.25)
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_contents(self):
         # test that contents works
-        self.widget = SplitPanel(self.window.control, lhs=HeadingText,
-                                 rhs=HeadingText)
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget = SplitPanel(
+                self.window.control, lhs=HeadingText, rhs=HeadingText
+            )
+        with self.event_loop():
+            self.widget.destroy()

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -10,7 +10,6 @@ no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
 
 class ConcreteWidget(Widget):
-
     def _create_control(self, parent):
         if toolkit_object.toolkit == 'wx':
             import wx
@@ -28,7 +27,6 @@ class ConcreteWidget(Widget):
 
 
 class TestWidget(unittest.TestCase, UnittestTools):
-
     def setUp(self):
         self.widget = Widget()
 
@@ -75,7 +73,6 @@ class TestWidget(unittest.TestCase, UnittestTools):
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.widget = ConcreteWidget()
@@ -88,56 +85,56 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
         GuiTestAssistant.tearDown(self)
 
     def test_lifecycle(self):
-        self.widget._create()
-        self.event_loop()
-        self.widget.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.widget._create()
+        with self.event_loop():
+            self.widget.destroy()
 
     def test_initialize(self):
         self.widget.visible = False
         self.widget.enabled = False
-        self.widget._create()
-        self.event_loop()
+        with self.event_loop():
+            self.widget._create()
 
         self.assertFalse(self.widget.control.isVisible())
         self.assertFalse(self.widget.control.isEnabled())
 
     def test_show(self):
-        self.widget._create()
-        self.event_loop()
+        with self.event_loop():
+            self.widget._create()
 
         with self.assertTraitChanges(self.widget, 'visible', count=1):
-            self.widget.show(False)
-            self.event_loop()
+            with self.event_loop():
+                self.widget.show(False)
 
         self.assertFalse(self.widget.control.isVisible())
 
     def test_visible(self):
-        self.widget._create()
-        self.event_loop()
+        with self.event_loop():
+            self.widget._create()
 
         with self.assertTraitChanges(self.widget, 'visible', count=1):
-            self.widget.visible = False
-            self.event_loop()
+            with self.event_loop():
+                self.widget.visible = False
 
         self.assertFalse(self.widget.control.isVisible())
 
     def test_enable(self):
-        self.widget._create()
-        self.event_loop()
+        with self.event_loop():
+            self.widget._create()
 
         with self.assertTraitChanges(self.widget, 'enabled', count=1):
-            self.widget.enable(False)
-            self.event_loop()
+            with self.event_loop():
+                self.widget.enable(False)
 
         self.assertFalse(self.widget.control.isEnabled())
 
     def test_enabled(self):
-        self.widget._create()
-        self.event_loop()
+        with self.event_loop():
+            self.widget._create()
 
         with self.assertTraitChanges(self.widget, 'enabled', count=1):
-            self.widget.enabled = False
-            self.event_loop()
+            with self.event_loop():
+                self.widget.enabled = False
 
         self.assertFalse(self.widget.control.isEnabled())

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -8,7 +8,6 @@ from ..constant import CANCEL, NO, OK, YES
 from ..toolkit import toolkit_object
 from ..window import Window
 
-
 is_qt = toolkit_object.toolkit == 'qt4'
 if is_qt:
     from pyface.qt import qt_api
@@ -16,7 +15,9 @@ if is_qt:
 GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
 no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
 
-ModalDialogTester = toolkit_object('util.modal_dialog_tester:ModalDialogTester')
+ModalDialogTester = toolkit_object(
+    'util.modal_dialog_tester:ModalDialogTester'
+)
 no_modal_dialog_tester = (ModalDialogTester.__name__ == 'Unimplemented')
 
 is_pyqt5 = (is_qt and qt_api == 'pyqt5')
@@ -25,7 +26,6 @@ is_pyqt4_linux = (is_qt and qt_api == 'pyqt' and platform.system() == 'Linux')
 
 @unittest.skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
 class TestWindow(unittest.TestCase, GuiTestAssistant):
-
     def setUp(self):
         GuiTestAssistant.setUp(self)
         self.window = Window()
@@ -39,108 +39,111 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
 
     def test_destroy(self):
         # test that destroy works even when no control
-        self.window.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.window.destroy()
 
     def test_open_close(self):
         # test that opening and closing works as expected
         with self.assertTraitChanges(self.window, 'opening', count=1):
             with self.assertTraitChanges(self.window, 'opened', count=1):
-                self.window.open()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.open()
+
         with self.assertTraitChanges(self.window, 'closing', count=1):
             with self.assertTraitChanges(self.window, 'closed', count=1):
-                self.window.close()
-        self.event_loop()
+                with self.event_loop():
+                    self.window.close()
 
     def test_show(self):
         # test that showing works as expected
-        self.window._create()
-        self.window.show(True)
-        self.event_loop()
-        self.window.show(False)
-        self.event_loop()
-        self.window.destroy()
-        self.event_loop()
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.destroy()
 
     def test_activate(self):
         # test that activation works as expected
-        self.window.open()
-        self.event_loop()
-        self.window.activate()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.activate()
+        with self.event_loop():
+            self.window.close()
 
     def test_position(self):
         # test that default position works as expected
         self.window.position = (100, 100)
-        self.window.open()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.close()
 
     def test_reposition(self):
         # test that changing position works as expected
-        self.window.open()
-        self.event_loop()
-        self.window.position = (100, 100)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.position = (100, 100)
+        with self.event_loop():
+            self.window.close()
 
     def test_size(self):
         # test that default size works as expected
         self.window.size = (100, 100)
-        self.window.open()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.close()
 
     def test_resize(self):
         # test that changing size works as expected
-        self.window.open()
-        self.event_loop()
-        self.window.size = (100, 100)
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.size = (100, 100)
+        with self.event_loop():
+            self.window.close()
 
     def test_title(self):
         # test that default title works as expected
         self.window.title = "Test Title"
-        self.window.open()
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.close()
 
     def test_retitle(self):
         # test that changing title works as expected
-        self.window.open()
-        self.event_loop()
-        self.window.title = "Test Title"
-        self.event_loop()
-        self.window.close()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.title = "Test Title"
+        with self.event_loop():
+            self.window.close()
 
     def test_show_event(self):
-        self.window.open()
-        self.window.visible = False
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
+        with self.event_loop():
+            self.window.visible = False
 
         with self.assertTraitChanges(self.window, 'visible', count=1):
-            self.window.control.show()
-            self.event_loop()
+            with self.event_loop():
+                self.window.control.show()
 
         self.assertTrue(self.window.visible)
 
     def test_hide_event(self):
-        self.window.open()
-        self.event_loop()
+        with self.event_loop():
+            self.window.open()
 
         with self.assertTraitChanges(self.window, 'visible', count=1):
-            self.window.control.hide()
-            self.event_loop()
+            with self.event_loop():
+                self.window.control.hide()
 
         self.assertFalse(self.window.visible)
 
@@ -148,39 +151,57 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
     def test_confirm_reject(self):
         # test that cancel works as expected
         tester = ModalDialogTester(
-            lambda: self.window.confirm("message", cancel=True))
+            lambda: self.window.confirm("message", cancel=True)
+        )
         tester.open_and_run(when_opened=lambda x: x.close(accept=False))
+
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     def test_confirm_yes(self):
         # test that yes works as expected
         tester = ModalDialogTester(lambda: self.window.confirm("message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(YES))
-        self.event_loop()
+
         self.assertEqual(tester.result, YES)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     def test_confirm_no(self):
         # test that no works as expected
         tester = ModalDialogTester(lambda: self.window.confirm("message"))
         tester.open_and_wait(when_opened=lambda x: x.click_button(NO))
-        self.event_loop()
+
         self.assertEqual(tester.result, NO)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Confirmation dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Confirmation dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Confirmation dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Confirmation dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     def test_confirm_cancel(self):
         # test that cncel works as expected
         tester = ModalDialogTester(
-            lambda: self.window.confirm("message", cancel=True))
+            lambda: self.window.confirm("message", cancel=True)
+        )
         tester.open_and_wait(when_opened=lambda x: x.click_button(CANCEL))
-        self.event_loop()
+
         self.assertEqual(tester.result, CANCEL)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
@@ -188,8 +209,13 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.information)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Message dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Message dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     def test_information_ok(self):
         self._check_message_dialog_ok(self.window.information)
 
@@ -198,8 +224,13 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.warning)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Message dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Message dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     def test_warning_ok(self):
         self._check_message_dialog_ok(self.window.warning)
 
@@ -208,19 +239,26 @@ class TestWindow(unittest.TestCase, GuiTestAssistant):
         self._check_message_dialog_accept(self.window.error)
 
     @unittest.skipIf(no_modal_dialog_tester, 'ModalDialogTester unavailable')
-    @unittest.skipIf(is_pyqt5, "Message dialog click tests don't work on pyqt5.")  # noqa
-    @unittest.skipIf(is_pyqt4_linux, "Message dialog click tests don't work reliably on linux.  Issue #282.")  # noqa
+    @unittest.skipIf(
+        is_pyqt5, "Message dialog click tests don't work on pyqt5."
+    )  # noqa
+    @unittest.skipIf(
+        is_pyqt4_linux,
+        "Message dialog click tests don't work reliably on linux.  Issue #282."
+    )  # noqa
     def test_error_ok(self):
         self._check_message_dialog_ok(self.window.error)
 
     def _check_message_dialog_ok(self, method):
         tester = self._setup_tester(method)
         tester.open_and_wait(when_opened=lambda x: x.click_button(OK))
+
         self.assertIsNone(tester.result)
 
     def _check_message_dialog_accept(self, method):
         tester = self._setup_tester(method)
         tester.open_and_run(when_opened=lambda x: x.close(accept=True))
+
         self.assertIsNone(tester.result)
 
     def _setup_tester(self, method):


### PR DESCRIPTION
Should have been being used as a context manager, rather than as straight call.  Hopefully this may lead to better testing results in some environments.