### PR TITLE
Make sure selected QtAPI actually provides QT support

### DIFF
--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -61,7 +61,7 @@ else:
 if qt_api is None:
     for api_name, module in QtAPIs:
         try:
-            importlib.import_module(module)
+            importlib.import_module('.QtCore', module)
             qt_api = api_name
             break
         except ImportError:


### PR DESCRIPTION
Maybe related issues: enthought/mayavi#448, enthought/mayavi#460, enthought/mayavi#483

PyFace might select PyQt5 as the default API if it is installed even if Qt5 itself is missing.
This PR fix such an issue by ensuring that at least `QtCore` can be imported from the being-selected API, otherwise try the next one.