### PR TITLE
Better handling of Qt API imports

### DIFF
--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -12,7 +12,6 @@
 import importlib
 import os
 import sys
-import warnings
 
 QtAPIs = [
     ('pyside', 'PySide'),

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -12,6 +12,7 @@
 import importlib
 import os
 import sys
+import warnings
 
 QtAPIs = [
     ('pyside', 'PySide'),
@@ -61,6 +62,7 @@ else:
 if qt_api is None:
     for api_name, module in QtAPIs:
         try:
+            importlib.import_module(module)
             importlib.import_module('.QtCore', module)
             qt_api = api_name
             break


### PR DESCRIPTION
Python 3.5 (and maybe 3.6) requires that the Qt API package `module` be explicitly imported.

Fixes #346.