### PR TITLE
FIX: Fix deprecation warnings

### DIFF
--- a/pyface/i_clipboard.py
+++ b/pyface/i_clipboard.py
@@ -14,7 +14,10 @@
 
 """ The interface for manipulating the toolkit clipboard.
 """
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:  # Python 3.8 deprecation
+    from collections import Sequence
 
 # ETS imports
 from traits.api import HasStrictTraits, Interface, Property

--- a/pyface/i_image_resource.py
+++ b/pyface/i_image_resource.py
@@ -10,7 +10,10 @@
 #------------------------------------------------------------------------------
 """ The interface for an image resource. """
 
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:  # Python 3.8 deprecation
+    from collections import Sequence
 
 from pyface.resource_manager import resource_manager
 from pyface.resource.resource_path import resource_module, resource_path

--- a/pyface/workbench/__init__.py
+++ b/pyface/workbench/__init__.py
@@ -4,5 +4,5 @@ warnings.warn(
     PendingDeprecationWarning(
         "Workbench will be moved from pyface.workbench to apptools.workbench "
         "in Pyface 7.0.0"
-    )
+    ), stacklevel=2
 )


### PR DESCRIPTION
Fixes warnings of this type:
```
  /home/larsoner/python/pyface/build/lib/pyface/i_clipboard.py:17: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
And also fixes the `stacklevel` in an internal `PendingDeprecationWarning`.