### PR TITLE
BUG: Only display context menu when mouse is not on page.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -814,10 +814,15 @@ class DraggableTabWidget(QtGui.QTabWidget):
     def contextMenuEvent(self, event):
         """ To show collapse context menu even on empty tabwidgets
         """
-        global_pos = self.mapToGlobal(event.pos())
-        menu = self.editor_area.get_context_menu(pos=global_pos)
-        qmenu = menu.create_menu(self)
-        qmenu.exec_(global_pos)
+        local_pos = event.pos()
+        if (self.empty_widget is not None or
+                self.tabBar().rect().contains(local_pos)):
+            # Only display if we are in the tab bar region or the whole area if
+            # we are displaying the default empty widget.
+            global_pos = self.mapToGlobal(local_pos)
+            menu = self.editor_area.get_context_menu(pos=global_pos)
+            qmenu = menu.create_menu(self)
+            qmenu.exec_(global_pos)
 
     def dragEnterEvent(self, event):
         """ Re-implemented to highlight the tabwidget on drag enter


### PR DESCRIPTION
In the `SplitEditorAreaPane`, a right click will bring up a context menu asking if you want to split the pane. When a tab is displaying a Chaco plot, a right click on the Chaco plot will interrupt still bring up that context menu. It is the case that Enable/Chaco is not `accept()`ing the Qt `QMouseEvent`s when it handles them as it should, but even when I fix that, I still get these context menus. I am not sure what's going with that.

In this PR, I only allow the context menu when it's the default empty page being displayed (e.g. in a fresh pane split) or when the mouse is in the tab bar, which is where I would expect to have pane-related actions to be available.

I invite feedback if this change in the user experience is acceptable to your applications.