### PR TITLE
Allow traits UI-based dispatch even when TraitsUI not available

### DIFF
--- a/pyface/ui/qt4/gui.py
+++ b/pyface/ui/qt4/gui.py
@@ -159,8 +159,10 @@ class _FutureCall(QtCore.QObject):
 
         # Save the instance.
         self._calls_mutex.lock()
-        self._calls.append(self)
-        self._calls_mutex.unlock()
+        try:
+            self._calls.append(self)
+        finally:
+            self._calls_mutex.unlock()
 
         # Move to the main GUI thread.
         self.moveToThread(QtGui.QApplication.instance().thread())
@@ -175,8 +177,18 @@ class _FutureCall(QtCore.QObject):
         """ QObject event handler.
         """
         if event.type() == self._pyface_event:
-            # Invoke the callable (puts it at the end of the event queue)
-            QtCore.QTimer.singleShot(self._ms, self._dispatch)
+            if self._ms == 0:
+                # Invoke the callable now
+                try:
+                    self._callable(*self._args, **self._kw)
+                finally:
+                    # We cannot remove from self._calls here. QObjects don't like being
+                    # garbage collected during event handlers (there are tracebacks,
+                    # plus maybe a memory leak, I think).
+                    QtCore.QTimer.singleShot(0, self._finished)
+            else:
+                # Invoke the callable (puts it at the end of the event queue)
+                QtCore.QTimer.singleShot(self._ms, self._dispatch)
             return True
 
         return super(_FutureCall, self).event(event)
@@ -197,5 +209,3 @@ class _FutureCall(QtCore.QObject):
             self._calls.remove(self)
         finally:
             self._calls_mutex.unlock()
-
-#### EOF ######################################################################

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -15,8 +15,11 @@
 
 import sys
 
+from traits.trait_notifiers import set_ui_handler, ui_handler
+
 from pyface.qt import QtCore, QtGui, qt_api
 from pyface.base_toolkit import Toolkit
+from .gui import GUI
 
 if qt_api == 'pyqt':
     # Check the version numbers are late enough.
@@ -39,3 +42,9 @@ if _app is None:
 
 # create the toolkit object
 toolkit_object = Toolkit('pyface', 'qt4', 'pyface.ui.qt4')
+
+
+# ensure that Traits has a UI handler appropriate for the toolkit.
+if ui_handler is None:
+    # Tell the traits notification handlers to use this UI handler
+    set_ui_handler(GUI.invoke_later)

--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -13,7 +13,10 @@
 
 import wx
 
+from traits.trait_notifiers import set_ui_handler, ui_handler
+
 from pyface.base_toolkit import Toolkit
+from .gui import GUI
 
 
 # Check the version number is late enough.
@@ -37,3 +40,9 @@ wx.Log.SetActiveTarget(_log)
 
 # create the toolkit object
 toolkit_object = Toolkit('pyface', 'wx', 'pyface.ui.wx')
+
+
+# ensure that Traits has a UI handler appropriate for the toolkit.
+if ui_handler is None:
+    # Tell the traits notification handlers to use this UI handler
+    set_ui_handler(GUI.invoke_later)


### PR DESCRIPTION
This checks to see if there is a ui dispatcher available for Traits when initializing the Pyface toolkit, and if not sets one.

This PR also includes a change that makes `_FutureCall` behave more like the TraitsUI `_CallAfter` for the `qt` toolkit when there is no delay for the callback.  This will potentially allow `_CallAfter` to be removed from TraitsUI in the future.

Fixes #362 