### PR TITLE
Fix TraitsUI dependency of GuiTestAssistant

### DIFF
--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -11,7 +11,11 @@ import contextlib
 import gc
 import threading
 
-from six.moves import mock
+import six
+if six.PY2:
+    import mock
+else:
+    import unittest.mock as mock
 
 from pyface.qt.QtGui import QApplication
 from pyface.ui.qt4.gui import GUI

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -37,9 +37,14 @@ class GuiTestAssistant(UnittestTools):
             qt_app=self.qt_app,
             gui=self.gui
         )
-        self.traitsui_raise_patch = mock.patch(
-            'traitsui.qt4.ui_base._StickyDialog.raise_')
-        self.traitsui_raise_patch.start()
+        try:
+            import traitsui.api
+        except ImportError:
+            self.traitsui_raise_patch = None
+        else:
+            self.traitsui_raise_patch = mock.patch(
+                'traitsui.qt4.ui_base._StickyDialog.raise_')
+            self.traitsui_raise_patch.start()
 
         def new_activate(self):
             self.control.activateWindow()
@@ -68,7 +73,8 @@ class GuiTestAssistant(UnittestTools):
 
         self.qt_app.flush()
         self.pyface_raise_patch.stop()
-        self.traitsui_raise_patch.stop()
+        if self.traitsui_raise_patch is not None:
+            self.traitsui_raise_patch.stop()
 
         del self.pyface_raise_patch
         del self.traitsui_raise_patch

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -11,7 +11,7 @@ import contextlib
 import gc
 import threading
 
-import mock
+from six.moves import mock
 
 from pyface.qt.QtGui import QApplication
 from pyface.ui.qt4.gui import GUI


### PR DESCRIPTION
Checks to see if traitsui is available before patching StickyDialog.

Fixes #341 and fixes #353.