### PR TITLE
Fix bad dev version number when installing from non-Git clone.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,13 +91,13 @@ if not is_released:
         try:
             data = read_module('_version')
             git_rev = data['git_revision']
-            fullversion = data['full_version']
+            fullversion_source = data['full_version']
         except ImportError:
             raise ImportError("Unable to read git_revision. Try removing "
                               "pyface/_version.py and the build directory "
                               "before building.")
 
-        match = re.match(r'.*?\.dev(?P<dev_num>\d+)', fullversion)
+        match = re.match(r'.*?\.dev(?P<dev_num>\d+)', fullversion_source)
         if match is None:
             dev_num = '0'
         else:


### PR DESCRIPTION
When installing a non-released PyFace from source rather than a Git clone, we end up with an invalid version number ending with `.dev0.dev0`. This PR fixes that.


```
mirzakhani:Desktop mdickinson$ edm env create test --force
Removing environment: test
Fetching indices for runtime repositories. done
Installing runtime... done
Fetching indices for package repositories....... done
Installing/removing package(s)
setuptools        [..........................................................................................................................................................................]
mirzakhani:Desktop mdickinson$ git clone git@github.com:enthought/pyface.git
Cloning into 'pyface'...
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Compressing objects: 100% (3/3), done.
remote: Total 27531 (delta 0), reused 1 (delta 0), pack-reused 27528
Receiving objects: 100% (27531/27531), 15.76 MiB | 8.73 MiB/s, done.
Resolving deltas: 100% (15457/15457), done.
mirzakhani:Desktop mdickinson$ rm -fr pyface/.git
mirzakhani:Desktop mdickinson$ edm run -e test -- pip install pyface/
Processing ./pyface
Collecting traits (from pyface==6.1.0.dev0)
  Using cached https://files.pythonhosted.org/packages/81/80/2b5bb0036bbd05b971546b0d3a942b97896122681d4c657edb12d299d891/traits-5.1.1.tar.gz
Requirement already satisfied: six in /Users/mdickinson/.edm/envs/test/lib/python2.7/site-packages (from traits->pyface==6.1.0.dev0) (1.11.0)
Installing collected packages: traits, pyface
  Running setup.py install for traits ... done
  Running setup.py install for pyface ... done
Successfully installed pyface-6.1.0.dev0.dev0 traits-5.1.1
```



