### PR TITLE
Don't compare integers using 'is'

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -58,7 +58,7 @@ the following to generate a platform-independent file dialog::
         """ Ask the user for a Python file to open """
         dialog = FileDialog(action='open', wildcard=FileDialog.WILDCARD_PY)
         result = dialog.open()
-        if result is OK:
+        if result == OK:
             return dialog.path
         else:
             return None


### PR DESCRIPTION
Nitpick: don't promote the antipattern of comparing integers using `is` rather than `==`. In this case it's harmless, but there's potential for the pattern to be copied elsewhere. Simpler to go for a blanket rule that integers should always be compared with `==`.