### PR TITLE
FIX wx backend local import

### DIFF
--- a/pyface/dock/api.py
+++ b/pyface/dock/api.py
@@ -28,26 +28,18 @@
 #  Imports:
 #-------------------------------------------------------------------------------
 
-from dock_window \
-    import DockWindow, DockWindowHandler
+from .dock_window import DockWindow, DockWindowHandler
 
-from dock_sizer \
-    import DockSizer, DockSection, DockRegion, DockControl, DockStyle, \
-           DOCK_LEFT, DOCK_RIGHT, DOCK_TOP, DOCK_BOTTOM, SetStructureHandler, \
-           add_feature, DockGroup
+from .dock_sizer import DockSizer, DockSection, DockRegion, DockControl, \
+    DockStyle, DOCK_LEFT, DOCK_RIGHT, DOCK_TOP, DOCK_BOTTOM, \
+    SetStructureHandler, add_feature, DockGroup
 
-from idockable \
-    import IDockable
+from .idockable import IDockable
 
-from idock_ui_provider \
-    import IDockUIProvider
+from .idock_ui_provider import IDockUIProvider
 
-from ifeature_tool \
-    import IFeatureTool
+from .ifeature_tool import IFeatureTool
 
-from dock_window_shell \
-    import DockWindowShell
+from .dock_window_shell import DockWindowShell
 
-from dock_window_feature \
-    import DockWindowFeature
-
+from .dock_window_feature import DockWindowFeature

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -29,33 +29,19 @@
 from __future__ import print_function
 import wx, sys
 
-from traits.api \
-    import HasPrivateTraits, Instance, Str, Int, List, Enum, Tuple, Any, \
-           Range, Property, Callable, Constant, Event, Undefined, Bool, \
-           cached_property
-
-from traitsui.dock_window_theme \
-    import dock_window_theme
-
-from traitsui.wx.helper \
-    import BufferDC
+from traits.api import HasPrivateTraits, Instance, Str, Int, List, Enum, \
+    Tuple, Any, Range, Property, Callable, Constant, Event, Undefined, Bool, \
+    cached_property
+from traitsui.dock_window_theme import dock_window_theme
+from traitsui.wx.helper import BufferDC
 
 from pyface.api import SystemMetrics
+from pyface.image_resource import ImageResource
+from pyface.wx.drag_and_drop import PythonDropSource
+from pyface.timer.api import do_later, do_after
+from .idockable import IDockable
+from .ifeature_tool import IFeatureTool
 
-from pyface.image_resource \
-    import ImageResource
-
-from pyface.wx.drag_and_drop \
-    import PythonDropSource
-
-from pyface.timer.api \
-    import do_later, do_after
-
-from idockable \
-    import IDockable
-
-from ifeature_tool \
-    import IFeatureTool
 
 # Define version dependent values:
 wx_26  = (wx.__version__[:3] == '2.6')

--- a/pyface/dock/dock_window.py
+++ b/pyface/dock/dock_window.py
@@ -62,15 +62,10 @@ from pyface.wx.drag_and_drop \
 from pyface.message_dialog \
     import error as warning
 
-from dock_sizer \
-    import DockSizer, DockControl, DockRegion, DockStyle, DockSplitter, \
-           no_dock_info, clear_window, features
-
-from idockable \
-    import IDockable
-
-from idock_ui_provider \
-    import IDockUIProvider
+from .dock_sizer import DockSizer, DockControl, DockRegion, DockStyle, \
+    DockSplitter, no_dock_info, clear_window, features
+from .idockable import IDockable
+from .idock_ui_provider import IDockUIProvider
 
 is_mac = (sys.platform == 'darwin')
 

--- a/pyface/dock/dock_window_feature.py
+++ b/pyface/dock/dock_window_feature.py
@@ -31,29 +31,16 @@
 #  Imports:
 #-------------------------------------------------------------------------------
 
-from weakref \
-    import ref
+from weakref import ref
 
-from traits.api \
-    import HasPrivateTraits, Instance, Int, Str, Bool, Property
+from traits.api import HasPrivateTraits, Instance, Int, Str, Bool, Property
+from traitsui.menu import Menu, Action
 
-from traitsui.menu \
-    import Menu, Action
-
-from pyface.timer.api \
-    import do_later
-
-from pyface.image_resource \
-    import ImageResource
-
-from dock_window \
-    import DockWindow
-
-from dock_sizer \
-    import DockControl, add_feature
-
-from ifeature_tool \
-    import IFeatureTool
+from pyface.timer.api import do_later
+from pyface.image_resource import ImageResource
+from .dock_window import DockWindow
+from .dock_sizer import DockControl, add_feature
+from .ifeature_tool import IFeatureTool
 
 #-------------------------------------------------------------------------------
 #  'DockWindowFeature' class:

--- a/pyface/dock/dock_window_shell.py
+++ b/pyface/dock/dock_window_shell.py
@@ -27,23 +27,14 @@ import wx
 
 # Fixme: Hack to force 'image_slice' to be added via Category to Theme class:
 import traitsui.wx
-
-from traits.api \
-    import HasPrivateTraits, Instance
-
-from traitsui.api \
-    import View, Group
+from traits.api import HasPrivateTraits, Instance
+from traitsui.api import View, Group
 
 from pyface.api import SystemMetrics
-
-from pyface.image_resource \
-    import ImageResource
-
-from dock_window \
-    import DockWindow
-
-from dock_sizer \
-    import DockSizer, DockSection, DockRegion, DockControl, DOCK_RIGHT
+from pyface.image_resource import ImageResource
+from .dock_window import DockWindow
+from .dock_sizer import DockSizer, DockSection, DockRegion, DockControl, \
+    DOCK_RIGHT
 
 #-------------------------------------------------------------------------------
 #  Constants:

--- a/pyface/dock/feature_bar.py
+++ b/pyface/dock/feature_bar.py
@@ -27,17 +27,11 @@
 
 import wx
 
-from traits.api \
-    import HasPrivateTraits, Instance, Bool, Event, Color
+from traits.api import HasPrivateTraits, Instance, Bool, Event, Color
 
-from pyface.wx.drag_and_drop \
-    import PythonDropTarget, PythonDropSource
-
-from dock_sizer \
-    import DockControl, FEATURE_EXTERNAL_DRAG
-
-from ifeature_tool \
-    import IFeatureTool
+from pyface.wx.drag_and_drop import PythonDropTarget, PythonDropSource
+from .dock_sizer import DockControl, FEATURE_EXTERNAL_DRAG
+from .ifeature_tool import IFeatureTool
 
 #-------------------------------------------------------------------------------
 #  'FeatureBar' class:

--- a/pyface/dock/feature_tool.py
+++ b/pyface/dock/feature_tool.py
@@ -24,11 +24,8 @@
 #  Imports:
 #-------------------------------------------------------------------------------
 
-from dock_window_feature \
-    import DockWindowFeature
-
-from pyface.image_resource \
-    import ImageResource
+from pyface.image_resource import ImageResource
+from .dock_window_feature import DockWindowFeature
 
 #-------------------------------------------------------------------------------
 #  'FeatureTool' class:

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -34,7 +34,6 @@ from pyface.image_resource import ImageResource
 
 # Local imports.
 from .window import Window
-from .system_metrics import SystemMetrics
 
 
 @provides(IApplicationWindow)

--- a/pyface/ui/wx/window.py
+++ b/pyface/ui/wx/window.py
@@ -19,7 +19,7 @@ from traits.api import Event, Property, Tuple, Unicode, VetoableEvent, provides
 # Local imports.
 from pyface.i_window import IWindow, MWindow
 from pyface.key_pressed_event import KeyPressedEvent
-from system_metrics import SystemMetrics
+from pyface.system_metrics import SystemMetrics
 from .widget import Widget
 
 

--- a/pyface/ui/wx/window.py
+++ b/pyface/ui/wx/window.py
@@ -19,7 +19,7 @@ from traits.api import Event, Property, Tuple, Unicode, VetoableEvent, provides
 # Local imports.
 from pyface.i_window import IWindow, MWindow
 from pyface.key_pressed_event import KeyPressedEvent
-from pyface.system_metrics import SystemMetrics
+from .system_metrics import SystemMetrics
 from .widget import Widget
 
 


### PR DESCRIPTION
`6.1.0` seems to have a couple of broken imports, e.g.

```
In [1]: from pyface.action import api                                                                         
2019-05-28 08:58:43.581 python[83375:7529411] ApplePersistenceIgnoreState: Existing state will not be touched. New state will be written to (null)
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
<ipython-input-2-06b3548f7385> in <module>
----> 1 from pyface.action import api

~/Code/pyface/pyface/action/api.py in <module>
     28 from .tool_bar_manager import ToolBarManager
     29 from .traitsui_widget_action import TraitsUIWidgetAction
---> 30 from .window_action import CloseWindowAction, WindowAction
     31 
     32 # This part of the module handles widgets that are still wx specific.  This

~/Code/pyface/pyface/action/window_action.py in <module>
     13 
     14 # Enthought library imports.
---> 15 from pyface.window import Window
     16 from traits.api import Instance, Property
     17 

~/Code/pyface/pyface/window.py in <module>
     19 
     20 from .toolkit import toolkit_object
---> 21 Window = toolkit_object('window:Window')
     22 
     23 #### EOF ######################################################################

~/Code/pyface/pyface/base_toolkit.py in __call__(self, name)
    142         for package in self.packages:
    143             try:
--> 144                 module = import_module(mname, package)
    145             except ImportError as exc:
    146                 # is the error while trying to import package mname or not?

~/anaconda3/envs/eeldev/lib/python3.7/importlib/__init__.py in import_module(name, package)
    125                 break
    126             level += 1
--> 127     return _bootstrap._gcd_import(name[level:], package, level)
    128 
    129 

~/Code/pyface/pyface/ui/wx/window.py in <module>
     20 from pyface.i_window import IWindow, MWindow
     21 from pyface.key_pressed_event import KeyPressedEvent
---> 22 from system_metrics import SystemMetrics
     23 from .widget import Widget
     24 

ModuleNotFoundError: No module named 'system_metrics'
```