### PR TITLE
Fix API of DoLaterTimer to match earlier versions (#389)

### DIFF
--- a/pyface/timer/do_later.py
+++ b/pyface/timer/do_later.py
@@ -23,6 +23,10 @@ class DoLaterTimer(Timer):
     #: The perform the callback once.
     repeat = 1
 
+    def __init__(self, interval, callable, args, kw_args):
+        # Adapt the old DoLaterTimer initializer to the Timer initializer.
+        super(DoLaterTimer, self).__init__(interval, callable, *args, **kw_args)
+
 
 def do_later(callable, *args, **kwargs):
     """ Does something 50 milliseconds from now.
@@ -50,7 +54,7 @@ def do_after(interval, callable, *args, **kwargs):
     interval : float
         The time interval in milliseconds to wait before calling.
     callable : callable
-        The callable to call in 50ms time.
+        The callable to call.
     *args, **kwargs :
         Arguments to be passed through to the callable.
     """

--- a/pyface/timer/tests/test_do_later.py
+++ b/pyface/timer/tests/test_do_later.py
@@ -1,0 +1,129 @@
+from __future__ import print_function
+
+import time
+from unittest import TestCase, skipIf
+
+from pyface.toolkit import toolkit_object
+from ..i_timer import perf_counter
+from ..do_later import DoLaterTimer, do_after, do_later
+
+GuiTestAssistant = toolkit_object('util.gui_test_assistant:GuiTestAssistant')
+no_gui_test_assistant = (GuiTestAssistant.__name__ == 'Unimplemented')
+
+
+class ConditionHandler(object):
+    def __init__(self):
+        self.count = 0
+        self.times = []
+
+    def callback(self):
+        self.times.append(perf_counter())
+        self.count += 1
+
+
+@skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestDoLaterTimer(TestCase, GuiTestAssistant):
+    """ Test the DoLaterTimer. """
+
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+
+    def tearDown(self):
+        GuiTestAssistant.tearDown(self)
+
+    def test_basic(self):
+        handler = ConditionHandler()
+        start_time = perf_counter()
+        length = 500
+        timer = DoLaterTimer(length, handler.callback, (), {})
+
+        try:
+            self.assertTrue(timer.active)
+            self.event_loop_helper.event_loop_until_condition(
+                lambda: not timer.active
+            )
+            self.assertFalse(timer.active)
+        finally:
+            timer.stop()
+
+        self.assertEqual(handler.count, 1)
+
+        # should take no less than 85% of time requested
+        expected_length = (length / 1000.0) * 0.85
+        expected_time = start_time + expected_length
+
+        self.assertLessEqual(
+            expected_time,
+            handler.times[0],
+            "Expected call after {} seconds, took {} seconds)".format(
+                expected_length,
+                handler.times[0] - start_time
+            )
+        )
+
+
+@skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestDoLater(TestCase, GuiTestAssistant):
+    """ Test do_later. """
+
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+
+    def tearDown(self):
+        GuiTestAssistant.tearDown(self)
+
+    def test_basic(self):
+        handler = ConditionHandler()
+        timer = do_later(handler.callback)
+
+        try:
+            self.assertTrue(timer.active)
+            self.event_loop_helper.event_loop_until_condition(
+                lambda: not timer.active
+            )
+            self.assertFalse(timer.active)
+        finally:
+            timer.stop()
+
+        self.assertEqual(handler.count, 1)
+
+
+@skipIf(no_gui_test_assistant, 'No GuiTestAssistant')
+class TestDoAfter(TestCase, GuiTestAssistant):
+    """ Test do_after. """
+
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+
+    def tearDown(self):
+        GuiTestAssistant.tearDown(self)
+
+    def test_basic(self):
+        handler = ConditionHandler()
+        start_time = perf_counter()
+        length = 500
+        timer = do_after(length, handler.callback)
+
+        try:
+            self.assertTrue(timer.active)
+            self.event_loop_helper.event_loop_until_condition(
+                lambda: not timer.active
+            )
+            self.assertFalse(timer.active)
+        finally:
+            timer.stop()
+
+        self.assertEqual(handler.count, 1)
+
+        # should take no less than 85% of time requested
+        expected_length = (length / 1000.0) * 0.85
+        expected_time = start_time + expected_length
+
+        self.assertLessEqual(
+            expected_time,
+            handler.times[0],
+            "Expected call after {} seconds, took {} seconds)".format(
+                expected_length,
+                handler.times[0] - start_time
+            )
+        )


### PR DESCRIPTION
* Fix API of DoLaterTimer to match earlier versions.

* Get tests working.

* Add tests for do_later and do_after.

* Add a little bit of slack to timing tests.

* Fix docstring

* We don't have a start time unless there is an expire.

* Better failure messages; add some slack into timing estimates.

* Make tests more robust (longer time, more slack)