### PR TITLE
Fix ArgSpec attribute access

### DIFF
--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -195,7 +195,7 @@ class _MenuItem(HasTraits):
             argspec = getargspec(action.perform)
 
             # If the only argument is 'self' then don't pass the event!
-            if len(argspec.argspecargs) == 1:
+            if len(argspec.args) == 1:
                 action.perform()
 
             else:


### PR DESCRIPTION
The `ArgSpec` returned by `getargspec` does not contain an `argspecargs` attribute. This was introduced in the PR #370 .

See https://docs.python.org/3.6/library/inspect.html#inspect.getargspec for more information on the namedtuple returned by `getargspec`

fixes #392 