### PR TITLE
Fix imports for pyqt5 with webkit

### DIFF
--- a/pyface/qt/QtScript.py
+++ b/pyface/qt/QtScript.py
@@ -3,11 +3,11 @@ from . import qt_api
 if qt_api == 'pyqt':
     from PyQt4.QtScript import *
 
-if qt_api == 'pyqt5':
+elif qt_api == 'pyqt5':
     import warnings
     warnings.warn(DeprecationWarning("QtScript is not supported in PyQt5"))
 
-if qt_api == 'pyside2':
+elif qt_api == 'pyside2':
     import warnings
     warnings.warn(DeprecationWarning("QtScript is not supported in PyQt5"))
 

--- a/pyface/qt/QtWebKit.py
+++ b/pyface/qt/QtWebKit.py
@@ -4,16 +4,19 @@ if qt_api == 'pyqt':
     from PyQt4.QtWebKit import *
 
 elif qt_api == 'pyqt5':
-    #from PyQt5.QtWebKit import *
-    #from PyQt5.QtWebKitWidgets import *
     from PyQt5.QtWidgets import *
-    from PyQt5.QtWebEngine import *
-    from PyQt5.QtWebEngineWidgets import (
-        QWebEngineHistory as QWebHistory,
-        QWebEngineHistoryItem as QWebHistoryItem,
-        QWebEnginePage as QWebPage,
-        QWebEngineView as QWebView,
-    )
+    try:
+        from PyQt5.QtWebEngine import *
+        from PyQt5.QtWebEngineWidgets import (
+            QWebEngineHistory as QWebHistory,
+            QWebEngineHistoryItem as QWebHistoryItem,
+            QWebEnginePage as QWebPage,
+            QWebEngineView as QWebView,
+            QWebEngineSettings as QWebSettings,
+        )
+    except ImportError:
+        from PyQt5.QtWebKit import *
+        from PyQt5.QtWebKitWidgets import *
 
 elif qt_api == 'pyside2':
     from PySide2.QtWidgets import *
@@ -27,6 +30,7 @@ elif qt_api == 'pyside2':
             QWebEngineSettings as QWebSettings,
         )
     except ImportError:
+        from PySide2.QtWebKit import *
         from PySide2.QtWebKitWidgets import *
 
 else:

--- a/pyface/ui/qt4/tests/test_qt_imports.py
+++ b/pyface/ui/qt4/tests/test_qt_imports.py
@@ -1,0 +1,15 @@
+import unittest
+
+
+class TestPyfaceQtImports(unittest.TestCase):
+
+    def test_imports(self):
+        # check that all Qt API imports work
+        import pyface.qt.QtCore
+        import pyface.qt.QtGui
+        import pyface.qt.QtNetwork
+        import pyface.qt.QtOpenGL
+        import pyface.qt.QtScript
+        import pyface.qt.QtSvg
+        import pyface.qt.QtTest
+        import pyface.qt.QtWebKit


### PR DESCRIPTION
This is the pyqt5 fix from #387 without the interference of changing the etstool infrastructure at the same time.