### PR TITLE
Import unittest from stdlib (maintenance)

### DIFF
--- a/pyface/action/tests/test_action.py
+++ b/pyface/action/tests/test_action.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..action import Action
 from ..action_event import ActionEvent

--- a/pyface/action/tests/test_action_controller.py
+++ b/pyface/action/tests/test_action_controller.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..action import Action
 from ..action_controller import ActionController

--- a/pyface/action/tests/test_action_event.py
+++ b/pyface/action/tests/test_action_event.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import time
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..action_event import ActionEvent
 

--- a/pyface/action/tests/test_action_item.py
+++ b/pyface/action/tests/test_action_item.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import UnittestTools, unittest
+import unittest
+
+from traits.testing.unittest_tools import UnittestTools
 
 from pyface.image_cache import ImageCache
 from pyface.toolkit import toolkit_object

--- a/pyface/action/tests/test_action_manager.py
+++ b/pyface/action/tests/test_action_manager.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import UnittestTools, unittest
+import unittest
+
+from traits.testing.unittest_tools import UnittestTools
 
 from ..action import Action
 from ..action_item import ActionItem

--- a/pyface/action/tests/test_field_action.py
+++ b/pyface/action/tests/test_field_action.py
@@ -11,7 +11,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from pyface.fields.api import ComboField, SpinField, TextField
 from pyface.gui import GUI

--- a/pyface/action/tests/test_group.py
+++ b/pyface/action/tests/test_group.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import UnittestTools, unittest
+import unittest
+
+from traits.testing.unittest_tools import UnittestTools
 
 from ..action import Action
 from ..action_item import ActionItem

--- a/pyface/action/tests/test_gui_application_action.py
+++ b/pyface/action/tests/test_gui_application_action.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+import unittest
+
+from traits.testing.unittest_tools import UnittestTools
 
 from pyface.gui_application import GUIApplication
 from ..gui_application_action import GUIApplicationAction

--- a/pyface/action/tests/test_listening_action.py
+++ b/pyface/action/tests/test_listening_action.py
@@ -1,7 +1,9 @@
 from __future__ import absolute_import
 
+import unittest
+
 from traits.api import Any, Bool, HasTraits
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import UnittestTools
 
 from ..listening_action import ListeningAction
 from ..action_event import ActionEvent

--- a/pyface/action/tests/test_traitsui_widget_action.py
+++ b/pyface/action/tests/test_traitsui_widget_action.py
@@ -11,8 +11,10 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
+import unittest
+
 from traits.api import Enum, HasTraits
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import UnittestTools
 
 from pyface.gui import GUI
 from pyface.toolkit import toolkit

--- a/pyface/fields/tests/test_combo_field.py
+++ b/pyface/fields/tests/test_combo_field.py
@@ -11,9 +11,9 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-from six import text_type
+import unittest
 
-from traits.testing.unittest_tools import unittest
+from six import text_type
 
 from pyface.image_resource import ImageResource
 from ..combo_field import ComboField

--- a/pyface/fields/tests/test_spin_field.py
+++ b/pyface/fields/tests/test_spin_field.py
@@ -11,7 +11,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..spin_field import SpinField
 from .field_mixin import FieldMixin

--- a/pyface/fields/tests/test_text_field.py
+++ b/pyface/fields/tests/test_text_field.py
@@ -12,7 +12,7 @@ from __future__ import (
     absolute_import, division, print_function, unicode_literals
 )
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from pyface.toolkit import toolkit
 from ..text_field import TextField

--- a/pyface/tasks/tests/test_enaml_dock_pane.py
+++ b/pyface/tasks/tests/test_enaml_dock_pane.py
@@ -1,4 +1,5 @@
-from traits.testing.unittest_tools import unittest
+import unittest
+
 from traits.etsconfig.api import ETSConfig
 
 # Skip tests if Enaml is not installed or we're using the wx backend.

--- a/pyface/tasks/tests/test_enaml_editor.py
+++ b/pyface/tasks/tests/test_enaml_editor.py
@@ -1,4 +1,5 @@
-from traits.testing.unittest_tools import unittest
+import unittest
+
 from traits.etsconfig.api import ETSConfig
 
 # Skip tests if Enaml is not installed or we're using the wx backend.

--- a/pyface/tasks/tests/test_enaml_task_pane.py
+++ b/pyface/tasks/tests/test_enaml_task_pane.py
@@ -1,4 +1,5 @@
-from traits.testing.unittest_tools import unittest
+import unittest
+
 from traits.etsconfig.api import ETSConfig
 
 # Skip tests if Enaml is not installed or we're using the wx backend.

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..about_dialog import AboutDialog
 from ..constant import OK, CANCEL

--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..action.api import Action, MenuManager, MenuBarManager, StatusBarManager, ToolBarManager
 from ..application_window import ApplicationWindow

--- a/pyface/tests/test_base_toolkit.py
+++ b/pyface/tests/test_base_toolkit.py
@@ -1,4 +1,5 @@
-from traits.testing.unittest_tools import unittest
+import unittest
+
 from traits.etsconfig.api import ETSConfig
 
 from pyface.base_toolkit import find_toolkit, import_toolkit

--- a/pyface/tests/test_beep.py
+++ b/pyface/tests/test_beep.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+import unittest
+
+from traits.testing.unittest_tools import UnittestTools
 
 from ..beep import beep
 

--- a/pyface/tests/test_clipboard.py
+++ b/pyface/tests/test_clipboard.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..clipboard import clipboard
 

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import platform
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..confirmation_dialog import ConfirmationDialog, confirm
 from ..constant import YES, NO, OK, CANCEL

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import platform
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..dialog import Dialog
 from ..constant import OK, CANCEL

--- a/pyface/tests/test_directory_dialog.py
+++ b/pyface/tests/test_directory_dialog.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import os
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..directory_dialog import DirectoryDialog
 from ..gui import GUI

--- a/pyface/tests/test_file_dialog.py
+++ b/pyface/tests/test_file_dialog.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import os
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..file_dialog import FileDialog
 from ..gui import GUI

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..heading_text import HeadingText
 from ..image_resource import ImageResource

--- a/pyface/tests/test_image_cache.py
+++ b/pyface/tests/test_image_cache.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import os
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..image_cache import ImageCache
 

--- a/pyface/tests/test_image_resource.py
+++ b/pyface/tests/test_image_resource.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import
 import os
 import platform
 import pkg_resources
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 import pyface
 import pyface.tests

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import platform
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..message_dialog import MessageDialog, information, warning, error
 from ..constant import OK

--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..progress_dialog import ProgressDialog
 from ..toolkit import toolkit_object

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 
 import os
 import sys
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..python_editor import PythonEditor
 from ..toolkit import toolkit_object

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -2,8 +2,7 @@ from __future__ import absolute_import
 
 import os
 import sys
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..python_shell import PythonShell
 from ..toolkit import toolkit_object

--- a/pyface/tests/test_resource_manager.py
+++ b/pyface/tests/test_resource_manager.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import os
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..resource_manager import PyfaceResourceFactory
 

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -16,8 +16,9 @@
 
 from __future__ import absolute_import
 
+import unittest
+
 from traits.etsconfig.api import ETSConfig
-from traits.testing.unittest_tools import unittest
 
 from ..single_choice_dialog import SingleChoiceDialog
 from ..constant import OK, CANCEL

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..gui import GUI
 from ..image_resource import ImageResource

--- a/pyface/tests/test_split_application_window.py
+++ b/pyface/tests/test_split_application_window.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..heading_text import HeadingText
 from ..split_application_window import SplitApplicationWindow

--- a/pyface/tests/test_split_dialog.py
+++ b/pyface/tests/test_split_dialog.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..heading_text import HeadingText
 from ..split_dialog import SplitDialog

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..heading_text import HeadingText
 from ..split_panel import SplitPanel

--- a/pyface/tests/test_system_metrics.py
+++ b/pyface/tests/test_system_metrics.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..system_metrics import SystemMetrics
 

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -1,6 +1,5 @@
 import pkg_resources
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 import pyface.toolkit
 

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -1,6 +1,8 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+import unittest
+
+from traits.testing.unittest_tools import UnittestTools
 
 from ..toolkit import toolkit_object
 from ..widget import Widget

--- a/pyface/tests/test_window.py
+++ b/pyface/tests/test_window.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import
 
 import platform
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..constant import CANCEL, NO, OK, YES
 from ..toolkit import toolkit_object

--- a/pyface/ui/qt4/tests/test_progress_dialog.py
+++ b/pyface/ui/qt4/tests/test_progress_dialog.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from ..progress_dialog import ProgressDialog
 from ..util.gui_test_assistant import GuiTestAssistant

--- a/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 import mock
-
-from traits.testing.unittest_tools import unittest
+import unittest
 
 from pyface.ui.qt4.workbench.split_tab_widget import SplitTabWidget
 from pyface.ui.qt4.workbench.workbench_window_layout import \

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -2,8 +2,9 @@ import mock
 import tempfile
 import shutil
 import os
+import unittest
 
-from traits.testing.unittest_tools import unittest, UnittestTools
+from traits.testing.unittest_tools import UnittestTools
 
 from pyface.workbench.perspective import Perspective
 from pyface.workbench.api import Workbench


### PR DESCRIPTION
Import unittest from the std lib instead of importing it from traits.testing.unittest_tools