### PR TITLE
Release 6.1.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,29 @@
 Pyface Changelog
 ================
 
+Release 6.1.1
+=============
+
+This is a bugfix release which fixes a number of minor issues with the 6.1.0 release.
+
+Thanks to:
+
+David Baddeley, Christian Brodbeck, Mark Dickinson, Rahul Poruri, Corran Webster.
+
+Change summary
+--------------
+
+Fixes
+
+* Remove use of deprecated Traits get() method (#403)
+* Fix pyqt5 webkit imports (#396)
+* Remove use of cmp in fix_introspection_bug (#395)
+* Update CI infrastructure (#394, #399)
+* Update unittest imports (#391)
+* Fix bug in argspec usage (#393)
+* Fix regression in DoLaterTimer API (#389)
+
+
 Release 6.1.0
 =============
 

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ from setuptools import setup, find_packages
 
 MAJOR = 6
 MINOR = 1
-MICRO = 1
+MICRO = 2
 
-IS_RELEASED = True
+IS_RELEASED = False
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ MAJOR = 6
 MINOR = 1
 MICRO = 1
 
-IS_RELEASED = False
+IS_RELEASED = True
 
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
Bugfix release.  Includes:

* Remove use of deprecated Traits get() method (#403)
* Fix pyqt5 webkit imports (#396)
* Remove use of cmp in fix_introspection_bug (#395)
* Update CI infrastructure (#394, #399)
* Update unittest imports (#391)
* Fix bug in argspec usage (#393)
* Fix regression in DoLaterTimer API (#389)
