### PR TITLE
Fix a questionable version check.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -939,17 +939,17 @@ class TabDragObject(object):
         painter.drawPrimitive(QtGui.QStyle.PE_FrameTabBarBase, optTabBase)
 
         # region of active tab
-        if QtGui.qt_api=='pyqt5':
-            pixmap1 = tabBar.grab()
-        else: # pyqt4 (grabWidget was removed in pyqt5)
+        if QtCore.QT_VERSION >= 0x050000:
+            pixmap1 = tabBar.grab(tab_rect)
+        else:  # Qt4 (grabWidget was removed in Qt5)
             pixmap1 = QtGui.QPixmap.grabWidget(tabBar, tab_rect)
 
-        painter.drawPixmap(0,0,pixmap1) #tab_rect.topLeft(), pixmap1)
+        painter.drawPixmap(0, 0, pixmap1)  # tab_rect.topLeft(), pixmap1)
 
         # region of the page widget
-        if QtGui.qt_api=='pyqt5':
+        if QtCore.QT_VERSION >= 0x050000:
             pixmap2 = self.widget.grab()
-        else: # pyqt4 (grabWidget was removed in pyqt5)
+        else:  # Qt4 (grabWidget was removed in pyqt5)
             pixmap2 = QtGui.QPixmap.grabWidget(self.widget)
         painter.drawPixmap(0, tab_rect.height(), size.width(), size.height(), pixmap2)
 

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -6,7 +6,7 @@ from pyface.tasks.i_editor_area_pane import IEditorAreaPane, \
     MEditorAreaPane
 from traits.api import Bool, cached_property, Callable, Dict, Instance, List, \
     on_trait_change, Property, provides, Str
-from pyface.qt import QtCore, QtGui
+from pyface.qt import is_qt4, QtCore, QtGui
 from pyface.action.api import Action, Group, MenuManager
 from pyface.tasks.task_layout import PaneItem, Tabbed, Splitter
 from pyface.mimedata import PyMimeData
@@ -939,18 +939,18 @@ class TabDragObject(object):
         painter.drawPrimitive(QtGui.QStyle.PE_FrameTabBarBase, optTabBase)
 
         # region of active tab
-        if QtCore.__version_info__ >= (5,):
-            pixmap1 = tabBar.grab(tab_rect)
-        else:  # Qt4 (grabWidget was removed in Qt5)
+        if is_qt4:  # grab wasn't introduced until Qt5
             pixmap1 = QtGui.QPixmap.grabWidget(tabBar, tab_rect)
+        else:
+            pixmap1 = tabBar.grab(tab_rect)
 
         painter.drawPixmap(0, 0, pixmap1)  # tab_rect.topLeft(), pixmap1)
 
         # region of the page widget
-        if QtCore.__version_info__ >= (5,):
-            pixmap2 = self.widget.grab()
-        else:  # Qt4 (grabWidget was removed in pyqt5)
+        if is_qt4:
             pixmap2 = QtGui.QPixmap.grabWidget(self.widget)
+        else:
+            pixmap2 = self.widget.grab()
         painter.drawPixmap(0, tab_rect.height(), size.width(), size.height(), pixmap2)
 
         # finish painting

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -939,7 +939,7 @@ class TabDragObject(object):
         painter.drawPrimitive(QtGui.QStyle.PE_FrameTabBarBase, optTabBase)
 
         # region of active tab
-        if QtCore.QT_VERSION >= 0x050000:
+        if QtCore.__version_info__ >= (5,):
             pixmap1 = tabBar.grab(tab_rect)
         else:  # Qt4 (grabWidget was removed in Qt5)
             pixmap1 = QtGui.QPixmap.grabWidget(tabBar, tab_rect)
@@ -947,7 +947,7 @@ class TabDragObject(object):
         painter.drawPixmap(0, 0, pixmap1)  # tab_rect.topLeft(), pixmap1)
 
         # region of the page widget
-        if QtCore.QT_VERSION >= 0x050000:
+        if QtCore.__version_info__ >= (5,):
             pixmap2 = self.widget.grab()
         else:  # Qt4 (grabWidget was removed in pyqt5)
             pixmap2 = QtGui.QPixmap.grabWidget(self.widget)

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -944,7 +944,7 @@ class TabDragObject(object):
         else:
             pixmap1 = tabBar.grab(tab_rect)
 
-        painter.drawPixmap(0, 0, pixmap1)  # tab_rect.topLeft(), pixmap1)
+        painter.drawPixmap(0, 0, pixmap1)
 
         # region of the page widget
         if is_qt4:


### PR DESCRIPTION
`TabDragObject.get_pixmap` switches on `QtGui.qt_api` to decide whether to use `widget.grab()` (available only in Qt 5) or `QPixmap.grabWidget(widget)` (available only in Qt 4).

But this seems like the wrong check, and will likely do the wrong thing for PySide 2. We're not interested in the pyqt version; we're interested in the Qt version.

This PR fixes that, and tidies up some nearby code in passing.