### PR TITLE
Fix timer issue #408.

### DIFF
--- a/pyface/timer/tests/test_timer.py
+++ b/pyface/timer/tests/test_timer.py
@@ -373,14 +373,24 @@ class TestTimer(TestCase, GuiTestAssistant):
     def test_restart(self):
         handler = ConditionHandler()
 
-        timer = Timer(250, handler.callback)
+        timer = Timer(20, handler.callback)
         timer.Stop()
+
+        # Ensure that it is indeed stopped.
         self.assertFalse(timer.IsRunning())
+        count = handler.count
+
+        # Wait to see if the timer has indeed stopped.
+        self.event_loop_helper.event_loop()
+        time.sleep(0.1)
+        self.assertEqual(handler.count, count)
 
         timer.Start()
         try:
             self.assertTrue(timer.IsRunning())
-            self.event_loop_helper.event_loop()
+            self.event_loop_helper.event_loop_until_condition(
+                lambda: handler.count > 0
+            )
             self.assertTrue(timer.IsRunning())
         finally:
             timer.Stop()

--- a/pyface/timer/timer.py
+++ b/pyface/timer/timer.py
@@ -50,7 +50,6 @@ class Timer(CallbackTimer):
     def Start(self, millisecs=None):
         """ Alias for `start` to match old API.
         """
-        self._active = True
         if millisecs is not None:
             self.interval = millisecs / 1000.0
 
@@ -59,7 +58,6 @@ class Timer(CallbackTimer):
     def Stop(self):
         """ Alias for `stop` to match old API.
         """
-        self._active = False
         self.stop()
 
     def IsRunning(self):


### PR DESCRIPTION
This adds a test and fixes the issue.  It doesn't address setting the interval trait when the timer is running.