### PR TITLE
Use decorator forms of classmethod and staticmethod.

### DIFF
--- a/pyface/dock/dock_window_feature.py
+++ b/pyface/dock/dock_window_feature.py
@@ -527,6 +527,7 @@ class DockWindowFeature ( HasPrivateTraits ):
     #  specified DockControl (or None if the feature does not apply to it):
     #---------------------------------------------------------------------------
 
+    @classmethod
     def feature_for ( cls, dock_control ):
         """ Returns a single new feature object or list of new feature objects
         for a specified DockControl.
@@ -564,12 +565,11 @@ class DockWindowFeature ( HasPrivateTraits ):
 
         return None
 
-    feature_for = classmethod( feature_for )
-
     #---------------------------------------------------------------------------
     #  Returns a new feature instance for a specified DockControl:
     #---------------------------------------------------------------------------
 
+    @classmethod
     def new_feature ( cls, dock_control ):
         """ Returns a new feature instance for a specified DockControl.
 
@@ -598,13 +598,12 @@ class DockWindowFeature ( HasPrivateTraits ):
         """
         return cls( dock_control = dock_control )
 
-    new_feature = classmethod( new_feature )
-
     #---------------------------------------------------------------------------
     #  Returns whether or not the DockWindowFeature is a valid feature for a
     #  specified DockControl:
     #---------------------------------------------------------------------------
 
+    @classmethod
     def is_feature_for ( self, dock_control ):
         """ Returns whether this class is a valid feature for the application
         object corresponding to a specified DockControl.
@@ -629,8 +628,6 @@ class DockWindowFeature ( HasPrivateTraits ):
         returns **True**.
         """
         return True
-
-    is_feature_for = classmethod( is_feature_for )
 
 #-- Private Methods ------------------------------------------------------------
 
@@ -731,6 +728,7 @@ class DockWindowFeature ( HasPrivateTraits ):
     #  if the feature does not apply to the DockControl object):
     #---------------------------------------------------------------------------
 
+    @classmethod
     def new_feature_for ( cls, dock_control ):
         """ Returns a feature object for use with the specified DockControl (or
         **None** if the feature does not apply to the DockControl object).
@@ -746,12 +744,11 @@ class DockWindowFeature ( HasPrivateTraits ):
 
         return result
 
-    new_feature_for = classmethod( new_feature_for )
-
     #---------------------------------------------------------------------------
     #  Toggles the feature on/off:
     #---------------------------------------------------------------------------
 
+    @classmethod
     def toggle_feature ( cls, event ):
         """ Toggles the feature on or off.
         """
@@ -773,8 +770,6 @@ class DockWindowFeature ( HasPrivateTraits ):
                 feature = aref()
                 if feature is not None:
                     getattr( feature, method )()
-
-    toggle_feature = classmethod( toggle_feature )
 
 #-- Event Handlers -------------------------------------------------------------
 
@@ -845,4 +840,3 @@ class DockWindowFeature ( HasPrivateTraits ):
             eval( action, globals(), { 'self': self } )
         else:
             getattr( self, action )()
-

--- a/pyface/ui/qt4/gui.py
+++ b/pyface/ui/qt4/gui.py
@@ -59,26 +59,23 @@ class GUI(MGUI, HasTraits):
     # 'GUI' class interface.
     ###########################################################################
 
+    @classmethod
     def invoke_after(cls, millisecs, callable, *args, **kw):
         _FutureCall(millisecs, callable, *args, **kw)
 
-    invoke_after = classmethod(invoke_after)
-
+    @classmethod
     def invoke_later(cls, callable, *args, **kw):
         _FutureCall(0, callable, *args, **kw)
 
-    invoke_later = classmethod(invoke_later)
-
+    @classmethod
     def set_trait_after(cls, millisecs, obj, trait_name, new):
         _FutureCall(millisecs, setattr, obj, trait_name, new)
 
-    set_trait_after = classmethod(set_trait_after)
-
+    @classmethod
     def set_trait_later(cls, obj, trait_name, new):
         _FutureCall(0, setattr, obj, trait_name, new)
 
-    set_trait_later = classmethod(set_trait_later)
-
+    @staticmethod
     def process_events(allow_user_events=True):
         if allow_user_events:
             events = QtCore.QEventLoop.AllEvents
@@ -87,15 +84,12 @@ class GUI(MGUI, HasTraits):
 
         QtCore.QCoreApplication.processEvents(events)
 
-    process_events = staticmethod(process_events)
-
+    @staticmethod
     def set_busy(busy=True):
         if busy:
             QtGui.QApplication.setOverrideCursor(QtCore.Qt.WaitCursor)
         else:
             QtGui.QApplication.restoreOverrideCursor()
-
-    set_busy = staticmethod(set_busy)
 
     ###########################################################################
     # 'GUI' interface.

--- a/pyface/ui/wx/gui.py
+++ b/pyface/ui/wx/gui.py
@@ -63,41 +63,35 @@ class GUI(MGUI, HasTraits):
     # 'GUI' class interface.
     ###########################################################################
 
+    @classmethod
     def invoke_after(cls, millisecs, callable, *args, **kw):
         wx.CallLater(millisecs, callable, *args, **kw)
 
-    invoke_after = classmethod(invoke_after)
-
+    @classmethod
     def invoke_later(cls, callable, *args, **kw):
         wx.CallAfter(callable, *args, **kw)
 
-    invoke_later = classmethod(invoke_later)
-
+    @classmethod
     def set_trait_after(cls, millisecs, obj, trait_name, new):
         wx.CallLater(millisecs, setattr, obj, trait_name, new)
 
-    set_trait_after = classmethod(set_trait_after)
-
+    @classmethod
     def set_trait_later(cls, obj, trait_name, new):
         wx.CallAfter(setattr, obj, trait_name, new)
 
-    set_trait_later = classmethod(set_trait_later)
-
+    @staticmethod
     def process_events(allow_user_events=True):
         if allow_user_events:
             wx.GetApp().Yield(True)
         else:
             wx.SafeYield()
 
-    process_events = staticmethod(process_events)
-
+    @staticmethod
     def set_busy(busy=True):
         if busy:
             GUI._cursor = wx.BusyCursor()
         else:
             GUI._cursor = None
-
-    set_busy = staticmethod(set_busy)
 
     ###########################################################################
     # 'GUI' interface.


### PR DESCRIPTION
I think it's safe to drop compatibility with Python 2.3 now.