### PR TITLE
Add GuiTestAssistant.assertEventuallyTrueInGui

### DIFF
--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -148,6 +148,31 @@ class GuiTestAssistant(UnittestTools):
         except ConditionTimeoutError:
             self.fail('Timed out waiting for condition')
 
+    def assertEventuallyTrueInGui(self, condition, timeout=10.0):
+        """
+        Assert that the given condition becomes true if we run the GUI
+        event loop for long enough.
+
+        This assertion runs the real Qt event loop, polling the condition
+        and returning as soon as the condition becomes true. If the condition
+        does not become true within the given timeout, the assertion fails.
+
+        Parameters
+        ----------
+        condition : callable() -> bool
+            Callable accepting no arguments and returning a bool.
+        timeout : float
+            Maximum length of time to wait for the condition to become
+            true, in seconds.
+
+        Raises
+        ------
+        self.failureException
+            If the condition does not become true within the given timeout.
+        """
+        with self.event_loop_until_condition(condition, timeout=timeout):
+            pass
+
     @contextlib.contextmanager
     def assertTraitChangesInEventLoop(self, obj, trait, condition, count=1,
                                       timeout=10.0):

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -170,8 +170,11 @@ class GuiTestAssistant(UnittestTools):
         self.failureException
             If the condition does not become true within the given timeout.
         """
-        with self.event_loop_until_condition(condition, timeout=timeout):
-            pass
+        try:
+            self.event_loop_helper.event_loop_until_condition(
+                condition, timeout=timeout)
+        except ConditionTimeoutError:
+            self.fail("Timed out waiting for condition to become true.")
 
     @contextlib.contextmanager
     def assertTraitChangesInEventLoop(self, obj, trait, condition, count=1,

--- a/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
+++ b/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
@@ -1,5 +1,6 @@
 import unittest
 
+from pyface.timer.api import CallbackTimer, do_after
 from pyface.ui.qt4.util.gui_test_assistant import \
     GuiTestAssistant
 from traits.api import Event, HasStrictTraits
@@ -58,3 +59,30 @@ class TestGuiTestAssistant(GuiTestAssistant, unittest.TestCase):
         # Successful case.
         with self.event_loop_until_traits_change(obj):
             pass
+
+    def test_assert_eventually_true_in_gui_success(self):
+        my_list = []
+
+        timer = CallbackTimer(
+            interval=0.05,
+            callback=my_list.append,
+            args=("bob",),
+            repeat=1,
+        )
+
+        timer.start()
+        try:
+            self.assertEventuallyTrueInGui(lambda: len(my_list) > 0)
+            self.assertEqual(my_list, ["bob"])
+        finally:
+            timer.stop()
+
+    def test_assert_eventually_true_in_gui_already_true(self):
+        my_list = ["bob"]
+        self.assertEventuallyTrueInGui(lambda: len(my_list) > 0)
+
+    def test_assert_eventually_true_in_gui_failure(self):
+        my_list = []
+        with self.assertRaises(AssertionError):
+            self.assertEventuallyTrueInGui(
+                lambda: len(my_list) > 0, timeout=0.1)

--- a/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
+++ b/pyface/ui/qt4/util/tests/test_gui_test_assistant.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pyface.timer.api import CallbackTimer, do_after
+from pyface.timer.api import CallbackTimer
 from pyface.ui.qt4.util.gui_test_assistant import \
     GuiTestAssistant
 from traits.api import Event, HasStrictTraits


### PR DESCRIPTION
When writing unit tests or regression tests for GUIs, I often want to assert that "if you run the event loop for long enough, such-and-such happens".

The `GuiTestAssistant.event_loop_until_condition` method does this, but it has a (to my eyes) strange API and feels awkward and error-prone to use:

- it has to be used as a context manager, even though it doesn't really fit the notion of a context manager because there's no setup step
- it's easy to accidentally misuse it (e.g., not as a context manager), and it's then not so easy to diagnose why things aren't working as expected
- it's making a unittest assertion (calling self.fail on timeout), but this isn't obvious from the name

This PR adds a new method `GuiTestAssistant.assertEventuallyTrueInGui` that can be used in the simple form:
```
self.assertEventuallyTrueInGui(some_condition)
```
This is more clearly an assertion (that can fail) to code readers, and doesn't need the extra `with` statement.
