### PR TITLE
Fix some occurrences of PyFace (should be Pyface)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,7 +4,7 @@ Welcome to the Pyface Documentation!
 
 Pyface contains a toolkit-independent GUI abstraction layers, used to support
 the "visualization" features of the Traits package. Thus, you can write code
-in the abstraction of the PyFace API and the selected toolkit and backend take
+in the abstraction of the Pyface API and the selected toolkit and backend take
 care of the details of displaying them.
 
 Pyface

--- a/pyface/tasks/action/schema.py
+++ b/pyface/tasks/action/schema.py
@@ -60,7 +60,7 @@ class ActionSchema(Schema):
         return []
 
     def create(self, children):
-        """ Create the appropriate PyFace Action instance. """
+        """ Create the appropriate Pyface Action instance. """
 
         traits = dict(id=self.id)
         return self.action_factory(**traits)
@@ -147,7 +147,7 @@ class ToolBarSchema(Schema):
 
     def create(self, children):
         traits = dict(id=self.id, name=self.name, image_size=self.image_size,
-                      orientation=self.orientation, 
+                      orientation=self.orientation,
                       show_divider=self.show_divider,
                       show_tool_names=self.show_tool_names)
         return self.tool_bar_manager_factory(*children, **traits)

--- a/pyface/workbench/action/view_chooser.py
+++ b/pyface/workbench/action/view_chooser.py
@@ -73,7 +73,7 @@ class IViewTreeNode(TreeNode):
     for adaptation we would have to work out a way for the rest of the
     'TreeNode' code to access the adapter, not the original object. We could,
     of course override every method, but that seems a little, errr, tedious.
-    We could probably do with something like in the PyFace tree where there
+    We could probably do with something like in the Pyface tree where there
     is a method that returns the actual object that we want to manipulate.
 
     """

--- a/pyface/workbench/action/view_menu_manager.py
+++ b/pyface/workbench/action/view_menu_manager.py
@@ -103,7 +103,7 @@ class ViewMenuManager(MenuManager):
     def _clear_group(self, group):
         """ Remove all items in a group. """
 
-        # fixme: Fix this API in PyFace so there is only one call!
+        # fixme: Fix this API in Pyface so there is only one call!
         group.destroy()
         group.clear()
 


### PR DESCRIPTION
Be consistent about the package name: it's "Pyface", not "PyFace".

Mostly inconsequential, but the occurrence in the index page of the top-level docs is a bit glaring.