### PR TITLE
Use equality rather than is when checking orientation.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -209,12 +209,12 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         # add collapse action (only show for collapsible splitters)
         if splitter.is_collapsible():
             if splitter is splitter.parent().leftchild:
-                if splitter.parent().orientation() is QtCore.Qt.Horizontal:
+                if splitter.parent().orientation() == QtCore.Qt.Horizontal:
                     text = 'Merge with right pane'
                 else:
                     text = 'Merge with bottom pane'
             else:
-                if splitter.parent().orientation() is QtCore.Qt.Horizontal:
+                if splitter.parent().orientation() == QtCore.Qt.Horizontal:
                     text = 'Merge with left pane'
                 else:
                     text = 'Merge with top pane'


### PR DESCRIPTION
The `is` test for orientation can fail: there's no reason why the value returned from the `orientation()` call should be identical to one of the `QtCore.Qt.Horizontal` or `QtCore.Qt.Vertical` enumeration values.