### PR TITLE
Fix some comments that should be Traits doc-comments.

### DIFF
--- a/pyface/tasks/i_editor.py
+++ b/pyface/tasks/i_editor.py
@@ -7,35 +7,35 @@ class IEditor(Interface):
     """ The base interface for all panes (central and dock) in a Task.
     """
 
-    # The editor's user-visible name.
+    #: The editor's user-visible name.
     name = Unicode
 
-    # The tooltip to show for the editor's tab, if any.
+    #: The tooltip to show for the editor's tab, if any.
     tooltip = Unicode
 
-    # The toolkit-specific control that represents the editor.
+    #: The toolkit-specific control that represents the editor.
     control = Any
 
-    # The object that the editor is editing.
+    #: The object that the editor is editing.
     obj = Any
 
-    # Has the editor's object been modified but not saved?
+    #: Has the editor's object been modified but not saved?
     dirty = Bool
 
-    # The editor area to which the editor belongs.
+    #: The editor area to which the editor belongs.
     editor_area = Instance(
         'pyface.tasks.i_editor_area_pane.IEditorAreaPane')
 
-    # Is the editor active in the editor area?
+    #: Is the editor active in the editor area?
     is_active = Bool
 
-    # Does the editor currently have the focus?
+    #: Does the editor currently have the focus?
     has_focus = Bool
 
-    # Fired when the editor has been requested to close.
+    #: Fired when the editor has been requested to close.
     closing = VetoableEvent
 
-    # Fired when the editor has been closed.
+    #: Fired when the editor has been closed.
     closed = Event
 
     ###########################################################################

--- a/pyface/tasks/i_task_pane.py
+++ b/pyface/tasks/i_task_pane.py
@@ -10,19 +10,19 @@ class ITaskPane(Interface):
     """ The base interface for all panes (central and dock) in a Task.
     """
 
-    # The pane's identifier, unique within a Task.
+    #: The pane's identifier, unique within a Task.
     id = Str
 
-    # The pane's user-visible name.
+    #: The pane's user-visible name.
     name = Unicode
 
-    # The toolkit-specific control that represents the pane.
+    #: The toolkit-specific control that represents the pane.
     control = Any
 
-    # Does the pane currently have focus?
+    #: Does the pane currently have focus?
     has_focus = Bool
 
-    # The task with which the pane is associated. Set by the framework.
+    #: The task with which the pane is associated. Set by the framework.
     task = Instance(Task)
 
     ###########################################################################

--- a/pyface/tasks/i_task_window_backend.py
+++ b/pyface/tasks/i_task_window_backend.py
@@ -10,10 +10,10 @@ class ITaskWindowBackend(Interface):
     layout functionality.
     """
 
-    # The root control of the TaskWindow to which the layout belongs.
+    #: The root control of the TaskWindow to which the layout belongs.
     control = Any
 
-    # The TaskWindow to which the layout belongs.
+    #: The TaskWindow to which the layout belongs.
     window = Instance('pyface.tasks.task_window.TaskWindow')
 
     ###########################################################################


### PR DESCRIPTION
Fixes some cases of #425: I concentrated on interfaces for non-outdated code pieces (so ignoring stuff in the `wizards` and `workspaces` packages).