### PR TITLE
Fix: Don't try to open directories in PythonEditorTask

### DIFF
--- a/examples/application/python_editor/python_editor_task.py
+++ b/examples/application/python_editor/python_editor_task.py
@@ -232,9 +232,9 @@ class PythonEditorTask(Task):
 
     def save(self):
         """ Save the current file.
-        
+
         If needed, this code prompts for a path.
-        
+
         Returns
         -------
         saved : bool
@@ -279,8 +279,9 @@ class PythonEditorTask(Task):
         """
         browser = PythonBrowserPane()
 
-        def handler():
-            return self.create_editor(browser.selected_file)
+        def handler(path):
+            if os.path.isfile(path):
+                return self.create_editor(path)
 
         browser.on_trait_change(handler, 'activated')
         return [browser]


### PR DESCRIPTION
If you run the Python Editor example application (`pyface/examples/application/python_editor/`) and try to select a directory, you get a traceback on the console resembling the following:

```
Traceback (most recent call last):
  File "/Users/mdickinson/.edm/envs/pyface-test-3.6-pyqt/lib/python3.6/site-packages/traits/trait_notifiers.py", line 591, in _dispatch_change_event
    self.dispatch(handler, *args)
  File "/Users/mdickinson/.edm/envs/pyface-test-3.6-pyqt/lib/python3.6/site-packages/traits/trait_notifiers.py", line 553, in dispatch
    handler(*args)
  File "/Users/mdickinson/Enthought/ETS/pyface/examples/application/python_editor/python_editor_task.py", line 283, in handler
    return self.create_editor(browser.selected_file)
  File "/Users/mdickinson/Enthought/ETS/pyface/examples/application/python_editor/python_editor_task.py", line 211, in create_editor
    self.active_editor.load()
  File "/Users/mdickinson/Enthought/ETS/pyface/examples/application/python_editor/python_editor.py", line 118, in load
    with open(path) as fp:
IsADirectoryError: [Errno 21] Is a directory: '/Users/mdickinson'
```

This PR fixes that by only attempting to open files.