### PR TITLE
Eliminate deprecation warnings about assertEquals

### DIFF
--- a/pyface/tasks/tests/test_action_manager_builder.py
+++ b/pyface/tasks/tests/test_action_manager_builder.py
@@ -28,22 +28,22 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
         """ Checks that two action managers are (logically) equivalent.
         """
         children1 = children2 = []
-        self.assertEquals(type(first), type(second))
-        self.assertEquals(first.id, second.id)
+        self.assertEqual(type(first), type(second))
+        self.assertEqual(first.id, second.id)
 
         if isinstance(first, ActionItem):
-            self.assertEquals(first.action.name, second.action.name)
+            self.assertEqual(first.action.name, second.action.name)
 
         elif isinstance(first, ActionManager):
             if not isinstance(first, MenuBarManager):
-                self.assertEquals(first.name, second.name)
+                self.assertEqual(first.name, second.name)
             children1, children2 = first.groups, second.groups
 
         elif isinstance(first, Group):
-            self.assertEquals(first.separator, second.separator)
+            self.assertEqual(first.separator, second.separator)
             children1, children2 = first.items, second.items
 
-        self.assertEquals(len(children1), len(children2))
+        self.assertEqual(len(children1), len(children2))
         for i in range(len(children1)):
             self.assertActionElementsEqual(children1[i], children2[i])
 

--- a/pyface/tasks/tests/test_topological_sort.py
+++ b/pyface/tasks/tests/test_topological_sort.py
@@ -36,7 +36,7 @@ class TopologicalSortTestCase(unittest.TestCase):
         actual = before_after_sort(items)
         desired = [ TestItem(1), TestItem(3), TestItem(4),
                     TestItem(2), TestItem(5) ]
-        self.assertEquals(actual, desired)
+        self.assertEqual(actual, desired)
 
     def test_before_after_sort_2(self):
         """ Does the before-after sort work when both 'before' and 'after'
@@ -46,14 +46,14 @@ class TopologicalSortTestCase(unittest.TestCase):
                   TestItem(4, after=2, before=3) ]
         actual = before_after_sort(items)
         desired = [ TestItem(1), TestItem(2), TestItem(4), TestItem(3) ]
-        self.assertEquals(actual, desired)
+        self.assertEqual(actual, desired)
 
     def test_before_after_sort_3(self):
         """ Does the degenerate case for the before-after sort work?
         """
         actual = before_after_sort([ TestItem(1) ])
         desired = [ TestItem(1) ]
-        self.assertEquals(actual, desired)
+        self.assertEqual(actual, desired)
 
     def test_topological_sort_1(self):
         """ Does a basic topological sort work?
@@ -61,7 +61,7 @@ class TopologicalSortTestCase(unittest.TestCase):
         pairs = [ (1,2), (3,5), (4,6), (1,3), (1,4), (1,6), (2,4) ]
         result, has_cycles = topological_sort(pairs)
         self.assert_(not has_cycles)
-        self.assertEquals(result, [1, 2, 3, 4, 5, 6])
+        self.assertEqual(result, [1, 2, 3, 4, 5, 6])
 
     def test_topological_sort_2(self):
         """ Does another basic topological sort work?
@@ -69,7 +69,7 @@ class TopologicalSortTestCase(unittest.TestCase):
         pairs = [ (1,2), (1,3), (2,4), (3,4), (5,6), (4,5) ]
         result, has_cycles = topological_sort(pairs)
         self.assert_(not has_cycles)
-        self.assertEquals(result, [1, 2, 3, 4, 5, 6])
+        self.assertEqual(result, [1, 2, 3, 4, 5, 6])
 
     def test_topological_sort_3(self):
         """ Does cycle detection work?

--- a/pyface/tests/test_clipboard.py
+++ b/pyface/tests/test_clipboard.py
@@ -24,20 +24,20 @@ class TestClipboard(unittest.TestCase):
     def test_set_text_data(self):
         self.clipboard.data = 'test'
         self.assertTrue(self.clipboard.has_data)
-        self.assertEquals(self.clipboard.data_type, 'str')
-        self.assertEquals(self.clipboard.data, 'test')
+        self.assertEqual(self.clipboard.data_type, 'str')
+        self.assertEqual(self.clipboard.data, 'test')
         self.assertTrue(self.clipboard.has_text_data)
-        self.assertEquals(self.clipboard.text_data, 'test')
+        self.assertEqual(self.clipboard.text_data, 'test')
         self.assertFalse(self.clipboard.has_file_data)
         self.assertFalse(self.clipboard.has_object_data)
 
     def test_set_text_data_unicode(self):
         self.clipboard.data = u'test'
         self.assertTrue(self.clipboard.has_data)
-        self.assertEquals(self.clipboard.data_type, 'str')
-        self.assertEquals(self.clipboard.data, u'test')
+        self.assertEqual(self.clipboard.data_type, 'str')
+        self.assertEqual(self.clipboard.data, u'test')
         self.assertTrue(self.clipboard.has_text_data)
-        self.assertEquals(self.clipboard.text_data, u'test')
+        self.assertEqual(self.clipboard.text_data, u'test')
         self.assertFalse(self.clipboard.has_file_data)
         self.assertFalse(self.clipboard.has_object_data)
 
@@ -45,10 +45,10 @@ class TestClipboard(unittest.TestCase):
     def test_set_file_data(self):
         self.clipboard.data = ['file:///images']
         self.assertTrue(self.clipboard.has_data)
-        self.assertEquals(self.clipboard.data_type, 'file')
-        self.assertEquals(self.clipboard.data, ['/images'])
+        self.assertEqual(self.clipboard.data_type, 'file')
+        self.assertEqual(self.clipboard.data, ['/images'])
         self.assertTrue(self.clipboard.has_file_data)
-        self.assertEquals(self.clipboard.file_data, ['/images'])
+        self.assertEqual(self.clipboard.file_data, ['/images'])
         self.assertFalse(self.clipboard.has_text_data)
         self.assertFalse(self.clipboard.has_object_data)
 
@@ -56,10 +56,10 @@ class TestClipboard(unittest.TestCase):
         data = TestObject(foo='bar', baz=1)
         self.clipboard.data = data
         self.assertTrue(self.clipboard.has_data)
-        self.assertEquals(self.clipboard.data_type, TestObject)
-        self.assertEquals(self.clipboard.data, data)
+        self.assertEqual(self.clipboard.data_type, TestObject)
+        self.assertEqual(self.clipboard.data, data)
         self.assertTrue(self.clipboard.has_object_data)
-        self.assertEquals(self.clipboard.object_type, TestObject)
-        self.assertEquals(self.clipboard.object_data, data)
+        self.assertEqual(self.clipboard.object_type, TestObject)
+        self.assertEqual(self.clipboard.object_data, data)
         self.assertFalse(self.clipboard.has_text_data)
         self.assertFalse(self.clipboard.has_file_data)

--- a/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
@@ -83,29 +83,29 @@ class TestEditorAreaWidget(unittest.TestCase):
         self.assertIsNotNone(root.rightchild)
         self.assertIsInstance(root.leftchild, EditorAreaWidget)
         self.assertIsInstance(root.rightchild, EditorAreaWidget)
-        self.assertEquals(root.leftchild.count(), 1)
-        self.assertEquals(root.rightchild.count(), 1)
+        self.assertEqual(root.leftchild.count(), 1)
+        self.assertEqual(root.rightchild.count(), 1)
 
         # are the tabwidgets laid out correctly?
-        self.assertEquals(root.leftchild.tabwidget(), tabwidget)
+        self.assertEqual(root.leftchild.tabwidget(), tabwidget)
         self.assertIsNotNone(root.rightchild.tabwidget().empty_widget)
 
         # are the contents of the left tabwidget correct?
-        self.assertEquals(root.leftchild.tabwidget().count(), 2)
-        self.assertEquals(root.leftchild.tabwidget().widget(0), btn0)
-        self.assertEquals(root.leftchild.tabwidget().widget(1), btn1)
-        self.assertEquals(root.leftchild.tabwidget().currentWidget(), btn1)
+        self.assertEqual(root.leftchild.tabwidget().count(), 2)
+        self.assertEqual(root.leftchild.tabwidget().widget(0), btn0)
+        self.assertEqual(root.leftchild.tabwidget().widget(1), btn1)
+        self.assertEqual(root.leftchild.tabwidget().currentWidget(), btn1)
 
         # does the right tabwidget contain nothing but the empty widget?
-        self.assertEquals(root.rightchild.tabwidget().count(), 1)
-        self.assertEquals(root.rightchild.tabwidget().widget(0),
+        self.assertEqual(root.rightchild.tabwidget().count(), 1)
+        self.assertEqual(root.rightchild.tabwidget().widget(0),
                           root.rightchild.tabwidget().empty_widget)
 
         # do we have an equally sized split?
-        self.assertEquals(root.leftchild.width(), root.rightchild.width())
+        self.assertEqual(root.leftchild.width(), root.rightchild.width())
 
         # is the rightchild active?
-        self.assertEquals(root.editor_area.active_tabwidget,
+        self.assertEqual(root.editor_area.active_tabwidget,
                           root.rightchild.tabwidget())
 
     def _setUp_collapse(self, parent=None):
@@ -162,12 +162,12 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         # test
         # has the root now become the leaf?
-        self.assertEquals(root.count(), 1)
+        self.assertEqual(root.count(), 1)
         self.assertIsInstance(root.widget(0), QtGui.QTabWidget)
 
         # how does the combined list look?
-        self.assertEquals(root.tabwidget().count(), 4)
-        self.assertEquals(root.tabwidget().currentWidget(), btn2)
+        self.assertEqual(root.tabwidget().count(), 4)
+        self.assertEqual(root.tabwidget().currentWidget(), btn2)
 
     def test_collapse_empty(self):
         """ Test for collapse function when the collapse origin is an empty
@@ -188,18 +188,18 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         # test
         # is the layout of root now same as left?
-        self.assertEquals(root.count(), 2)
-        self.assertEquals(root.leftchild, left_left)
-        self.assertEquals(root.rightchild, left_right)
+        self.assertEqual(root.count(), 2)
+        self.assertEqual(root.leftchild, left_left)
+        self.assertEqual(root.rightchild, left_right)
 
         # are the contents of left_left and left_right preserved
-        self.assertEquals(root.leftchild.tabwidget().count(), 2)
-        self.assertEquals(root.rightchild.tabwidget().count(), 2)
-        self.assertEquals(root.leftchild.tabwidget().currentIndex(), 1)
-        self.assertEquals(root.rightchild.tabwidget().currentIndex(), 0)
+        self.assertEqual(root.leftchild.tabwidget().count(), 2)
+        self.assertEqual(root.rightchild.tabwidget().count(), 2)
+        self.assertEqual(root.leftchild.tabwidget().currentIndex(), 1)
+        self.assertEqual(root.rightchild.tabwidget().currentIndex(), 0)
 
         # what is the current active_tabwidget?
-        self.assertEquals(root.editor_area.active_tabwidget,
+        self.assertEqual(root.editor_area.active_tabwidget,
                           root.leftchild.tabwidget())
 
     def test_persistence(self):
@@ -235,11 +235,11 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         ######## test tooltips #############
 
-        self.assertEquals(editor_area.active_tabwidget.tabToolTip(0),
+        self.assertEqual(editor_area.active_tabwidget.tabToolTip(0),
                           "test_tooltip0")
-        self.assertEquals(editor_area.active_tabwidget.tabToolTip(1),
+        self.assertEqual(editor_area.active_tabwidget.tabToolTip(1),
                           "test_tooltip1")
-        self.assertEquals(editor_area.active_tabwidget.tabToolTip(2),
+        self.assertEqual(editor_area.active_tabwidget.tabToolTip(2),
                           "test_tooltip2")
 
         ######## test set_layout #############
@@ -250,14 +250,14 @@ class TestEditorAreaWidget(unittest.TestCase):
         # file0 goes to left pane?
         left = editor_area.control.leftchild
         editor = editor_area._get_editor(left.tabwidget().widget(0))
-        self.assertEquals(editor.obj, file0)
+        self.assertEqual(editor.obj, file0)
 
         # right pane is a splitter made of two panes?
         right = editor_area.control.rightchild
         self.assertFalse(right.is_leaf())
 
         # right pane is vertical splitter?
-        self.assertEquals(right.orientation(), QtCore.Qt.Vertical)
+        self.assertEqual(right.orientation(), QtCore.Qt.Vertical)
 
         # top pane of this vertical split is empty?
         right_top = right.leftchild
@@ -269,14 +269,14 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         # file1 goes first on bottom pane?
         editor = editor_area._get_editor(right_bottom.tabwidget().widget(0))
-        self.assertEquals(editor.obj, file1)
+        self.assertEqual(editor.obj, file1)
 
         # file2 goes second on bottom pane?
         editor = editor_area._get_editor(right_bottom.tabwidget().widget(1))
-        self.assertEquals(editor.obj, file2)
+        self.assertEqual(editor.obj, file2)
 
         # file1 tab is active?
-        self.assertEquals(right_bottom.tabwidget().currentIndex(), 0)
+        self.assertEqual(right_bottom.tabwidget().currentIndex(), 0)
 
         ######### test get_layout #############
 
@@ -285,28 +285,28 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         # is the top level a horizontal splitter?
         self.assertIsInstance(layout_new, Splitter)
-        self.assertEquals(layout_new.orientation, 'horizontal')
+        self.assertEqual(layout_new.orientation, 'horizontal')
 
         # tests on left child
         left = layout_new.items[0]
         self.assertIsInstance(left, Tabbed)
-        self.assertEquals(left.items[0].id, 0)
+        self.assertEqual(left.items[0].id, 0)
 
         # tests on right child
         right = layout_new.items[1]
         self.assertIsInstance(right, Splitter)
-        self.assertEquals(right.orientation, 'vertical')
+        self.assertEqual(right.orientation, 'vertical')
 
         # tests on top pane of right child
         right_top = right.items[0]
         self.assertIsInstance(right_top, Tabbed)
-        self.assertEquals(right_top.items[0].id, -1)
+        self.assertEqual(right_top.items[0].id, -1)
 
         # tests on bottom pane of right child
         right_bottom = right.items[1]
         self.assertIsInstance(right_bottom, Tabbed)
-        self.assertEquals(right_bottom.items[0].id, 1)
-        self.assertEquals(right_bottom.items[1].id, 2)
+        self.assertEqual(right_bottom.items[0].id, 1)
+        self.assertEqual(right_bottom.items[1].id, 2)
 
     def test_context_menu_merge_text_left_right_split(self):
         # Regression test for enthought/pyface#422


### PR DESCRIPTION
Trivial PR that eliminates one cause of deprecation warnings seen during the test run.