### PR TITLE
Python 3 compatibility: replace true division with integer division.

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -583,7 +583,7 @@ class EditorAreaWidget(QtGui.QSplitter):
         self.addWidget(self.rightchild)
 
         # set equal sizes of splits
-        self.setSizes([orig_size/2,orig_size/2])
+        self.setSizes([orig_size//2, orig_size//2])
 
         # make the rightchild's tabwidget active & show its empty widget
         self.editor_area.active_tabwidget = self.rightchild.tabwidget()


### PR DESCRIPTION
Drive-by fix: fix an instance of true division that should be integer division (`QSplitter.setSizes` expects integers).

It's possible that the new sizes should be spelled `[(orig_size + 1)//2, orig_size//2]`, but the docs for `setSizes` indicate that Qt handles distributing extra space anyway, and the change in this PR matches current Python 2 behaviour (and probably current Python 3 behaviour, too).