### PR TITLE
Don't show the context help button in Windows dialogs.

### DIFF
--- a/pyface/ui/qt4/dialog.py
+++ b/pyface/ui/qt4/dialog.py
@@ -123,8 +123,15 @@ class Dialog(MDialog, Window):
         return panel
 
     def _show_modal(self):
-        self.control.setWindowModality(QtCore.Qt.ApplicationModal)
-        retval = self.control.exec_()
+        dialog = self.control
+        dialog.setWindowModality(QtCore.Qt.ApplicationModal)
+
+        # Suppress the context-help button hint, which
+        # results in a non-functional "?" button on Windows.
+        dialog.setWindowFlags(
+            dialog.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+
+        retval = dialog.exec_()
         return _RESULT_MAP[retval]
 
     ###########################################################################


### PR DESCRIPTION
Out of the box, Windows dialogs have an extra "?" button in their title bar that does nothing (and looks ugly). This PR turns it off.

Before:
![Screenshot 2019-08-09 at 11 49 10](https://user-images.githubusercontent.com/662003/62774073-ba4fcd00-ba9b-11e9-8fb2-290dba321d4b.png)

After:
![Screenshot 2019-08-09 at 11 48 53](https://user-images.githubusercontent.com/662003/62774075-bd4abd80-ba9b-11e9-87e9-eede8b831a97.png)

Test script:
```python
from pyface.api import MessageDialog

dialog = MessageDialog(message="just testing long dialog message")
dialog.open()
```
