### PR TITLE
Ensure close button and ESC key close message dialogs under Qt.

### DIFF
--- a/pyface/ui/qt4/message_dialog.py
+++ b/pyface/ui/qt4/message_dialog.py
@@ -65,6 +65,7 @@ class MessageDialog(MMessageDialog, Dialog):
                 self.title, self.message, QtGui.QMessageBox.Ok, parent)
         message_box.setInformativeText(self.informative)
         message_box.setDetailedText(self.detail)
+        message_box.setEscapeButton(QtGui.QMessageBox.Ok)
 
         if self.size != (-1, -1):
             message_box.resize(*self.size)

--- a/pyface/ui/qt4/tests/test_message_dialog.py
+++ b/pyface/ui/qt4/tests/test_message_dialog.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
-# license included in enthought/LICENSE.txt and may be redistributed only
+# license included in LICENSE.txt and may be redistributed only
 # under the conditions described in the aforementioned license.  The license
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 # Thanks for using Enthought open source!

--- a/pyface/ui/qt4/tests/test_message_dialog.py
+++ b/pyface/ui/qt4/tests/test_message_dialog.py
@@ -1,0 +1,58 @@
+"""
+Qt-specific tests for the MessageDialog
+"""
+
+import unittest
+
+from pyface.api import MessageDialog
+from pyface.qt import QtGui
+from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
+
+
+class TestMessageDialog(GuiTestAssistant, unittest.TestCase):
+    def test_escape_button_no_details(self):
+        dialog = MessageDialog(
+            parent=None,
+            title=u"Dialog title",
+            message=u"Printer on fire",
+            informative=u"Your printer is on fire",
+            severity=u"error",
+            size=(600, 400),
+        )
+
+        with self.event_loop():
+            dialog._create()
+
+        try:
+            escape_button = dialog.control.escapeButton()
+            ok_button = dialog.control.button(QtGui.QMessageBox.Ok)
+            # It's possible for both the above to be None, so double check.
+            self.assertIsNotNone(escape_button)
+            self.assertIs(escape_button, ok_button)
+        finally:
+            with self.event_loop():
+                dialog.destroy()
+
+    def test_escape_button_with_details(self):
+        dialog = MessageDialog(
+            parent=None,
+            title=u"Dialog title",
+            message=u"Printer on fire",
+            informative=u"Your printer is on fire",
+            details=u"Temperature exceeds 1000 degrees",
+            severity=u"error",
+            size=(600, 400),
+        )
+
+        with self.event_loop():
+            dialog._create()
+
+        try:
+            escape_button = dialog.control.escapeButton()
+            ok_button = dialog.control.button(QtGui.QMessageBox.Ok)
+            # It's possible for both the above to be None, so double check.
+            self.assertIsNotNone(escape_button)
+            self.assertIs(escape_button, ok_button)
+        finally:
+            with self.event_loop():
+                dialog.destroy()

--- a/pyface/ui/qt4/tests/test_message_dialog.py
+++ b/pyface/ui/qt4/tests/test_message_dialog.py
@@ -1,3 +1,12 @@
+# (C) Copyright 2019 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in enthought/LICENSE.txt and may be redistributed only
+# under the conditions described in the aforementioned license.  The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+# Thanks for using Enthought open source!
+
 """
 Qt-specific tests for the MessageDialog
 """

--- a/pyface/ui/qt4/tests/test_message_dialog.py
+++ b/pyface/ui/qt4/tests/test_message_dialog.py
@@ -11,6 +11,7 @@
 Qt-specific tests for the MessageDialog
 """
 
+import contextlib
 import unittest
 
 from pyface.api import MessageDialog
@@ -29,18 +30,12 @@ class TestMessageDialog(GuiTestAssistant, unittest.TestCase):
             size=(600, 400),
         )
 
-        with self.event_loop():
-            dialog._create()
-
-        try:
+        with self.create_dialog(dialog):
             escape_button = dialog.control.escapeButton()
             ok_button = dialog.control.button(QtGui.QMessageBox.Ok)
             # It's possible for both the above to be None, so double check.
             self.assertIsNotNone(escape_button)
             self.assertIs(escape_button, ok_button)
-        finally:
-            with self.event_loop():
-                dialog.destroy()
 
     def test_escape_button_with_details(self):
         dialog = MessageDialog(
@@ -53,15 +48,22 @@ class TestMessageDialog(GuiTestAssistant, unittest.TestCase):
             size=(600, 400),
         )
 
-        with self.event_loop():
-            dialog._create()
-
-        try:
+        with self.create_dialog(dialog):
             escape_button = dialog.control.escapeButton()
             ok_button = dialog.control.button(QtGui.QMessageBox.Ok)
             # It's possible for both the above to be None, so double check.
             self.assertIsNotNone(escape_button)
             self.assertIs(escape_button, ok_button)
+
+    @contextlib.contextmanager
+    def create_dialog(self, dialog):
+        """
+        Create a dialog, then destroy at the end of a with block.
+        """
+        with self.event_loop():
+            dialog._create()
+        try:
+            yield
         finally:
             with self.event_loop():
                 dialog.destroy()


### PR DESCRIPTION
With a Qt backend, message dialogs that don't contain any details have a single "Ok" button, and can be closed by clicking on the close button or pressing the Esc key. This is fine.

Dialogs that _do_ have details have an extra "Show details..." button (at least on macOS), and can no longer be closed by clicking on the close button or pressing Esc. This is surprising behaviour.

This PR ensures that the close button and the Esc key work to close the dialog in both cases.

Fix has been manually tested on macOS; ~I'll test on Windows and Linux~ Tested manually on Windows and Linux, too.