### PR TITLE
Fix relative imports for wx tasks

### DIFF
--- a/pyface/ui/wx/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/wx/tasks/advanced_editor_area_pane.py
@@ -6,7 +6,7 @@ from traits.api import provides
 
 # Local imports.
 from pyface.tasks.i_advanced_editor_area_pane import IAdvancedEditorAreaPane
-from editor_area_pane import EditorAreaPane
+from .editor_area_pane import EditorAreaPane
 
 ###############################################################################
 # 'AdvancedEditorAreaPane' class.

--- a/pyface/ui/wx/tasks/main_window_layout.py
+++ b/pyface/ui/wx/tasks/main_window_layout.py
@@ -6,7 +6,7 @@ import logging
 from traits.api import Any, HasTraits
 
 # Local imports.
-from dock_pane import AREA_MAP, INVERSE_AREA_MAP
+from .dock_pane import AREA_MAP, INVERSE_AREA_MAP
 from pyface.tasks.task_layout import LayoutContainer, PaneItem, Tabbed, \
      Splitter, HSplitter, VSplitter
 

--- a/pyface/ui/wx/tasks/split_editor_area_pane.py
+++ b/pyface/ui/wx/tasks/split_editor_area_pane.py
@@ -6,7 +6,7 @@ from traits.api import provides
 
 # Local imports.
 from pyface.tasks.i_editor_area_pane import IEditorAreaPane
-from editor_area_pane import EditorAreaPane
+from .editor_area_pane import EditorAreaPane
 
 ###############################################################################
 # 'AdvancedEditorAreaPane' class.

--- a/pyface/ui/wx/tasks/task_window_backend.py
+++ b/pyface/ui/wx/tasks/task_window_backend.py
@@ -9,7 +9,7 @@ from pyface.wx.aui import aui
 from traits.api import Instance, List, Str
 
 # Local imports.
-from main_window_layout import MainWindowLayout
+from .main_window_layout import MainWindowLayout
 from pyface.tasks.i_task_window_backend import MTaskWindowBackend
 from pyface.tasks.task_layout import PaneItem, TaskLayout
 


### PR DESCRIPTION
These imports failed for me when trying to import envisage.plugins.ipython_kernel.ipython_kernel_ui_plugin.IPythonKernelUIPlugin