### PR TITLE
MAINT: Update deprecated attribute name.

### DIFF
--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -199,7 +199,7 @@ class GuiTestAssistant(UnittestTools):
             change does not occur.
         """
         condition_ = lambda: condition(obj)
-        collector = TraitsChangeCollector(obj=obj, trait=trait)
+        collector = TraitsChangeCollector(obj=obj, trait_name=trait)
 
         collector.start_collecting()
         try:


### PR DESCRIPTION
This changes the deprecated `traits` attribute name into `traits_name`, from the (privately imported) `TraitsChangeCollector`. This was renamed in https://github.com/enthought/traits/pull/343.

I realize that this code may be obsoleted by https://github.com/enthought/pyface/pull/447, but having one less `DeprecationWarning` for pyface end users would be a good thing, in the meantime.