### PR TITLE
Replace uses of trait types 'false' and 'true' with 'Bool'

### DIFF
--- a/pyface/dock/dock_window.py
+++ b/pyface/dock/dock_window.py
@@ -36,7 +36,7 @@ import sys
 from pyface.api import SystemMetrics
 
 from traits.api \
-    import HasPrivateTraits, Instance, Tuple, Property, Any, Str, List, false
+    import HasPrivateTraits, Instance, Tuple, Property, Any, Str, List, Bool
 
 from traits.trait_base \
     import traits_home
@@ -274,7 +274,7 @@ class DockWindow ( HasPrivateTraits ):
     handler_args = Tuple
 
     # Close the parent window if the DockWindow becomes empty:
-    auto_close = false
+    auto_close = Bool(False)
 
     # The DockWindow graphical theme style information:
     theme = Instance( DockWindowTheme, allow_none = False )
@@ -1263,14 +1263,14 @@ class ControlInfo ( HasPrivateTraits ):
     name = Str
 
     # Has the user set the name of the control?
-    user_name = false
+    user_name = Bool(False)
     id = Str
 
     # Style of drag bar/tab:
     style = DockStyle
 
     # Has the user set the style for this control:
-    user_style = false
+    user_style = Bool(False)
 
     #---------------------------------------------------------------------------
     #  Traits view definition:
@@ -1286,4 +1286,3 @@ class ControlInfo ( HasPrivateTraits ):
                         title   = 'Edit properties',
                         kind    = 'modal',
                         buttons = [ 'OK', 'Cancel' ] )
-

--- a/pyface/ui/wx/image_button.py
+++ b/pyface/ui/wx/image_button.py
@@ -22,7 +22,7 @@ from __future__ import absolute_import
 import wx
 from numpy import array, fromstring, reshape, ravel, dtype
 
-from traits.api import Str, Range, Enum, Instance, Event, false
+from traits.api import Bool, Str, Range, Enum, Instance, Event
 
 from .widget import Widget
 from .image_resource import ImageResource
@@ -77,7 +77,7 @@ class ImageButton ( Widget ):
     orientation = Enum( 'vertical', 'horizontal' )
 
     # Is the control selected ('radio' or 'checkbox' style)?
-    selected = false
+    selected = Bool(False)
 
     # Fired when a 'button' or 'toolbar' style control is clicked:
     clicked = Event


### PR DESCRIPTION
Replace uses of the convenience trait types `false` and `true` with the corresponding `Bool` traits.