### PR TITLE
Turn some old-style classes into new-style classes

### DIFF
--- a/pyface/resource/resource_factory.py
+++ b/pyface/resource/resource_factory.py
@@ -14,7 +14,7 @@
 """ Default base-class for resource factories. """
 
 
-class ResourceFactory:
+class ResourceFactory(object):
     """ Default base-class for resource factories. """
 
     ###########################################################################

--- a/pyface/ui/wx/python_shell.py
+++ b/pyface/ui/wx/python_shell.py
@@ -293,7 +293,7 @@ class PyShell(PyShellBase):
         super(PyShellBase, self).Destroy()
 
 
-class _NullIO:
+class _NullIO(object):
     """ A portable /dev/null for use with PythonShell.execute_file.
     """
     def tell(self): return 0

--- a/pyface/wx/drag_and_drop.py
+++ b/pyface/wx/drag_and_drop.py
@@ -27,7 +27,7 @@ import wx
 import six
 
 
-class Clipboard:
+class Clipboard(object):
     """ The clipboard is used when dragging and dropping Python objects. """
 
     # fixme: This obviously only works within a single process!

--- a/pyface/wx/image_cache.py
+++ b/pyface/wx/image_cache.py
@@ -18,7 +18,7 @@
 import wx
 
 
-class ImageCache:
+class ImageCache(object):
     """ An image cache. """
 
     def __init__(self, width, height):

--- a/pyface/wx/shell.py
+++ b/pyface/wx/shell.py
@@ -64,7 +64,7 @@ else:  # GTK
             }
 
 
-class ShellFacade:
+class ShellFacade(object):
     """Simplified interface to all shell-related functionality.
 
     This is a semi-transparent facade, in that all attributes of other are
@@ -1129,7 +1129,7 @@ ID_FILLING_SHOW_DOC = wxNewId()
 ID_FILLING_SHOW_MODULE = wxNewId()
 
 
-class ShellMenu:
+class ShellMenu(object):
     """Mixin class to add standard menu items."""
 
     def createMenus(self):

--- a/pyface/wx/spreadsheet/font_renderer.py
+++ b/pyface/wx/spreadsheet/font_renderer.py
@@ -75,7 +75,7 @@ class FontRenderer(DefaultRenderer):
         dc.DestroyClippingRegion()
         return
 
-class FontRendererFactory88:
+class FontRendererFactory88(object):
     """ I don't grok why this Factory (which I copied from the wx demo)
         was ever necessary? """
     def __init__(self, color, font, fontsize):


### PR DESCRIPTION
This PR is possibly a little late. However ...

While removing support for old-style classes from Traits, I found some surprises, once of which was the `ResourceFactory` class from Pyface.

This PR turns that class and a handful of other old-style classes into new-style classes.