### PR TITLE
Include additional copyright notices in AboutDialog

### DIFF
--- a/pyface/i_about_dialog.py
+++ b/pyface/i_about_dialog.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005, Enthought, Inc.
+# Copyright (c) 2005-2019, Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD
@@ -28,6 +28,9 @@ class IAboutDialog(IDialog):
 
     #: Additional strings to be added to the dialog.
     additions = List(Unicode)
+
+    #: Additional copyright strings to be added above the standard ones.
+    copyrights = List(Unicode)
 
     #: The image displayed in the dialog.
     image = Instance(ImageResource, ImageResource('about'))

--- a/pyface/i_about_dialog.py
+++ b/pyface/i_about_dialog.py
@@ -1,5 +1,5 @@
 #------------------------------------------------------------------------------
-# Copyright (c) 2005-2019, Enthought, Inc.
+# Copyright (c) 2005-2020, Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -94,5 +94,7 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
         html = self.dialog._create_html()
         self.assertIn("test line 1<br />test line 2<br>",
                       html)
-        self.assertIn("Copyright (c) copyright<br />Copyright (c) copyleft",
-                      html)
+        self.assertIn(
+            "Copyright &copy; copyright<br />Copyright &copy; copyleft",
+            html
+        )

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -86,3 +86,13 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
+
+    def test__create_html(self):
+        # test that the html content is properly created
+        self.dialog.additions.extend(["test line 1", "test line 2"])
+        self.dialog.copyrights.extend(["copyright", "copyleft"])
+        html = self.dialog._create_html()
+        self.assertIn("test line 1<br />test line 2<br>",
+                      html)
+        self.assertIn("Copyright (c) copyright<br />Copyright (c) copyleft",
+                      html)

--- a/pyface/ui/qt4/about_dialog.py
+++ b/pyface/ui/qt4/about_dialog.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 # Copyright (c) 2007, Riverbank Computing Limited
-# Copyright (c) 2019, Enthought, Inc.
+# Copyright (c) 2020, Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD license.
@@ -121,7 +121,7 @@ class AboutDialog(MAboutDialog, Dialog):
         qt_version = QtCore.__version__
 
         # The additional copyright strings.
-        copyrights = "<br />".join(["Copyright (c) %s" % line
+        copyrights = "<br />".join(["Copyright &copy; %s" % line
                                     for line in self.copyrights])
 
         return _DIALOG_TEXT % (path, additions, py_version, qt_version,

--- a/pyface/ui/qt4/about_dialog.py
+++ b/pyface/ui/qt4/about_dialog.py
@@ -1,12 +1,13 @@
 #------------------------------------------------------------------------------
 # Copyright (c) 2007, Riverbank Computing Limited
+# Copyright (c) 2019, Enthought, Inc.
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD license.
 # However, when used with the GPL version of PyQt the additional terms described in the PyQt GPL exception also apply
 
 #
-# Author: Riverbank Computing Limited
+# Author: Riverbank Computing Limited; Enthought, Inc.
 # Description: <Enthought pyface package component>
 #------------------------------------------------------------------------------
 
@@ -46,6 +47,9 @@ _DIALOG_TEXT = '''
       Qt %s<br>
       </p>
       <p>
+      %s
+      </p>
+      <p>
       Copyright &copy; 2003-2010 Enthought, Inc.<br>
       Copyright &copy; 2007 Riverbank Computing Limited
       </p>
@@ -65,6 +69,8 @@ class AboutDialog(MAboutDialog, Dialog):
 
     additions = List(Unicode)
 
+    copyrights = List(Unicode)
+
     image = Instance(ImageResource, ImageResource('about'))
 
     ###########################################################################
@@ -83,19 +89,8 @@ class AboutDialog(MAboutDialog, Dialog):
             # Set the title.
             self.title = "About %s" % title
 
-        # Load the image to be displayed in the about box.
-        image = self.image.create_image()
-        path = self.image.absolute_path
-
-        # The additional strings.
-        additions = '<br />'.join(self.additions)
-
-        # Get the version numbers.
-        py_version = platform.python_version()
-        qt_version = QtCore.__version__
-
         # Set the page contents.
-        label.setText(_DIALOG_TEXT % (path, additions, py_version, qt_version))
+        label.setText(self._create_html())
 
         # Create the button.
         buttons = QtGui.QDialogButtonBox()
@@ -112,3 +107,22 @@ class AboutDialog(MAboutDialog, Dialog):
         lay.addWidget(buttons)
 
         parent.setLayout(lay)
+
+    def _create_html(self):
+        # Load the image to be displayed in the about box.
+        image = self.image.create_image()
+        path = self.image.absolute_path
+
+        # The additional strings.
+        additions = '<br />'.join(self.additions)
+
+        # Get the version numbers.
+        py_version = platform.python_version()
+        qt_version = QtCore.__version__
+
+        # The additional copyright strings.
+        copyrights = "<br />".join(["Copyright (c) %s" % line
+                                    for line in self.copyrights])
+
+        return _DIALOG_TEXT % (path, additions, py_version, qt_version,
+                               copyrights)

--- a/pyface/ui/wx/about_dialog.py
+++ b/pyface/ui/wx/about_dialog.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2005-2019, Enthought, Inc.
+#  Copyright (c) 2005-2020, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD
@@ -140,7 +140,7 @@ class AboutDialog(MAboutDialog, Dialog):
         wx_version = wx.VERSION_STRING
 
         # The additional copyright strings.
-        copyrights = "<br />".join(["Copyright (c) %s" % line
+        copyrights = "<br />".join(["Copyright &copy; %s" % line
                                     for line in self.copyrights])
 
         # Get the text of the OK button.

--- a/pyface/ui/wx/about_dialog.py
+++ b/pyface/ui/wx/about_dialog.py
@@ -1,6 +1,6 @@
 #------------------------------------------------------------------------------
 #
-#  Copyright (c) 2005, Enthought, Inc.
+#  Copyright (c) 2005-2019, Enthought, Inc.
 #  All rights reserved.
 #
 #  This software is provided without warranty under the terms of the BSD
@@ -54,6 +54,9 @@ _DIALOG_TEXT = '''
       wxPython %s<br>
       </p>
       <p>
+      %s
+      </p>
+      <p>
       Copyright &copy; 2003-2010 Enthought, Inc.
       </p>
 
@@ -80,6 +83,8 @@ class AboutDialog(MAboutDialog, Dialog):
 
     additions = List(Unicode)
 
+    copyrights = List(Unicode)
+
     image = Instance(ImageResource, ImageResource('about'))
 
     ###########################################################################
@@ -98,10 +103,6 @@ class AboutDialog(MAboutDialog, Dialog):
 
         # Load the image to be displayed in the about box.
         image = self.image.create_image()
-        path  = self.image.absolute_path
-
-        # The additional strings.
-        additions = '<br />'.join(self.additions)
 
         # The width of a wx HTML window is fixed (and  is given in the
         # constructor). We set it to the width of the image plus a fudge
@@ -109,20 +110,8 @@ class AboutDialog(MAboutDialog, Dialog):
         width = image.GetWidth() + 80
         html = wx.html.HtmlWindow(parent, -1, size=(width, -1))
 
-        # Get the version numbers.
-        py_version = sys.version[0:sys.version.find("(")]
-        wx_version = wx.VERSION_STRING
-
-        # Get the text of the OK button.
-        if self.ok_label is None:
-            ok = "OK"
-        else:
-            ok = self.ok_label
-
         # Set the page contents.
-        html.SetPage(
-            _DIALOG_TEXT % (path, additions, py_version, wx_version, ok)
-        )
+        html.SetPage(self._create_html())
 
         # Make the 'OK' button the default button.
         ok_button = html.FindWindowById(wx.ID_OK)
@@ -138,5 +127,29 @@ class AboutDialog(MAboutDialog, Dialog):
         # size!?!
         width, height = html.GetSize()
         parent.SetClientSize((width, height + 10))
+
+    def _create_html(self):
+        # Load the image to be displayed in the about box.
+        path = self.image.absolute_path
+
+        # The additional strings.
+        additions = '<br />'.join(self.additions)
+
+        # Get the version numbers.
+        py_version = sys.version[0:sys.version.find("(")]
+        wx_version = wx.VERSION_STRING
+
+        # The additional copyright strings.
+        copyrights = "<br />".join(["Copyright (c) %s" % line
+                                    for line in self.copyrights])
+
+        # Get the text of the OK button.
+        if self.ok_label is None:
+            ok = "OK"
+        else:
+            ok = self.ok_label
+
+        return _DIALOG_TEXT % (path, additions, py_version, wx_version,
+                               copyrights, ok)
 
 ### EOF #######################################################################


### PR DESCRIPTION
Closes #466 

As per offline discussion with @corranwebster , we decided to leave the existing Enthought and Riverbank copyright lines as they are, and add an optional trait that will allow users to include their own copyright notices. This new trait works exactly as the `additions` trait, but prepends each line with `Copyright (c) `.

I also had to refactor a bit both `ui/qt4/about_dialog.py` and `ui/wx/about_dialog.py` to accommodate a new `AboutDialog._create_html()` method, which builds the html shown in the dialog. This allows to properly test its content, something that was missing so far. 