### PR TITLE
Test against Traits master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then sudo apt-get install -y libdbus-1-3 libxkbcommon-x11-0; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,23 +10,10 @@ env:
 
 matrix:
   include:
-    - env: RUNTIME=2.7 TOOLKITS="pyqt pyside wx"
-    - env: RUNTIME=2.7 TOOLKITS="pyside2"
-    - env: RUNTIME=3.5 TOOLKITS="pyqt pyqt5"
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
-    - os: osx
-      env: RUNTIME=2.7 TOOLKITS="pyside pyqt wx"
-    - os: osx
-      env: RUNTIME=2.7 TOOLKITS="pyside2"
-    - os: osx
-      env: RUNTIME=3.5 TOOLKITS="pyqt pyqt5"
     - os: osx
       env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2"
   fast_finish: true
-  allow_failures:
-    - env: RUNTIME=2.7 TOOLKITS="pyside2"
-    - os: osx
-      env: RUNTIME=2.7 TOOLKITS="pyside2"
 
 branches:
   only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,11 +8,6 @@ environment:
     INSTALL_EDM_VERSION: "2.0.0"
 
   matrix:
-
-    - RUNTIME: '2.7'
-      TOOLKITS: "pyqt pyside wx"
-    - RUNTIME: '3.5'
-      TOOLKITS: "pyqt pyqt5"
     - RUNTIME: '3.6'
       TOOLKITS: "pyqt pyqt5"
     - RUNTIME: '3.6'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,15 +9,15 @@ environment:
 
   matrix:
     - RUNTIME: '3.6'
-      TOOLKITS: "pyqt pyqt5"
+      TOOLKITS: "pyqt"
     - RUNTIME: '3.6'
-      TOOLKITS: "pyside2"
+      TOOLKITS: "pyside2 pyqt5"
 
 matrix:
   fast_finish: true
   allow_failures:
     - RUNTIME: '3.6'
-      TOOLKITS: "pyside2"
+      TOOLKITS: "pyside2 pyqt5"
 
 
 branches:

--- a/ci-src-requirements.txt
+++ b/ci-src-requirements.txt
@@ -1,1 +1,2 @@
+git+http://github.com/enthought/traits.git#egg=traits
 git+http://github.com/enthought/traitsui.git#egg=traitsui

--- a/etstool.py
+++ b/etstool.py
@@ -87,7 +87,6 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    '2.7': {'pyside', 'pyqt', 'wx', 'pyside2'},
     '3.5': {'pyqt', 'pyqt5'},
     '3.6': {'pyqt', 'pyqt5', 'pyside2'},
 }
@@ -107,7 +106,7 @@ extra_dependencies = {
     'pyside2': set(),
     'pyqt': {'pyqt<4.12'},  # FIXME: build 1 of.4-12 appears to be bad
     # XXX once pyqt5 is available in EDM, we will want it here
-    'pyqt5': set(),
+    'pyqt5': {'pyqt5'},
     'wx': {'wxpython'},
     'null': set()
 }
@@ -187,12 +186,11 @@ def install(edm, runtime, toolkit, environment):
         "{edm} run -e {environment} -- python setup.py install",
     ]
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
-    if toolkit == 'pyqt5':
-        commands.append("{edm} run -e {environment} -- pip install pyqt5==5.9.2")
-    elif toolkit == 'pyside2':
-        commands.append(
-            "{edm} run -e {environment} -- pip install pyside2==5.11.1"
-        )
+    if toolkit == 'pyside2':
+        commands.extend([
+            "{edm} run -e {environment} -- pip install shiboken2",
+            "{edm} run -e {environment} -- pip install pyside2"
+        ])
 
     click.echo("Creating environment '{environment}'".format(**parameters))
     execute(commands, parameters)

--- a/setup.py
+++ b/setup.py
@@ -140,10 +140,10 @@ if __name__ == "__main__":
               Operating System :: POSIX
               Operating System :: Unix
               Programming Language :: Python
-              Programming Language :: Python :: 2.7
-              Programming Language :: Python :: 3.4
               Programming Language :: Python :: 3.5
               Programming Language :: Python :: 3.6
+              Programming Language :: Python :: 3.7
+              Programming Language :: Python :: 3.8
               Topic :: Scientific/Engineering
               Topic :: Software Development
               Topic :: Software Development :: Libraries


### PR DESCRIPTION
Test against the master branch of Traits rather than the latest release since there have been a lot of changes.

This means turning off Python 2.7 testing.  We also stop running CI against 3.5 because it is not giving much information that testing on 3.6 isn't already giving us.