### PR TITLE
Replace use of default value constants with DefaultValue Enum

### DIFF
--- a/pyface/tests/test_ui_traits.py
+++ b/pyface/tests/test_ui_traits.py
@@ -17,16 +17,8 @@
 import os
 import unittest
 
-from traits.api import HasTraits, TraitError
+from traits.api import DefaultValue, HasTraits, TraitError
 from traits.testing.unittest_tools import UnittestTools
-try:
-    from traits.trait_handlers import (
-        CALLABLE_AND_ARGS_DEFAULT_VALUE,
-        UNSPECIFIED_DEFAULT_VALUE
-    )
-except ImportError:
-    UNSPECIFIED_DEFAULT_VALUE = -1
-    CALLABLE_AND_ARGS_DEFAULT_VALUE = 7
 
 from ..i_image_resource import IImageResource
 from ..image_resource import ImageResource
@@ -143,11 +135,11 @@ class TestHasMargin(unittest.TestCase, UnittestTools):
 
     def test_unspecified_default(self):
         trait = HasMargin()
-        trait.default_value_type = UNSPECIFIED_DEFAULT_VALUE
+        trait.default_value_type = DefaultValue.unspecified
 
         (dvt, dv) = trait.get_default_value()
 
-        self.assertEqual(dvt, CALLABLE_AND_ARGS_DEFAULT_VALUE)
+        self.assertEqual(dvt, DefaultValue.callable_and_args)
         self.assertEqual(
             dv,
             (

--- a/pyface/tests/test_ui_traits.py
+++ b/pyface/tests/test_ui_traits.py
@@ -366,11 +366,11 @@ class TestHasBorder(unittest.TestCase, UnittestTools):
 
     def test_unspecified_default(self):
         trait = HasBorder()
-        trait.default_value_type = UNSPECIFIED_DEFAULT_VALUE
+        trait.default_value_type = DefaultValue.unspecified
 
         (dvt, dv) = trait.get_default_value()
 
-        self.assertEqual(dvt, CALLABLE_AND_ARGS_DEFAULT_VALUE)
+        self.assertEqual(dvt, DefaultValue.callable_and_args)
         self.assertEqual(
             dv,
             (

--- a/pyface/ui_traits.py
+++ b/pyface/ui_traits.py
@@ -17,12 +17,10 @@
 """ Defines common traits used within the pyface library. """
 import logging
 
-from traits.api import ABCHasStrictTraits, Enum, Range, TraitError, TraitType
+from traits.api import (
+    ABCHasStrictTraits, DefaultValue, Enum, Range, TraitError, TraitType
+)
 from traits.trait_base import get_resource_path
-try:
-    from traits.trait_handlers import CALLABLE_AND_ARGS_DEFAULT_VALUE
-except ImportError:
-    CALLABLE_AND_ARGS_DEFAULT_VALUE = 7
 import six
 
 
@@ -235,7 +233,7 @@ class HasMargin(TraitType):
             if not isinstance(dv, self.klass):
                 return super(HasMargin, self).get_default_value()
 
-            self.default_value_type = dvt = CALLABLE_AND_ARGS_DEFAULT_VALUE
+            self.default_value_type = dvt = DefaultValue.callable_and_args
             dv = (self.klass, (), dv.trait_get())
 
         return (dvt, dv)


### PR DESCRIPTION
Tests weren't failing because the imports were already being guarded.  This now means we need Traits 6.0.