### PR TITLE
Action image (icon) attribute UI update

### DIFF
--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -128,6 +128,7 @@ class _MenuItem(HasTraits):
         action.on_trait_change(self._on_action_accelerator_changed,
                                'accelerator')
         action.on_trait_change(self._on_action_image_changed, 'image')
+        action.on_trait_change(self._on_action_tooltip_changed, 'tooltip')
 
         # Detect if the control is destroyed.
         self.control.destroyed.connect(self._qt4_on_destroyed)
@@ -149,6 +150,8 @@ class _MenuItem(HasTraits):
         action.on_trait_change(self._on_action_accelerator_changed,
             'accelerator', remove=True)
         action.on_trait_change(self._on_action_image_changed, 'image',
+            remove=True)
+        action.on_trait_change(self._on_action_tooltip_changed, 'tooltip',
             remove=True)
 
     ###########################################################################
@@ -251,6 +254,11 @@ class _MenuItem(HasTraits):
         if self.control is not None:
             self.control.setIcon(action.image.create_icon())
 
+    def _on_action_tooltip_changed(self, action, trait_name, old, new):
+        """ Called when the accelerator trait is changed on an action. """
+        if self.control is not None:
+            self.control.setToolTip(action.tooltip)
+
 
 class _Tool(HasTraits):
     """ A tool bar tool representation of an action item. """
@@ -337,6 +345,7 @@ class _Tool(HasTraits):
         action.on_trait_change(self._on_action_accelerator_changed,
                                'accelerator')
         action.on_trait_change(self._on_action_image_changed, 'image')
+        action.on_trait_change(self._on_action_tooltip_changed, 'tooltip')
 
         # Detect if the control is destroyed.
         self.control.destroyed.connect(self._qt4_on_destroyed)
@@ -443,6 +452,11 @@ class _Tool(HasTraits):
             self.control.setIcon(
                 action.image.create_icon((size.width(), size.height()))
             )
+
+    def _on_action_tooltip_changed(self, action, trait_name, old, new):
+        """ Called when the accelerator trait is changed on an action. """
+        if self.control is not None:
+            self.control.setToolTip(action.tooltip)
 
 
 class _PaletteTool(HasTraits):

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -127,6 +127,7 @@ class _MenuItem(HasTraits):
         action.on_trait_change(self._on_action_name_changed, 'name')
         action.on_trait_change(self._on_action_accelerator_changed,
                                'accelerator')
+        action.on_trait_change(self._on_action_image_changed, 'image')
 
         # Detect if the control is destroyed.
         self.control.destroyed.connect(self._qt4_on_destroyed)
@@ -147,6 +148,8 @@ class _MenuItem(HasTraits):
             remove=True)
         action.on_trait_change(self._on_action_accelerator_changed,
             'accelerator', remove=True)
+        action.on_trait_change(self._on_action_image_changed, 'image',
+            remove=True)
 
     ###########################################################################
     # Private interface.
@@ -242,6 +245,11 @@ class _MenuItem(HasTraits):
         """ Called when the accelerator trait is changed on an action. """
         if self.control is not None:
             self.control.setShortcut(action.accelerator)
+
+    def _on_action_image_changed(self, action, trait_name, old, new):
+        """ Called when the accelerator trait is changed on an action. """
+        if self.control is not None:
+            self.control.setIcon(action.image.create_icon())
 
 
 class _Tool(HasTraits):

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -336,6 +336,7 @@ class _Tool(HasTraits):
         action.on_trait_change(self._on_action_name_changed, 'name')
         action.on_trait_change(self._on_action_accelerator_changed,
                                'accelerator')
+        action.on_trait_change(self._on_action_image_changed, 'image')
 
         # Detect if the control is destroyed.
         self.control.destroyed.connect(self._qt4_on_destroyed)
@@ -434,6 +435,14 @@ class _Tool(HasTraits):
         """ Called when the accelerator trait is changed on an action. """
         if self.control is not None:
             self.control.setShortcut(action.accelerator)
+
+    def _on_action_image_changed(self, action, trait_name, old, new):
+        """ Called when the accelerator trait is changed on an action. """
+        if self.control is not None:
+            size = self.tool_bar.iconSize()
+            self.control.setIcon(
+                action.image.create_icon((size.width(), size.height()))
+            )
 
 
 class _PaletteTool(HasTraits):

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -118,6 +118,7 @@ class _Menu(QtGui.QMenu):
         self._manager.on_trait_change(self._on_enabled_changed, 'enabled')
         self._manager.on_trait_change(self._on_visible_changed, 'visible')
         self._manager.on_trait_change(self._on_name_changed, 'name')
+        self._manager.on_trait_change(self._on_image_changed, 'image')
         self.setEnabled(self._manager.enabled)
         self.menuAction().setVisible(self._manager.visible)
 
@@ -132,7 +133,7 @@ class _Menu(QtGui.QMenu):
 
         for item in self.menu_items:
             item.dispose()
-            
+
         self.menu_items = []
 
         super(_Menu, self).clear()
@@ -186,6 +187,13 @@ class _Menu(QtGui.QMenu):
         """ Dynamic trait change handler. """
 
         self.menuAction().setText(new)
+
+        return
+
+    def _on_image_changed(self, obj, trait_name, old, new):
+        """ Dynamic trait change handler. """
+
+        self.menuAction().setIcon(new.create_icon())
 
         return
 

--- a/pyface/ui/wx/action/action_item.py
+++ b/pyface/ui/wx/action/action_item.py
@@ -133,6 +133,7 @@ class _MenuItem(HasTraits):
         action.on_trait_change(self._on_action_visible_changed, 'visible')
         action.on_trait_change(self._on_action_checked_changed, 'checked')
         action.on_trait_change(self._on_action_name_changed, 'name')
+        action.on_trait_change(self._on_action_image_changed, 'image')
 
         if controller is not None:
             self.controller = controller
@@ -241,6 +242,14 @@ class _MenuItem(HasTraits):
         if len(action.accelerator) > 0:
             label = label + '\t' + action.accelerator
         self.control.SetText(label)
+
+        return
+
+    def _on_action_image_changed(self, action, trait_name, old, new):
+        """ Called when the name trait is changed on an action. """
+
+        if self.control is not None:
+            self.control.SetIcon(action.image.create_icon())
 
         return
 


### PR DESCRIPTION
This PR approaches #483 

We add `_on_action_image_changed` to the Qt `_MenuItem`, `_Tool` and `_Menu`, and to the wx `_MenuItem`. We add `_on_action_tooltip_changed` to the Qt `_MenuItem` and `_Tool`.

### Done

- Implemented the `_on_action_image_changed` method that sets the control icon to the icon provided by the `action.image.create_icon()`.
- Implemented the `_on_action_tooltip_changed` method that sets the tooltip provided by the `action.tooltip`.