### PR TITLE
More fixes for wxpython 4

### DIFF
--- a/pyface/dock/dock_window_shell.py
+++ b/pyface/dock/dock_window_shell.py
@@ -196,3 +196,5 @@ class DockWindowShell(HasPrivateTraits):
         if 0 < len(section.contents) < n:
             window.Layout()
             window.Refresh()
+
+        self.control.Unbind(wx.EVT_CLOSE)

--- a/pyface/ui/wx/image_button.py
+++ b/pyface/ui/wx/image_button.py
@@ -223,7 +223,7 @@ class ImageButton(Widget):
                     g = data[:, 0] + data[:, 1] + data[:, 2]
                     data[:, 0] = data[:, 1] = data[:, 2] = g
                     img.SetData(ravel(data.astype(dtype("uint8"))).tostring())
-                    img.SetColour(0, 0, 0)
+                    img.SetMaskColour(0, 0, 0)
                     self._mono_image = img.ConvertToBitmap()
                     self._img = None
                 image = self._mono_image

--- a/pyface/ui/wx/python_editor.py
+++ b/pyface/ui/wx/python_editor.py
@@ -259,6 +259,13 @@ class PythonEditor(MPythonEditor, Widget):
 
         return stc
 
+    def destroy(self):
+        """ Destroy the toolkit control. """
+        if self.control is not None:
+            self.control.Unbind(wx.stc.EVT_STC_CHANGE)
+            self.control.Unbind(wx.EVT_CHAR)
+        super().destroy()
+
     # wx event handlers ----------------------------------------------------
 
     def _on_stc_changed(self, event):


### PR DESCRIPTION
A few more fixes for wxPython 4.  The most important is the change to the `SetColour` call in the `ImageButton` class which was breaking the TraitsUI `ButtonEditor`.