### PR TITLE
[WIP] Deprecate trait_name in favor of attr_name

### DIFF
--- a/pyface/tree/trait_dict_node_type.py
+++ b/pyface/tree/trait_dict_node_type.py
@@ -11,7 +11,7 @@
 
 import warnings
 
-from traits.api import Any, Str, on_trait_change
+from traits.api import Any, Str, Property
 
 
 from .node_type import NodeType
@@ -38,7 +38,7 @@ class TraitDictNodeType(NodeType):
 
     # The trait name.
     # Deprecated. Use 'attr_name' instead.
-    trait_name = Str()
+    trait_name = Property(Str())
 
     # Name of the trait to be used.
     attr_name = Str()
@@ -79,8 +79,7 @@ class TraitDictNodeType(NodeType):
 
         return self.text
 
-    @on_trait_change("trait_name")
-    def _deprecate_trait_name(self, new):
+    def _get_trait_name(self):
         warnings.warn(
             (
                 "'trait_name' on {} is deprecated. "
@@ -88,4 +87,14 @@ class TraitDictNodeType(NodeType):
             ),
             DeprecationWarning,
         )
-        self.attr_name = new
+        return self.attr_name
+
+    def _set_trait_name(self, value):
+        warnings.warn(
+            (
+                "'trait_name' on {} is deprecated. "
+                "Use 'attr_name' instead.".format(type(self).__name__)
+            ),
+            DeprecationWarning,
+        )
+        self.attr_name = value

--- a/pyface/tree/trait_dict_node_type.py
+++ b/pyface/tree/trait_dict_node_type.py
@@ -9,12 +9,21 @@
 # Thanks for using Enthought open source!
 """ The node type for a trait dictionary. """
 
+import warnings
 
-from traits.api import Any, Str
+from traits.api import Any, Str, on_trait_change
 
 
 from .node_type import NodeType
 
+warnings.filterwarnings(
+    "ignore",
+    message=(
+        r".*The attribute named 'trait_name' of class TraitDictNodeType .*"
+    ),
+    category=Warning,
+    module=".*pyface.tree.trait_dict_node_type.*",
+)
 
 class TraitDictNodeType(NodeType):
     """ The node type for a trait dictionary. """
@@ -28,7 +37,11 @@ class TraitDictNodeType(NodeType):
     text = Str()
 
     # The trait name.
+    # Deprecated. Use 'attr_name' instead.
     trait_name = Str()
+
+    # Name of the trait to be used.
+    attr_name = Str()
 
     # ------------------------------------------------------------------------
     # 'NodeType' interface.
@@ -41,7 +54,7 @@ class TraitDictNodeType(NodeType):
             isinstance(node, dict)
             and hasattr(node, "object")
             and isinstance(node.object, self.klass)
-            and node.name == self.trait_name
+            and node.name == self.attr_name
         )
 
         return is_type_for
@@ -65,3 +78,14 @@ class TraitDictNodeType(NodeType):
         """ Returns the label text for a node. """
 
         return self.text
+
+    @on_trait_change("trait_name")
+    def _deprecate_trait_name(self, new):
+        warnings.warn(
+            (
+                "'trait_name' on {} is deprecated. "
+                "Use 'attr_name' instead.".format(type(self).__name__)
+            ),
+            DeprecationWarning,
+        )
+        self.attr_name = new

--- a/pyface/tree/trait_list_node_type.py
+++ b/pyface/tree/trait_list_node_type.py
@@ -11,7 +11,7 @@
 
 import warnings
 
-from traits.api import Any, Str, on_trait_change
+from traits.api import Any, Str, Property
 
 
 from .node_type import NodeType
@@ -40,7 +40,7 @@ class TraitListNodeType(NodeType):
 
     # The trait name.
     # Deprecated. Use 'attr_name' instead.
-    trait_name = Str()
+    trait_name = Property(Str())
 
     # Name of the trait to be used.
     attr_name = Str()
@@ -81,8 +81,7 @@ class TraitListNodeType(NodeType):
 
         return self.text
 
-    @on_trait_change("trait_name")
-    def _deprecate_trait_name(self, new):
+    def _get_trait_name(self):
         warnings.warn(
             (
                 "'trait_name' on {} is deprecated. "
@@ -90,4 +89,14 @@ class TraitListNodeType(NodeType):
             ),
             DeprecationWarning,
         )
-        self.attr_name = new
+        return self.attr_name
+
+    def _set_trait_name(self, value):
+        warnings.warn(
+            (
+                "'trait_name' on {} is deprecated. "
+                "Use 'attr_name' instead.".format(type(self).__name__)
+            ),
+            DeprecationWarning,
+        )
+        self.attr_name = value

--- a/pyface/tree/trait_list_node_type.py
+++ b/pyface/tree/trait_list_node_type.py
@@ -9,11 +9,22 @@
 # Thanks for using Enthought open source!
 """ The node type for a trait list. """
 
+import warnings
 
-from traits.api import Any, Str
+from traits.api import Any, Str, on_trait_change
 
 
 from .node_type import NodeType
+
+
+warnings.filterwarnings(
+    "ignore",
+    message=(
+        r".*The attribute named 'trait_name' of class TraitListNodeType .*"
+    ),
+    category=Warning,
+    module=".*pyface.tree.trait_list_node_type.*",
+)
 
 
 class TraitListNodeType(NodeType):
@@ -27,8 +38,12 @@ class TraitListNodeType(NodeType):
     # The label text.
     text = Str()
 
-    # The name of the trait.
+    # The trait name.
+    # Deprecated. Use 'attr_name' instead.
     trait_name = Str()
+
+    # Name of the trait to be used.
+    attr_name = Str()
 
     # ------------------------------------------------------------------------
     # 'NodeType' interface.
@@ -41,7 +56,7 @@ class TraitListNodeType(NodeType):
             isinstance(node, list)
             and hasattr(node, "object")
             and isinstance(node.object, self.klass)
-            and node.name == self.trait_name
+            and node.name == self.attr_name
         )
 
         return is_type_for
@@ -65,3 +80,14 @@ class TraitListNodeType(NodeType):
         """ Returns the label text for a node. """
 
         return self.text
+
+    @on_trait_change("trait_name")
+    def _deprecate_trait_name(self, new):
+        warnings.warn(
+            (
+                "'trait_name' on {} is deprecated. "
+                "Use 'attr_name' instead.".format(type(self).__name__)
+            ),
+            DeprecationWarning,
+        )
+        self.attr_name = new

--- a/pyface/ui/wx/grid/trait_grid_model.py
+++ b/pyface/ui/wx/grid/trait_grid_model.py
@@ -29,7 +29,7 @@ from traits.api import (
     Instance,
     Int,
     List,
-    on_trait_change,
+    Property,
     Str,
     Type,
 )
@@ -82,13 +82,12 @@ class TraitGridSelection(HasTraits):
 
     # The trait name.
     # Deprecated. Use 'attr_name' instead.
-    trait_name = Str()
+    trait_name = Property(Str())
 
     # Name of the trait to be used.
     attr_name = Str()
 
-    @on_trait_change("trait_name")
-    def _deprecate_trait_name(self, new):
+    def _get_trait_name(self):
         warnings.warn(
             (
                 "'trait_name' on {} is deprecated. "
@@ -96,7 +95,17 @@ class TraitGridSelection(HasTraits):
             ),
             DeprecationWarning,
         )
-        self.attr_name = new
+        return self.attr_name
+
+    def _set_trait_name(self, value):
+        warnings.warn(
+            (
+                "'trait_name' on {} is deprecated. "
+                "Use 'attr_name' instead.".format(type(self).__name__)
+            ),
+            DeprecationWarning,
+        )
+        self.attr_name = value
 
 
 # The meat.


### PR DESCRIPTION
The name of `trait_name` runs the risk overshadowing methods introduced by traits. cf. enthought/traits#705 and the related issues.

This PR proposes deprecating `trait_name` in a number of objects for viewing objects in a grid.
These classes only support wx and have not been CI-tested, but the `examples/grid.py` exercises them.

Opened for discussion, hence marked as WIP.