### PR TITLE
Timed messages in StatusBar

### DIFF
--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -225,6 +225,31 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         with self.event_loop():
             self.window.close()
 
+    def test_statusbar_timed_changed(self):
+        from time import sleep
+
+        # test that status bar gets changed as expected
+        self.window.status_bar_manager = StatusBarManager(
+            message="hello world"
+        )
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            duration = 0.3
+            status_bar = self.window.status_bar_manager
+            status_bar.message_duration_sec = duration
+            status_bar.messages = ["goodbye world"]
+            self.assertEqual(status_bar.message, "goodbye world")
+            sleep(duration)
+            self.gui.process_events()
+            self.assertEqual(status_bar.message, "")
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
+
     def test_icon(self):
         # test that status bar gets created as expected
         self.window.icon = ImageResource("core")

--- a/pyface/ui/qt4/action/status_bar_manager.py
+++ b/pyface/ui/qt4/action/status_bar_manager.py
@@ -17,7 +17,7 @@
 from pyface.qt import QtGui
 
 
-from traits.api import Any, Bool, HasTraits, Int, List, Property, Str
+from traits.api import Any, Bool, Float, HasTraits, List, Property, Str
 
 
 class StatusBarManager(HasTraits):
@@ -38,8 +38,8 @@ class StatusBarManager(HasTraits):
     # Whether the status bar is visible.
     visible = Bool(True)
 
-    # Number of millisecond to display new messages for [default: indefinitely]
-    message_duration = Int
+    # Number of seconds to display new messages for [default: indefinitely]
+    message_duration_sec = Float
 
     # ------------------------------------------------------------------------
     # 'StatusBarManager' interface.
@@ -52,11 +52,7 @@ class StatusBarManager(HasTraits):
             self.status_bar = QtGui.QStatusBar(parent)
             self.status_bar.setSizeGripEnabled(self.size_grip)
             self.status_bar.setVisible(self.visible)
-
-            if len(self.messages) > 1:
-                self._show_messages()
-            else:
-                self.status_bar.showMessage(self.message)
+            self._show_messages()
 
         return self.status_bar
 
@@ -130,4 +126,4 @@ class StatusBarManager(HasTraits):
         # probably also need to extend the API to allow a "message" to be a
         # widget - depends on what wx is capable of.
         self.status_bar.showMessage("  ".join(self.messages),
-                                    msecs=self.message_duration)
+                                    msecs=self.message_duration_sec * 1000)

--- a/pyface/ui/qt4/action/status_bar_manager.py
+++ b/pyface/ui/qt4/action/status_bar_manager.py
@@ -63,6 +63,10 @@ class StatusBarManager(HasTraits):
     def destroy_status_bar(self):
         """ Destroys the status bar. """
         if self.status_bar is not None:
+            if self._timer is not None:
+                self._timer.Stop()
+                self._timer = None
+
             self.status_bar.deleteLater()
             self.status_bar = None
 

--- a/pyface/ui/qt4/action/status_bar_manager.py
+++ b/pyface/ui/qt4/action/status_bar_manager.py
@@ -17,7 +17,9 @@
 from pyface.qt import QtGui
 
 
-from traits.api import Any, Bool, Float, HasTraits, List, Property, Str
+from traits.api import Any, Bool, Float, HasTraits, Instance, List, Property, \
+    Str
+from pyface.timer.api import Timer
 
 
 class StatusBarManager(HasTraits):
@@ -40,6 +42,8 @@ class StatusBarManager(HasTraits):
 
     # Number of seconds to display new messages for [default: indefinitely]
     message_duration_sec = Float
+
+    _timer = Instance(Timer)
 
     # ------------------------------------------------------------------------
     # 'StatusBarManager' interface.
@@ -67,7 +71,6 @@ class StatusBarManager(HasTraits):
     # ------------------------------------------------------------------------
 
     def _get_message(self):
-
         if len(self.messages) > 0:
             message = self.messages[0]
         else:
@@ -119,11 +122,25 @@ class StatusBarManager(HasTraits):
     # ------------------------------------------------------------------------
 
     def _show_messages(self):
-        """ Display the list of messages. """
+        """ Display the list of messages.
+
+        Note: not using the msecs argument of the `status_bar.showNessage`
+        method to keep this class' message trait in sync with the Qt widget.
+        """
+        def timed_action():
+            self.messages = []
+            self._timer.Stop()
+            self._timer = None
+
+        if self.status_bar is None:
+            return
 
         # FIXME v3: At the moment we just string them together but we may
         # decide to put all but the first message into separate widgets.  We
         # probably also need to extend the API to allow a "message" to be a
         # widget - depends on what wx is capable of.
-        self.status_bar.showMessage("  ".join(self.messages),
-                                    msecs=self.message_duration_sec * 1000)
+        self.status_bar.showMessage("  ".join(self.messages))
+
+        # Schedule removing the message if needed:
+        if self.message_duration_sec > 0 and self._timer is None:
+            self._timer = Timer(self.message_duration_sec * 1000, timed_action)

--- a/pyface/ui/qt4/action/status_bar_manager.py
+++ b/pyface/ui/qt4/action/status_bar_manager.py
@@ -17,7 +17,7 @@
 from pyface.qt import QtGui
 
 
-from traits.api import Any, Bool, HasTraits, List, Property, Str
+from traits.api import Any, Bool, HasTraits, Int, List, Property, Str
 
 
 class StatusBarManager(HasTraits):
@@ -37,6 +37,9 @@ class StatusBarManager(HasTraits):
 
     # Whether the status bar is visible.
     visible = Bool(True)
+
+    # Number of millisecond to display new messages for [default: indefinitely]
+    message_duration = Int
 
     # ------------------------------------------------------------------------
     # 'StatusBarManager' interface.
@@ -126,4 +129,5 @@ class StatusBarManager(HasTraits):
         # decide to put all but the first message into separate widgets.  We
         # probably also need to extend the API to allow a "message" to be a
         # widget - depends on what wx is capable of.
-        self.status_bar.showMessage("  ".join(self.messages))
+        self.status_bar.showMessage("  ".join(self.messages),
+                                    msecs=self.message_duration)

--- a/pyface/ui/wx/action/status_bar_manager.py
+++ b/pyface/ui/wx/action/status_bar_manager.py
@@ -101,7 +101,7 @@ class StatusBarManager(HasTraits):
         """ Sets the text displayed on the status bar. """
 
         def timed_action():
-            self.message = ""
+            self.messages = []
             self._timer.Stop()
             self._timer = None
 

--- a/pyface/ui/wx/action/status_bar_manager.py
+++ b/pyface/ui/wx/action/status_bar_manager.py
@@ -16,7 +16,9 @@
 import wx
 
 
-from traits.api import Any, HasTraits, List, Property, Str
+from traits.api import Any, Float, HasTraits, Instance, List, on_trait_change,\
+    Property, Str
+from pyface.timer.api import Timer
 
 
 class StatusBarManager(HasTraits):
@@ -31,22 +33,24 @@ class StatusBarManager(HasTraits):
     # The toolkit-specific control that represents the status bar.
     status_bar = Any()
 
+    # Number of seconds to display new messages for [default: indefinitely]
+    message_duration_sec = Float
+
+    _timer = Instance(Timer)
+
     # ------------------------------------------------------------------------
     # 'StatusBarManager' interface.
     # ------------------------------------------------------------------------
 
     def create_status_bar(self, parent):
         """ Creates a status bar. """
-
         if self.status_bar is None:
             self.status_bar = wx.StatusBar(parent)
             self.status_bar._pyface_control = self
             if len(self.messages) > 1:
                 self.status_bar.SetFieldsCount(len(self.messages))
-                for i in range(len(self.messages)):
-                    self.status_bar.SetStatusText(self.messages[i], i)
-            else:
-                self.status_bar.SetStatusText(self.message)
+
+            self.messages_changed()
 
         return self.status_bar
 
@@ -92,18 +96,21 @@ class StatusBarManager(HasTraits):
     # Trait event handlers.
     # ------------------------------------------------------------------------
 
-    def _messages_changed(self):
+    @on_trait_change("messages[]", post_init=True)
+    def messages_changed(self):
         """ Sets the text displayed on the status bar. """
 
-        if self.status_bar is not None:
-            for i in range(len(self.messages)):
-                self.status_bar.SetStatusText(self.messages[i], i)
+        def timed_action():
+            self.message = ""
+            self._timer.Stop()
+            self._timer = None
 
-    def _messages_items_changed(self):
-        """ Sets the text displayed on the status bar. """
+        if self.status_bar is None:
+            return
 
-        if self.status_bar is not None:
-            for i in range(len(self.messages)):
-                self.status_bar.SetStatusText(self.messages[i], i)
+        for i in range(len(self.messages)):
+            self.status_bar.SetStatusText(self.messages[i], i)
 
-        return
+        # Schedule removing the message if needed:
+        if self.message_duration_sec > 0 and self._timer is None:
+            self._timer = Timer(self.message_duration_sec * 1000, timed_action)

--- a/pyface/ui/wx/action/status_bar_manager.py
+++ b/pyface/ui/wx/action/status_bar_manager.py
@@ -58,6 +58,10 @@ class StatusBarManager(HasTraits):
         """ Removes a status bar. """
 
         if self.status_bar is not None:
+            if self._timer is not None:
+                self._timer.Stop()
+                self._timer = None
+
             self.status_bar.Destroy()
             self.status_bar._pyface_control = None
             self.status_bar = None


### PR DESCRIPTION
This PR exposes the ability to control the duration of a StatusBar message (qt only for now). I am creating this PR to start the discussion:
- Would others agree that this is desirable? 
- How to handle Wx since its `wx.StatusBar` doesn't expose the same ability? What's `pyface`'s policy for exposing toolkit specific capabilities? If that's not acceptable, a similar behavior could be implemented using a `wx.Timer`: https://stackoverflow.com/questions/23188042/wxpython-statusbar-temporary-text . That feels like a lot of complexity brought into pyface though.