### PR TITLE
Audit qt dialogs connections

### DIFF
--- a/pyface/tests/test_progress_dialog.py
+++ b/pyface/tests/test_progress_dialog.py
@@ -56,6 +56,14 @@ class TestProgressDialog(unittest.TestCase, GuiTestAssistant):
         with self.event_loop():
             self.dialog.destroy()
 
+    def test_can_ok(self):
+        # test that creation works with can_ok
+        self.dialog.can_ok = True
+        with self.event_loop():
+            self.dialog._create()
+        with self.event_loop():
+            self.dialog.destroy()
+
     def test_show_time(self):
         # test that creation works with show_time
         self.dialog.show_time = True

--- a/pyface/ui/qt4/about_dialog.py
+++ b/pyface/ui/qt4/about_dialog.py
@@ -71,6 +71,17 @@ class AboutDialog(MAboutDialog, Dialog):
 
     image = Instance(ImageResource, ImageResource("about"))
 
+    # -------------------------------------------------------------------------
+    # 'IWidget' interface.
+    # -------------------------------------------------------------------------
+
+    def destroy(self):
+        if self.control is not None:
+            buttons = self.control.findChild(QtGui.QDialogButtonBox)
+            buttons.accepted.disconnect(self.control.accept)
+
+        super(Dialog, self).destroy()
+
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.
     # ------------------------------------------------------------------------

--- a/pyface/ui/qt4/about_dialog.py
+++ b/pyface/ui/qt4/about_dialog.py
@@ -80,7 +80,7 @@ class AboutDialog(MAboutDialog, Dialog):
             buttons = self.control.findChild(QtGui.QDialogButtonBox)
             buttons.accepted.disconnect(self.control.accept)
 
-        super(Dialog, self).destroy()
+        super(AboutDialog, self).destroy()
 
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.

--- a/pyface/ui/qt4/about_dialog.py
+++ b/pyface/ui/qt4/about_dialog.py
@@ -83,10 +83,9 @@ class AboutDialog(MAboutDialog, Dialog):
     # -------------------------------------------------------------------------
 
     def destroy(self):
-        if self.control is not None:
-            while self._connections_to_remove:
-                signal, handler = self._connections_to_remove.pop()
-                signal.disconnect(handler)
+        while self._connections_to_remove:
+            signal, handler = self._connections_to_remove.pop()
+            signal.disconnect(handler)
 
         super(AboutDialog, self).destroy()
 

--- a/pyface/ui/qt4/dialog.py
+++ b/pyface/ui/qt4/dialog.py
@@ -153,10 +153,9 @@ class Dialog(MDialog, Window):
     # -------------------------------------------------------------------------
 
     def destroy(self):
-        if self.control is not None:
-            while self._connections_to_remove:
-                signal, handler = self._connections_to_remove.pop()
-                signal.disconnect(handler)
+        while self._connections_to_remove:
+            signal, handler = self._connections_to_remove.pop()
+            signal.disconnect(handler)
 
         super(Dialog, self).destroy()
 

--- a/pyface/ui/qt4/dialog.py
+++ b/pyface/ui/qt4/dialog.py
@@ -15,8 +15,9 @@
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Bool, Enum, Int, provides, Str
-
+from traits.api import (
+    Any, Bool, Callable, Enum, Int, List, provides, Str, Tuple
+)
 
 from pyface.i_dialog import IDialog, MDialog
 from pyface.constant import OK, CANCEL, YES, NO
@@ -60,6 +61,13 @@ class Dialog(MDialog, Window):
 
     title = Str("Dialog")
 
+    # Private interface ---------------------------------------------------#
+
+    #: A list of connected Qt signals to be removed before destruction.
+    #: First item in the tuple is the Qt signal. The second item is the event
+    #: handler.
+    _connections_to_remove = List(Tuple(Any, Callable))
+
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.
     # ------------------------------------------------------------------------
@@ -77,6 +85,7 @@ class Dialog(MDialog, Window):
 
         btn.setDefault(True)
         btn.clicked.connect(self.control.accept)
+        self._connections_to_remove.append((btn.clicked, self.control.accept))
 
         # 'Cancel' button.
         if self.cancel_label:
@@ -87,6 +96,7 @@ class Dialog(MDialog, Window):
             btn = buttons.addButton(QtGui.QDialogButtonBox.Cancel)
 
         btn.clicked.connect(self.control.reject)
+        self._connections_to_remove.append((btn.clicked, self.control.reject))
 
         # 'Help' button.
         # FIXME v3: In the original code the only possible hook into the help
@@ -138,6 +148,18 @@ class Dialog(MDialog, Window):
         retval = dialog.exec_()
         return _RESULT_MAP[retval]
 
+    # -------------------------------------------------------------------------
+    # 'IWidget' interface.
+    # -------------------------------------------------------------------------
+
+    def destroy(self):
+        if self.control is not None:
+            while self._connections_to_remove:
+                signal, handler = self._connections_to_remove.pop()
+                signal.disconnect(handler)
+
+        super(Dialog, self).destroy()
+
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.
     # ------------------------------------------------------------------------
@@ -149,6 +171,9 @@ class Dialog(MDialog, Window):
         # MDialog's open method. For 'nonmodal', we do it here.
         if self.style == "nonmodal":
             dlg.finished.connect(self._finished_fired)
+            self._connections_to_remove.append(
+                (dlg.finished, self._finished_fired)
+            )
 
         if self.size != (-1, -1):
             dlg.resize(*self.size)

--- a/pyface/ui/qt4/progress_dialog.py
+++ b/pyface/ui/qt4/progress_dialog.py
@@ -98,6 +98,20 @@ class ProgressDialog(MProgressDialog, Window):
         super(ProgressDialog, self).close()
 
     # -------------------------------------------------------------------------
+    # 'IWidget' interface.
+    # -------------------------------------------------------------------------
+
+    def destroy(self):
+        if self.control is not None:
+            buttons = self.control.findChild(QtGui.QDialogButtonBox)
+            if self.can_cancel:
+                buttons.rejected.disconnect(self.control.reject)
+            if self.can_ok:
+                buttons.accepted.disconnect(self.control.accept)
+
+        super(ProgressDialog, self).destroy()
+
+    # -------------------------------------------------------------------------
     # IProgressDialog Interface
     # -------------------------------------------------------------------------
 

--- a/pyface/ui/qt4/progress_dialog.py
+++ b/pyface/ui/qt4/progress_dialog.py
@@ -111,10 +111,9 @@ class ProgressDialog(MProgressDialog, Window):
     # -------------------------------------------------------------------------
 
     def destroy(self):
-        if self.control is not None:
-            while self._connections_to_remove:
-                signal, handler = self._connections_to_remove.pop()
-                signal.disconnect(handler)
+        while self._connections_to_remove:
+            signal, handler = self._connections_to_remove.pop()
+            signal.disconnect(handler)
 
         super(ProgressDialog, self).destroy()
 


### PR DESCRIPTION
Part of #258 

Adds additional cleanup (disconnecting qt signals) to `destroy` methods of some qt dialogs.

Also adds one additional smoke test for `ProgressDialog`.