### PR TITLE
Disconnect qt PythonShell downstream widget signals

### DIFF
--- a/pyface/ui/qt4/console/bracket_matcher.py
+++ b/pyface/ui/qt4/console/bracket_matcher.py
@@ -42,6 +42,15 @@ class BracketMatcher(QtCore.QObject):
         text_edit.cursorPositionChanged.connect(self._cursor_position_changed)
 
     # --------------------------------------------------------------------------
+    # Public interface
+    # --------------------------------------------------------------------------
+
+    def disconnect_event_listeners(self):
+        self._text_edit.cursorPositionChanged.disconnect(
+            self._cursor_position_changed
+        )
+
+    # --------------------------------------------------------------------------
     # Protected interface
     # --------------------------------------------------------------------------
 

--- a/pyface/ui/qt4/console/bracket_matcher.py
+++ b/pyface/ui/qt4/console/bracket_matcher.py
@@ -41,11 +41,7 @@ class BracketMatcher(QtCore.QObject):
         self._text_edit = text_edit
         text_edit.cursorPositionChanged.connect(self._cursor_position_changed)
 
-    # --------------------------------------------------------------------------
-    # Public interface
-    # --------------------------------------------------------------------------
-
-    def disconnect_event_listeners(self):
+    def _remove_event_listeners(self):
         self._text_edit.cursorPositionChanged.disconnect(
             self._cursor_position_changed
         )

--- a/pyface/ui/qt4/console/console_widget.py
+++ b/pyface/ui/qt4/console/console_widget.py
@@ -349,6 +349,10 @@ class ConsoleWidget(QtGui.QWidget):
 
         return QtCore.QSize(width, height)
 
+    # ---------------------------------------------------------------------------
+    # 'ConsoleWidget' public interface
+    # ---------------------------------------------------------------------------
+
     def can_copy(self):
         """ Returns whether text can be copied to the clipboard.
         """

--- a/pyface/ui/qt4/console/console_widget.py
+++ b/pyface/ui/qt4/console/console_widget.py
@@ -122,11 +122,6 @@ class ConsoleWidget(QtGui.QWidget):
         [QtCore.Qt.Key_C, QtCore.Qt.Key_G, QtCore.Qt.Key_O, QtCore.Qt.Key_V]
     )
 
-    #: A list of connected Qt signals to be removed before destruction.
-    #: First item in the tuple is the Qt signal. The second item is the event
-    #: handler.
-    _connections_to_remove = []
-
     # ---------------------------------------------------------------------------
     # 'QObject' interface
     # ---------------------------------------------------------------------------
@@ -140,6 +135,11 @@ class ConsoleWidget(QtGui.QWidget):
             The parent for this widget.
         """
         super(ConsoleWidget, self).__init__(parent)
+
+        # A list of connected Qt signals to be removed before destruction.
+        # First item in the tuple is the Qt signal. The second item is the
+        # event handler.
+        self._connections_to_remove = []
 
         # Create the layout and underlying text widget.
         layout = QtGui.QStackedLayout(self)

--- a/pyface/ui/qt4/console/console_widget.py
+++ b/pyface/ui/qt4/console/console_widget.py
@@ -1099,9 +1099,8 @@ class ConsoleWidget(QtGui.QWidget):
         layout = control.document().documentLayout()
         layout.documentSizeChanged.disconnect()
         layout.documentSizeChanged.connect(self._adjust_scrollbars)
-        self._connections_to_remove.append(
-            (layout.documentSizeChanged, self._adjust_scrollbars)
-        )
+        # The document layout doesn't stay the same therefore its signal is
+        # not explicitly disconnected on destruction
 
         # Configure the control.
         control.setContextMenuPolicy(QtCore.Qt.CustomContextMenu)

--- a/pyface/ui/qt4/console/console_widget.py
+++ b/pyface/ui/qt4/console/console_widget.py
@@ -340,6 +340,28 @@ class ConsoleWidget(QtGui.QWidget):
     # 'ConsoleWidget' public interface
     # ---------------------------------------------------------------------------
 
+    def disconnect_event_listeners(self):
+        # Disconnect signals from __init__
+        for action in self.actions():
+            action_text = action.text()
+            if action_text == "Print":
+                action.triggered.disconnect(self.print_)
+            elif action_text == "Save as HTML/XML":
+                action.triggered.disconnect(self.export)
+            elif action_text == "Select All":
+                action.triggered.disconnect(self.select_all)
+        # Disconnect signals from _create_control
+        control = self._control
+        control.cursorPositionChanged.disconnect(self._cursor_position_changed)
+        control.customContextMenuRequested.disconnect(
+            self._custom_context_menu_requested
+        )
+        control.copyAvailable.disconnect(self.copy_available)
+        control.redoAvailable.disconnect(self.redo_available)
+        control.undoAvailable.disconnect(self.undo_available)
+        layout = control.document().documentLayout()
+        layout.documentSizeChanged.disconnect(self._adjust_scrollbars)
+
     def can_copy(self):
         """ Returns whether text can be copied to the clipboard.
         """

--- a/pyface/ui/qt4/python_shell.py
+++ b/pyface/ui/qt4/python_shell.py
@@ -118,8 +118,10 @@ class PythonShell(MPythonShell, Widget):
     def _remove_event_listeners(self):
         if self.control is not None:
             # Disconnect signals for events.
-            self.control.executed.connect(self._on_command_executed)
+            self.control.executed.disconnect(self._on_command_executed)
             self._event_filter.signal.disconnect(self._on_obj_drop)
+
+            self.control.disconnect_event_listeners()
 
         super(PythonShell, self)._remove_event_listeners()
 
@@ -237,6 +239,17 @@ class PythonWidget(HistoryConsoleWidget):
         for line in lines:
             self.write(line, refresh=refresh)
 
+    # ---------------------------------------------------------------------------
+    # 'ConsoleWidget' public interface
+    # ---------------------------------------------------------------------------
+    def disconnect_event_listeners(self):
+        self.font_changed.disconnect(self._call_tip_widget.setFont)
+        document = self._control.document()
+        document.contentsChange.disconnect(self._document_contents_change)
+
+        self._bracket_matcher.disconnect_event_listeners()
+
+        super(PythonWidget, self).disconnect_event_listeners()
     # ---------------------------------------------------------------------------
     # 'ConsoleWidget' abstract interface
     # ---------------------------------------------------------------------------

--- a/pyface/ui/qt4/python_shell.py
+++ b/pyface/ui/qt4/python_shell.py
@@ -121,7 +121,7 @@ class PythonShell(MPythonShell, Widget):
             self.control.executed.disconnect(self._on_command_executed)
             self._event_filter.signal.disconnect(self._on_obj_drop)
 
-            self.control.disconnect_event_listeners()
+            self.control._remove_event_listeners()
 
         super(PythonShell, self)._remove_event_listeners()
 
@@ -202,6 +202,15 @@ class PythonWidget(HistoryConsoleWidget):
         # Display the banner and initial prompt.
         self.reset()
 
+    def _remove_event_listeners(self):
+        self.font_changed.disconnect(self._call_tip_widget.setFont)
+        document = self._control.document()
+        document.contentsChange.disconnect(self._document_contents_change)
+
+        self._bracket_matcher._remove_event_listeners()
+
+        super(PythonWidget, self)._remove_event_listeners()
+
     # --------------------------------------------------------------------------
     # file-like object interface
     # --------------------------------------------------------------------------
@@ -239,17 +248,6 @@ class PythonWidget(HistoryConsoleWidget):
         for line in lines:
             self.write(line, refresh=refresh)
 
-    # ---------------------------------------------------------------------------
-    # 'ConsoleWidget' public interface
-    # ---------------------------------------------------------------------------
-    def disconnect_event_listeners(self):
-        self.font_changed.disconnect(self._call_tip_widget.setFont)
-        document = self._control.document()
-        document.contentsChange.disconnect(self._document_contents_change)
-
-        self._bracket_matcher.disconnect_event_listeners()
-
-        super(PythonWidget, self).disconnect_event_listeners()
     # ---------------------------------------------------------------------------
     # 'ConsoleWidget' abstract interface
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
Part of #258

Adds `disconnect_event_listeners` methods to downstream widgets which are called from within `_remove_event_listeners` of `PythonShell`.

Right after `_remove_event_listeners` a `deleteLater` is called on control. In this case all signals are connected to methods in main `control` hierarchy, so as long as control is deleted, the signals should be disconnected as well according to qt documentation. The benefits of adding disconnect are very small (or completely non-existent).

It's quite straightforward and safe (I think) to disconnect most of the signals here. And since the work is already done, it wouldn't hurt to add this.