### PR TITLE
Disconnect trait change handlers from downstream ApplicationWindow widgets

### DIFF
--- a/pyface/tests/test_application_window.py
+++ b/pyface/tests/test_application_window.py
@@ -143,6 +143,32 @@ class TestApplicationWindow(unittest.TestCase, GuiTestAssistant):
         with self.event_loop():
             self.window.close()
 
+    def test_menubar_multiple_menus(self):
+        # test that menubar gets created as expected
+        self.window.menu_bar_manager = MenuBarManager(
+            MenuManager(
+                Action(name="New"),
+                Action(name="Open"),
+                Action(name="Save"),
+                Action(name="Close"),
+                Action(name="Quit"),
+                name="File",
+            ),
+            MenuManager(
+                Action(name="Zoom in"),
+                Action(name="Zoom out"),
+                name="View",
+            )
+        )
+        with self.event_loop():
+            self.window._create()
+        with self.event_loop():
+            self.window.show(True)
+        with self.event_loop():
+            self.window.show(False)
+        with self.event_loop():
+            self.window.close()
+
     def test_toolbar(self):
         # test that toolbar gets created as expected
         self.window.tool_bar_managers = [

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -315,6 +315,7 @@ class _Tool(HasTraits):
             size = tool_bar.iconSize()
             image = action.image.create_icon((size.width(), size.height()))
             self.control = tool_bar.addAction(image, action.name)
+        tool_bar.tools.append(self)
 
         self.control.triggered.connect(self._qt4_on_triggered)
 
@@ -362,14 +363,7 @@ class _Tool(HasTraits):
             self.controller = controller
             controller.add_to_toolbar(self)
 
-    # ------------------------------------------------------------------------
-    # Private interface.
-    # ------------------------------------------------------------------------
-
-    def _qt4_on_destroyed(self, control=None):
-        """ Delete the reference to the control to avoid attempting to talk to
-        it again and disconnect action trait change handlers.
-        """
+    def dispose(self):
         action = self.item.action
         action.on_trait_change(
             self._on_action_enabled_changed, "enabled", remove=True
@@ -393,6 +387,14 @@ class _Tool(HasTraits):
             self._on_action_tooltip_changed, "tooltip", remove=True
         )
 
+    # ------------------------------------------------------------------------
+    # Private interface.
+    # ------------------------------------------------------------------------
+
+    def _qt4_on_destroyed(self, control=None):
+        """ Delete the reference to the control to avoid attempting to talk to
+        it again.
+        """
         self.control = None
 
     def _qt4_on_triggered(self):

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -368,8 +368,31 @@ class _Tool(HasTraits):
 
     def _qt4_on_destroyed(self, control=None):
         """ Delete the reference to the control to avoid attempting to talk to
-        it again.
+        it again and disconnect action trait change handlers.
         """
+        action = self.item.action
+        action.on_trait_change(
+            self._on_action_enabled_changed, "enabled", remove=True
+        )
+        action.on_trait_change(
+            self._on_action_visible_changed, "visible", remove=True
+        )
+        action.on_trait_change(
+            self._on_action_checked_changed, "checked", remove=True
+        )
+        action.on_trait_change(
+            self._on_action_name_changed, "name", remove=True
+        )
+        action.on_trait_change(
+            self._on_action_accelerator_changed, "accelerator", remove=True
+        )
+        action.on_trait_change(
+            self._on_action_image_changed, "image", remove=True
+        )
+        action.on_trait_change(
+            self._on_action_tooltip_changed, "tooltip", remove=True
+        )
+
         self.control = None
 
     def _qt4_on_triggered(self):

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -75,6 +75,8 @@ class MenuManager(ActionManager, ActionManagerItem):
             menu = self._menus.pop()
             menu._remove_event_listeners()
 
+        super(MenuManager, self).destroy()
+
     # ------------------------------------------------------------------------
     # 'ActionManagerItem' interface.
     # ------------------------------------------------------------------------

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -73,7 +73,7 @@ class MenuManager(ActionManager, ActionManagerItem):
     def destroy(self):
         while self._menus:
             menu = self._menus.pop()
-            menu._remove_event_listeners()
+            menu.dispose()
 
         super(MenuManager, self).destroy()
 
@@ -150,7 +150,7 @@ class _Menu(QtGui.QMenu):
 
         return
 
-    def _remove_event_listeners(self):
+    def dispose(self):
         self._manager.on_trait_change(self.refresh, "changed", remove=True)
         self._manager.on_trait_change(
             self._on_enabled_changed, "enabled", remove=True

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -135,6 +135,23 @@ class _Menu(QtGui.QMenu):
     # '_Menu' interface.
     # ------------------------------------------------------------------------
 
+    def disconnect_event_listeners(self):
+        self._manager.on_trait_change(self.refresh, "changed", remove=True)
+        self._manager.on_trait_change(
+            self._on_enabled_changed, "enabled", remove=True
+        )
+        self._manager.on_trait_change(
+            self._on_visible_changed, "visible", remove=True
+        )
+        self._manager.on_trait_change(
+            self._on_name_changed, "name", remove=True
+        )
+        self._manager.on_trait_change(
+            self._on_image_changed, "image", remove=True
+        )
+        # Removes event listeners from downstream menu items
+        self.clear()
+
     def clear(self):
         """ Clears the items from the menu. """
 

--- a/pyface/ui/qt4/action/tool_bar_manager.py
+++ b/pyface/ui/qt4/action/tool_bar_manager.py
@@ -169,6 +169,20 @@ class _ToolBar(QtGui.QToolBar):
         return
 
     # ------------------------------------------------------------------------
+    # `_ToolBar` interface.
+    # ------------------------------------------------------------------------
+
+    def disconnect_event_listeners(self):
+        self.tool_bar_manager.on_trait_change(
+            self._on_tool_bar_manager_enabled_changed, "enabled", remove=True
+        )
+        self.tool_bar_manager.on_trait_change(
+            self._on_tool_bar_manager_visible_changed, "visible", remove=True
+        )
+        # Event listeners from downstream tools are removed just before
+        # destruction of their control.
+
+    # ------------------------------------------------------------------------
     # Trait change handlers.
     # ------------------------------------------------------------------------
 

--- a/pyface/ui/qt4/action/tool_bar_manager.py
+++ b/pyface/ui/qt4/action/tool_bar_manager.py
@@ -119,7 +119,7 @@ class ToolBarManager(ActionManager):
     def destroy(self):
         while self._toolbars:
             toolbar = self._toolbars.pop()
-            toolbar._remove_event_listeners()
+            toolbar.dispose()
 
         super(ToolBarManager, self).destroy()
 
@@ -186,7 +186,7 @@ class _ToolBar(QtGui.QToolBar):
 
         return
 
-    def _remove_event_listeners(self):
+    def dispose(self):
         self.tool_bar_manager.on_trait_change(
             self._on_tool_bar_manager_enabled_changed, "enabled", remove=True
         )

--- a/pyface/ui/qt4/action/tool_bar_manager.py
+++ b/pyface/ui/qt4/action/tool_bar_manager.py
@@ -121,6 +121,8 @@ class ToolBarManager(ActionManager):
             toolbar = self._toolbars.pop()
             toolbar._remove_event_listeners()
 
+        super(ToolBarManager, self).destroy()
+
     # ------------------------------------------------------------------------
     # Private interface.
     # ------------------------------------------------------------------------

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -116,28 +116,6 @@ class ApplicationWindow(MApplicationWindow, Window):
             self.control.setWindowIcon(icon.create_icon())
 
     # ------------------------------------------------------------------------
-    # 'Widget' interface.
-    # ------------------------------------------------------------------------
-
-    def destroy(self):
-        if self.control is not None:
-            menus = self.control.findChildren(QtGui.QMenu)
-            for menu in menus:
-                try:
-                    menu.disconnect_event_listeners()
-                except AttributeError:
-                    continue
-
-            toolbars = self.control.findChildren(QtGui.QToolBar)
-            for toolbar in toolbars:
-                try:
-                    toolbar.disconnect_event_listeners()
-                except AttributeError:
-                    continue
-
-        super(ApplicationWindow, self).destroy()
-
-    # ------------------------------------------------------------------------
     # 'Window' interface.
     # ------------------------------------------------------------------------
 

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -123,11 +123,17 @@ class ApplicationWindow(MApplicationWindow, Window):
         if self.control is not None:
             menus = self.control.findChildren(QtGui.QMenu)
             for menu in menus:
-                menu.disconnect_event_listeners()
+                try:
+                    menu.disconnect_event_listeners()
+                except AttributeError:
+                    continue
 
             toolbars = self.control.findChildren(QtGui.QToolBar)
             for toolbar in toolbars:
-                toolbar.disconnect_event_listeners()
+                try:
+                    toolbar.disconnect_event_listeners()
+                except AttributeError:
+                    continue
 
         super(ApplicationWindow, self).destroy()
 

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -116,6 +116,22 @@ class ApplicationWindow(MApplicationWindow, Window):
             self.control.setWindowIcon(icon.create_icon())
 
     # ------------------------------------------------------------------------
+    # 'Widget' interface.
+    # ------------------------------------------------------------------------
+
+    def destroy(self):
+        if self.control is not None:
+            menu = self.control.findChild(QtGui.QMenu)
+            if menu is not None:
+                menu.disconnect_event_listeners()
+
+            toolbars = self.control.findChildren(QtGui.QToolBar)
+            for toolbar in toolbars:
+                toolbar.disconnect_event_listeners()
+
+        super(ApplicationWindow, self).destroy()
+
+    # ------------------------------------------------------------------------
     # 'Window' interface.
     # ------------------------------------------------------------------------
 

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -121,8 +121,8 @@ class ApplicationWindow(MApplicationWindow, Window):
 
     def destroy(self):
         if self.control is not None:
-            menu = self.control.findChild(QtGui.QMenu)
-            if menu is not None:
+            menus = self.control.findChildren(QtGui.QMenu)
+            for menu in menus:
                 menu.disconnect_event_listeners()
 
             toolbars = self.control.findChildren(QtGui.QToolBar)


### PR DESCRIPTION
Part of #258 

Before destroying control of `ApplicationWindow`, trait change handlers from downstream widgets are disconnected.

The structure of these underlying widgets and their managers is fairly complex so it's hard to say if it is necessary to disconnect these trait change handlers and if it helps with garbage collection. I attempt to evaluate the risks and the benefits but there might be things that I've missed.
____
**`_Menu` in `menu_manager.py` and `_ToolBar` in `tool_bar_manager.py`**

They connect their methods to Python `MenuManager` and `ToolBarManager` object traits, but as far as I know that shouldn't prevent any of the objects from being garbage collected. And when either side is deleted, the connection should break. However, if for some reason those connections remain after an attempt to destroy the whole control hierarchy, they might cause problems because there are no safeguards in the handlers.

This PR removes `on_trait_change` connections, however, to do so it has to find these objects in the children of the control, since no proper reference is held. The code also only checks that the objects is an instance of expected Qt object, not the custom `_Menu` or `_ToolBar` because those are private classes. This is risky because there might be other `QMenu` and `QToolBar` objects that do not have expected `disconnect_event_listeners` method. One solution would be to wrap these in a `try-except`.

I'm open to suggestion on how to better approach this situation and if the potential benefits are worth the risk.
____
**`_MenuItem` and `_Tool` in `action_item.py`**

All handlers in `action_item.py` have protective `if self.control is not None` check so from code inspection it seems that leaving these handlers here shouldn't cause problems. But a disconnect structure was already implemented for `_MenuItem` in 80855481982ce433324123, which suggests that not removing the handlers was actually causing problems. Although it was only executed on refresh, not on destruction.

This PR connects that structure from `_MenuItem` to the main `destroy` method. The PR doesn't add a similar structure for `_Tool` because (1) its `clear` method behaves differently, (2) it would introduce more changes outside of disposal code. Instead trait change handlers of `_Tool` are disconnected in a slot that is connected to the `destroyed` signal of its control. I would say that the code added here is low risk because it disconnects `on_trait_change` from Python objects. And if the code from the section above doesn't work out, the disconnect in `_MenuItem` can also happen in a slot connected to `destroyed` signal.

There is a qt connection to `_Tool.control.triggered` signal that is not currently disconnected on destruction because there's no good place to do so without adding a lot of extra code. The slot does work with UI components and doesn't have a `control is None` check so it has some potential of causing problems. But I think a better (lower risk) approach would be to add this check to the slot rather than adding additional structure in order to disconnect it.

**Note1:** There are also 2 qt signal-slot connections that are connected to `destroyed` signal. This PR doesn't disconnect them because they shouldn't be disconnected.

**Note2:** `_PaletteTool` in `action_item.py` hasn't been touched because the support for it has not been implemented in qt.