### PR TITLE
Disconnect qt signals in qt implementation of pyface.tasks

### DIFF
--- a/pyface/tasks/tests/test_advanced_editor_area_pane.py
+++ b/pyface/tasks/tests/test_advanced_editor_area_pane.py
@@ -7,47 +7,20 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-
 import unittest
 
-
-from traits.etsconfig.api import ETSConfig
-from pyface.tasks.api import Editor, EditorAreaPane
+from pyface.tasks.api import Editor, AdvancedEditorAreaPane
 from pyface.toolkit import toolkit_object
 
 GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
 no_gui_test_assistant = GuiTestAssistant.__name__ == "Unimplemented"
 
-USING_WX = ETSConfig.toolkit not in ["", "qt4"]
-
-
-class EditorAreaPaneTestCase(unittest.TestCase):
-    @unittest.skipIf(USING_WX, "EditorAreaPane is not implemented in WX")
-    def test_create_editor(self):
-        """ Does creating an editor work?
-        """
-        area = EditorAreaPane()
-        area.register_factory(Editor, lambda obj: isinstance(obj, int))
-        self.assert_(isinstance(area.create_editor(0), Editor))
-
-    @unittest.skipIf(USING_WX, "EditorAreaPane is not implemented in WX")
-    def test_factories(self):
-        """ Does registering and unregistering factories work?
-        """
-        area = EditorAreaPane()
-        area.register_factory(Editor, lambda obj: isinstance(obj, int))
-        self.assertEqual(area.get_factory(0), Editor)
-        self.assertEqual(area.get_factory("foo"), None)
-
-        area.unregister_factory(Editor)
-        self.assertEqual(area.get_factory(0), None)
-
 
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
-class TestEditorAreaPane(unittest.TestCase, GuiTestAssistant):
+class TestAdvancedEditorAreaPane(unittest.TestCase, GuiTestAssistant):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self.area_pane = EditorAreaPane()
+        self.area_pane = AdvancedEditorAreaPane()
 
     def tearDown(self):
         if self.area_pane.control is not None:
@@ -62,6 +35,16 @@ class TestEditorAreaPane(unittest.TestCase, GuiTestAssistant):
         with self.event_loop():
             self.area_pane.destroy()
 
-
-if __name__ == "__main__":
-    unittest.main()
+    def test_create_destroy_with_editor(self):
+        # test that creating and destroying works as expected when there are
+        # editors
+        with self.event_loop():
+            self.area_pane.create(None)
+        with self.event_loop():
+            editor = self.area_pane.create_editor("Hello", Editor)
+        with self.event_loop():
+            self.area_pane.add_editor(editor)
+        with self.event_loop():
+            self.area_pane.activate_editor(editor)
+        with self.event_loop():
+            self.area_pane.destroy()

--- a/pyface/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/tasks/tests/test_split_editor_area_pane.py
@@ -7,47 +7,20 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-
 import unittest
 
-
-from traits.etsconfig.api import ETSConfig
-from pyface.tasks.api import Editor, EditorAreaPane
+from pyface.tasks.api import SplitEditorAreaPane
 from pyface.toolkit import toolkit_object
 
 GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
 no_gui_test_assistant = GuiTestAssistant.__name__ == "Unimplemented"
 
-USING_WX = ETSConfig.toolkit not in ["", "qt4"]
-
-
-class EditorAreaPaneTestCase(unittest.TestCase):
-    @unittest.skipIf(USING_WX, "EditorAreaPane is not implemented in WX")
-    def test_create_editor(self):
-        """ Does creating an editor work?
-        """
-        area = EditorAreaPane()
-        area.register_factory(Editor, lambda obj: isinstance(obj, int))
-        self.assert_(isinstance(area.create_editor(0), Editor))
-
-    @unittest.skipIf(USING_WX, "EditorAreaPane is not implemented in WX")
-    def test_factories(self):
-        """ Does registering and unregistering factories work?
-        """
-        area = EditorAreaPane()
-        area.register_factory(Editor, lambda obj: isinstance(obj, int))
-        self.assertEqual(area.get_factory(0), Editor)
-        self.assertEqual(area.get_factory("foo"), None)
-
-        area.unregister_factory(Editor)
-        self.assertEqual(area.get_factory(0), None)
-
 
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
-class TestEditorAreaPane(unittest.TestCase, GuiTestAssistant):
+class TestSplitEditorAreaPane(unittest.TestCase, GuiTestAssistant):
     def setUp(self):
         GuiTestAssistant.setUp(self)
-        self.area_pane = EditorAreaPane()
+        self.area_pane = SplitEditorAreaPane()
 
     def tearDown(self):
         if self.area_pane.control is not None:
@@ -61,7 +34,3 @@ class TestEditorAreaPane(unittest.TestCase, GuiTestAssistant):
             self.area_pane.create(None)
         with self.event_loop():
             self.area_pane.destroy()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -98,7 +98,7 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
         """ Destroy the toolkit-specific control that represents the pane.
         """
         self.control.removeEventFilter(self._filter)
-        self.control.disconnect_event_listeners()
+        self.control._remove_event_listeners()
         self._filter = None
 
         for editor in self.editors:
@@ -293,7 +293,7 @@ class EditorAreaWidget(QtGui.QMainWindow):
             QtCore.Qt.AllDockWidgetAreas, QtGui.QTabWidget.North
         )
 
-    def disconnect_event_listeners(self):
+    def _remove_event_listeners(self):
         """ Disconnects focusChanged signal of the application """
         app = QtGui.QApplication.instance()
         app.focusChanged.disconnect(self._focus_changed)
@@ -324,7 +324,7 @@ class EditorAreaWidget(QtGui.QMainWindow):
         """
         editor_widget.hide()
         editor_widget.removeEventFilter(self)
-        editor_widget.disconnect_event_listeners()
+        editor_widget._remove_event_listeners()
         editor_widget.editor.destroy()
         self.removeDockWidget(editor_widget)
 
@@ -631,7 +631,7 @@ class EditorWidget(QtGui.QDockWidget):
         self.dockLocationChanged.connect(self.update_title_bar)
         self.visibilityChanged.connect(self.update_title_bar)
 
-    def disconnect_event_listeners(self):
+    def _remove_event_listeners(self):
         self.dockLocationChanged.disconnect(self.update_title_bar)
         self.visibilityChanged.disconnect(self.update_title_bar)
 

--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -107,10 +107,9 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
             editor.editor_area = None
         self.active_editor = None
 
-        if self.control is not None:
-            while self._connections_to_remove:
-                signal, handler = self._connections_to_remove.pop()
-                signal.disconnect(handler)
+        while self._connections_to_remove:
+            signal, handler = self._connections_to_remove.pop()
+            signal.disconnect(handler)
 
         super(AdvancedEditorAreaPane, self).destroy()
 

--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -634,9 +634,6 @@ class EditorWidget(QtGui.QDockWidget):
     def disconnect_event_listeners(self):
         self.dockLocationChanged.disconnect(self.update_title_bar)
         self.visibilityChanged.disconnect(self.update_title_bar)
-        title_bar = self.titleBarWidget()
-        if isinstance(title_bar, EditorTitleBarWidget):
-            title_bar.disconnect_event_listeners(self)
 
     def update_title(self):
         title = self.editor.editor_area._get_label(self.editor)
@@ -683,10 +680,6 @@ class EditorTitleBarWidget(QtGui.QTabBar):
         self.setTabsClosable(True)
 
         self.tabCloseRequested.connect(editor_widget.editor.close)
-
-    def disconnect_event_listeners(self, editor_widget):
-        # Assumes that the editor of editor_widget never changes
-        self.tabCloseRequested.disconnect(editor_widget.editor.close)
 
     def mousePressEvent(self, event):
         self.parent().parent()._drag_widget = self.parent()

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -89,6 +89,17 @@ class DockPane(TaskPane, MDockPane):
         # parent immediately!
         control.hide()
 
+    def destroy(self):
+        """ Destroy the toolkit-specific control that represents the pane.
+        """
+        if self.control is not None:
+            control = self.control
+            control.dockLocationChanged.disconnect(self._receive_dock_area)
+            control.topLevelChanged.disconnect(self._receive_floating)
+            control.visibilityChanged.disconnect(self._receive_visible)
+
+        super(DockPane, self).destroy()
+
     def set_focus(self):
         """ Gives focus to the control that represents the pane.
         """

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -106,10 +106,9 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         for editor in self.editors:
             self.remove_editor(editor)
 
-        if self.control is not None:
-            while self._connections_to_remove:
-                signal, handler = self._connections_to_remove.pop()
-                signal.disconnect(handler)
+        while self._connections_to_remove:
+            signal, handler = self._connections_to_remove.pop()
+            signal.disconnect(handler)
 
         super(EditorAreaPane, self).destroy()
 

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -55,7 +55,13 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
 
         # Connect to the widget's signals.
         control.currentChanged.connect(self._update_active_editor)
+        self._connections_to_remove.append(
+            (control.currentChanged, self._update_active_editor)
+        )
         control.tabCloseRequested.connect(self._close_requested)
+        self._connections_to_remove.append(
+            (control.tabCloseRequested, self._close_requested)
+        )
 
         # Add shortcuts for scrolling through tabs.
         if sys.platform == "darwin":
@@ -101,9 +107,6 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             self.remove_editor(editor)
 
         if self.control is not None:
-            self.control.currentChanged.disconnect(self._update_active_editor)
-            self.control.tabCloseRequested.disconnect(self._close_requested)
-
             while self._connections_to_remove:
                 signal, handler = self._connections_to_remove.pop()
                 signal.disconnect(handler)

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -134,10 +134,9 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         for editor in self.editors[:]:
             self.remove_editor(editor)
 
-        if self.control is not None:
-            while self._connections_to_remove:
-                signal, handler = self._connections_to_remove.pop()
-                signal.disconnect(handler)
+        while self._connections_to_remove:
+            signal, handler = self._connections_to_remove.pop()
+            signal.disconnect(handler)
 
         # Remove reference to active tabwidget so that it can be deleted
         # together with the main control


### PR DESCRIPTION
Part of #258 

Distinct things this PR does:

1. `DockPane` - disconnects signals from its control. Low risk - low reward kind of change. Doesn't hurt to add this.

2. Deletes connections to shortcuts via `_connections_to_remove` in classes providing `IEditorAreaPane`. It is good to disconnect these shortcuts because if something goes wrong and the objects are not deleted, the handlers can still be activated via keyboard events. So the reward is fairly high. The risk with current code is low because it is only disconnecting what is added to the list and there are no other disconnects. The problems might arise if someone decides to disconnect the shortcuts elsewhere and doesn't remove them from the list. But maybe that should be considered a case of "Don't do that".

3. Removes reference to `active_tabwidget` from `SplitEditorAreaPane`. This was preventing the widget from being deleted together with the main control. Low risk - high reward kind of change. Although not directly related to signals (and thus can be separated from this).

4. `EditorAreaPane` - disconnects signals from its control. The handlers do work with UI elements accessible via control but then the signals are emitted from the same control. If control is set to `None` between the signal was emitted and slot was executed, there could be problems. So I would say that this is a low risk - low medium reward kind of change.

5. Removes reference to `active_editor` from `AdvancedEditorAreaPane`. The editor here is a python object so holding a reference to it doesn't really do anything (its control is destroyed separately). But other classes implementing `IEditorAreaPane` are removing this reference via `remove_editor` method, so I added that line of code here as well. No risk - no reward kind of change. Done for consistency.

6. `AdvancedEditorAreaPane` - tells its control to disconnect what it had connected. In this case it had connected a slot to `focusChanged` signal of the main application, so this is important to disconnect. Low risk - high reward kind of change.

5. When `EditorAreaWidget` destroys and `editor_widget`, it also tells the widget to disconnect what it had connected. The signals and slots belong to the same object but in the slot the objects tries to access an attribute on the parent, which might cause problems. Low risk - medium reward.

6. After disconnecting its own signals, `EditorWidget` tells its `titlebarWidget` (`EditorTitleBarWidget`) to disconnect what it had connected. The issue here is that `EditorTitleBarWidget` doesn't keep a reference to the slot it connected its signal to. The slot can be accessed from `EditorWidget` so it is easy to pass that in. However, an assumption has been made here that the `editor` of a certain `editor_widget` doesn't change. Making assumptions here is quite risky and this disconnect doesn't cover the case where new `EditorTitleBarWidget` is set as the `TitleBarWidget` and the old one is discarded. I'm not sure how qt handles disposal in that case but I assume that it destroys the old object and by doing so destroys the connections as well. So given that this added `disconnect` covers only a small case that is probably handled as expected by qt, this is a high risk - low benefit kind of change.

Connections that this PR doesn't remove:

1. In `childEvent` method of `EditorAreaWidget` (control of `Advanced EditorAreaPane`) a couple of slots are connected to a couple of signals of the child. I couldn't find an easy way to disconnect these signals, so I didn't add these changes. But given that this is a child signal connected to a parent slot and both are qt objects, qt should handle this situation well on its own.

2. `DraggableTabWidget` that are children of `SplitEditorAreaPane` control make a couple of connections in their `__init__`. The control can have a tree hierarchy structure with `DraggableTabWidget`s so there's no easy way to remove these connections. But given that both signals and slots belong to the same object, they shouldn't cause any problems.

3. In `ceate_empty_widget` of `DraggableTabWidget` buttons are created and their signals are connected to callbacks provided in top `SplitEditorAreaPane`. Again, there's no easy way to remove these connections. I think these connection can be problematic and would say that removing them would be a medium reward. But I think the code needed to disconnect them would be much riskier. I would like to hear more opinions on this.