### PR TITLE
Fix errors from incorrect QImage memory management.

### DIFF
--- a/pyface/ui/qt4/util/image_helpers.py
+++ b/pyface/ui/qt4/util/image_helpers.py
@@ -96,5 +96,6 @@ def array_to_QImage(array):
     elif channels == 4:
         image = QImage(data.data, width, height, bytes_per_line,
                        QImage.Format_ARGB32)
+    image._numpy_data = data
     return image
 


### PR DESCRIPTION
This should stop the sporadic test failures caused by referencing memory which has been freed and used by something else.  The fix is to attach the numpy array with the allocated memory to the QImage, so that the lifetime of the array is at least as long as that of the QImage.

Fixes #517