### PR TITLE
Use Traits List for _menus and _toolbars

### DIFF
--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -18,7 +18,7 @@
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Instance, Str
+from traits.api import Instance, List, Str
 
 
 from pyface.action.action_manager import ActionManager
@@ -45,7 +45,7 @@ class MenuManager(ActionManager, ActionManagerItem):
     # Private interface ---------------------------------------------------#
 
     #: Keep track of all created menus in order to properly dispose of them
-    _menus = []
+    _menus = List()
 
     # ------------------------------------------------------------------------
     # 'MenuManager' interface.

--- a/pyface/ui/qt4/action/tool_bar_manager.py
+++ b/pyface/ui/qt4/action/tool_bar_manager.py
@@ -17,7 +17,7 @@
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Bool, Enum, Instance, Str, Tuple
+from traits.api import Bool, Enum, Instance, List, Str, Tuple
 
 
 from pyface.image_cache import ImageCache
@@ -56,7 +56,7 @@ class ToolBarManager(ActionManager):
     _image_cache = Instance(ImageCache)
 
     #: Keep track of all created toolbars in order to properly dispose of them
-    _toolbars = []
+    _toolbars = List()
 
     # ------------------------------------------------------------------------
     # 'object' interface.


### PR DESCRIPTION
Additional fix following #541 

Use Traits `List()` so that each instance of manager has its own list for tracking `_menus` and `_toolbars`.