### PR TITLE
Add cron job to install/test against packages from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_install:
   - edm install -y wheel click coverage
 install:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
+  - if [[ ${TRAVIS_EVENT_TYPE} == 'cron' ]]; then for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} --source || exit; done; fi
 script:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py test --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done
 

--- a/etstool.py
+++ b/etstool.py
@@ -94,7 +94,7 @@ dependencies = {"traits", "numpy", "pygments", "coverage", "mock"}
 
 # NOTE : traitsui is always installed from source
 source_dependencies = {
-    "traits",
+    "traits": "git+http://github.com/enthought/traits.git#egg=traits",
 }
 
 extra_dependencies = {
@@ -138,8 +138,6 @@ edm_option = click.option(
     ),
     envvar="ETSTOOL_EDM",
 )
-
-github_url_fmt = "git+http://github.com/enthought/{0}.git#egg={0}"
 
 
 @click.group()
@@ -195,9 +193,9 @@ def install(edm, runtime, toolkit, environment, source):
 
     if source:
         cmd_fmt = "edm plumbing remove-package --environment {environment} --force "
-        commands = [cmd_fmt+dependency for dependency in source_dependencies]
+        commands = [cmd_fmt+dependency for dependency in source_dependencies.keys()]
         execute(commands, parameters)
-        source_pkgs = [github_url_fmt.format(pkg) for pkg in source_dependencies]
+        source_pkgs = source_dependencies.values()
         commands = [
             "python -m pip install {pkg} --no-deps".format(pkg=pkg)
             for pkg in source_pkgs


### PR DESCRIPTION
At the moment, traits is the only package installed from source as pyface is always installed from source on CI. The changes are almost the same as that in traits PR enthought/traits#479.

Exactly the same as the changes in https://github.com/enthought/traitsui/pull/914 except for replacing the word `"pyface"` with `"traitsui"`