### PR TITLE
# not $

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,7 +29,7 @@ Change summary
 Enhancements
 
 * Use Traits 6 features (#480, #494)
-* WxPython 4 support (#469, #473, #497, $499)
+* WxPython 4 support (#469, #473, #497, #499)
 * Remove six and other Python 2 code (#493)
 * Add utility functions for Qt images (#498)
 * Allow live update of Action images (#484)


### PR DESCRIPTION
This was messing with github automatically linking to the PRs. Note that the release page has been manually fixed (https://github.com/enthought/pyface/releases/tag/7.0.0). See below and after below.

![before](https://user-images.githubusercontent.com/1926457/86181508-a7177700-bb1d-11ea-8454-9d2c36728513.PNG)

![after](https://user-images.githubusercontent.com/1926457/86181552-c31b1880-bb1d-11ea-94e4-a81e19247259.PNG)
