### PR TITLE
Fix CodeWidget crashing due to KeyError from pygments Style.style_for_token

### DIFF
--- a/pyface/ui/qt4/code_editor/pygments_highlighter.py
+++ b/pyface/ui/qt4/code_editor/pygments_highlighter.py
@@ -192,6 +192,8 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
         if token in self._formats:
             return self._formats[token]
         result = None
+        while not self._style.styles_token(token):
+            token = token.parent
         for key, value in self._style.style_for_token(token).items():
             if value:
                 if result is None:

--- a/pyface/ui/qt4/code_editor/tests/test_code_widget.py
+++ b/pyface/ui/qt4/code_editor/tests/test_code_widget.py
@@ -32,6 +32,8 @@ class TestCodeWidget(unittest.TestCase):
         self.qapp.processEvents()
 
     def test_different_lexer(self):
+        # Setting a different lexer should not fail.
+        # See enthought/traitsui#982
         cw = CodeWidget(None, lexer="yaml")
         text = "number: 1"
         cw.setPlainText(text)

--- a/pyface/ui/qt4/code_editor/tests/test_code_widget.py
+++ b/pyface/ui/qt4/code_editor/tests/test_code_widget.py
@@ -31,6 +31,11 @@ class TestCodeWidget(unittest.TestCase):
     def tearDown(self):
         self.qapp.processEvents()
 
+    def test_different_lexer(self):
+        cw = CodeWidget(None, lexer="yaml")
+        text = "number: 1"
+        cw.setPlainText(text)
+
     def test_readonly_editor(self):
         cw = CodeWidget(None)
         text = "Some\nText"


### PR DESCRIPTION
This PR fixes the issue seen in https://github.com/enthought/traitsui/issues/982

pygments tokens are hierarchical: styles can define the styling for groups of tokens rather than an individual token type. The `Style.style_for_token` function is a lower level function that does not resolve the closest token group for a given leaf token. One needs to resolve the token group supported by a given style before calling `style_for_token`. 

This is consistent with how pygments handles the same situation: 
https://github.com/pygments/pygments/blob/4cd83f9e5e16e4bafa208e5be5bb3a9dc1ed813a/pygments/formatters/svg.py#L176-L178 