### PR TITLE
Backport fix to CodeWidget for 7.0.1 release

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,6 +19,8 @@ Fixes
 
 * Fix dock pane layout on Qt5. (#545)
 * Fix errors from incorrect QImage memory management. (#546)
+* Fix CodeWidget handling of parsed tokens which caused TraitsUI CodeEditor to
+  fail when a different lexer was chosen (#566).
 
 Release 7.0.0
 =============

--- a/pyface/ui/qt4/code_editor/pygments_highlighter.py
+++ b/pyface/ui/qt4/code_editor/pygments_highlighter.py
@@ -192,6 +192,8 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
         if token in self._formats:
             return self._formats[token]
         result = None
+        while not self._style.styles_token(token):
+            token = token.parent
         for key, value in self._style.style_for_token(token).items():
             if value:
                 if result is None:

--- a/pyface/ui/qt4/code_editor/tests/test_code_widget.py
+++ b/pyface/ui/qt4/code_editor/tests/test_code_widget.py
@@ -31,6 +31,13 @@ class TestCodeWidget(unittest.TestCase):
     def tearDown(self):
         self.qapp.processEvents()
 
+    def test_different_lexer(self):
+        # Setting a different lexer should not fail.
+        # See enthought/traitsui#982
+        cw = CodeWidget(None, lexer="yaml")
+        text = "number: 1"
+        cw.setPlainText(text)
+
     def test_readonly_editor(self):
         cw = CodeWidget(None)
         text = "Some\nText"


### PR DESCRIPTION
This PR backports the fix from #566 for the 7.0.1 release.

Note that the changelog is updated here (which needs review).