### PR TITLE
Update changelog on master for 7.0.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,6 +2,27 @@
 Pyface Changelog
 ================
 
+Release 7.0.1
+=============
+
+This is a bugfix release which fixes a number of minor issues with the 7.0.0
+release.
+
+Thanks to:
+
+Aaron Ayres, Kit Choi, Rahul Poruri, Pedro Rivotti, Corran Webster.
+
+Change summary
+--------------
+
+Fixes
+
+* Fix copyright header in AboutDialog. (#573)
+* Fix dock pane layout on Qt5. (#545)
+* Fix errors from incorrect QImage memory management. (#546)
+* Fix CodeWidget handling of parsed tokens which caused TraitsUI CodeEditor to
+  fail when a different lexer was chosen (#566).
+
 Release 7.0.0
 =============
 


### PR DESCRIPTION
Instead of manually cherry-picking commits from the maintenance branch to update the changelog on master, we just did it in one go. The changelog entry here matches with that on the maintenance branch `maint/7.0`