### PR TITLE
Bump micro version on maint 7.0 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,9 @@ from setuptools import setup, find_packages
 
 MAJOR = 7
 MINOR = 0
-MICRO = 1
+MICRO = 2
 
-IS_RELEASED = True
+IS_RELEASED = False
 
 VERSION = "%d.%d.%d" % (MAJOR, MINOR, MICRO)
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ MAJOR = 7
 MINOR = 0
 MICRO = 1
 
-IS_RELEASED = False
+IS_RELEASED = True
 
 VERSION = "%d.%d.%d" % (MAJOR, MINOR, MICRO)
 


### PR DESCRIPTION
This PR does has two commits : 

- The first sets IS_RELEASED to True, making the 7.0.1 release of pyface
- The second flips IS_RELEASED back to False and updates the verison to 7.0.2 to continue development on the maintenance branch

ref : #557 for the release issue