### PR TITLE
Replace Traits with TraitsUI in top-level Pyface description

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Pyface
 
 Pyface enables programmers to interact with generic GUI objects, such as an
 "MDI Application Window", rather than with raw GUI widgets. (Pyface is named by
-analogy to JFace in Java.) Traits uses Pyface to implement views and editors
+analogy to JFace in Java.) TraitsUI uses Pyface to implement views and editors
 for displaying and editing Traits-based objects.
 
 Toolkit Backends


### PR DESCRIPTION
The current text "Traits uses Pyface to implement views and editors" is out of date: it would be more accurate to say "TraitsUI" here. The use of "Traits" in "for displaying and editing Traits-based objects." seems sound, however.