### PR TITLE
Fixing typos and syntax errors in Pyface Docs

### DIFF
--- a/docs/source/applications.rst
+++ b/docs/source/applications.rst
@@ -199,7 +199,7 @@ While the GUI application window subclass looks like this::
                 name='&Help',
             )
         )
-    return window
+        return window
 
     def main():
         app = GUIApplication(

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -229,7 +229,7 @@ define a very simple Python editor application with menus::
             if self.control:
                 try:
                     self._editor.save()
-                except IOError, e:
+                except IOError:
                     # If you are trying to save to a file that doesn't exist,
                     # open up a FileDialog with a 'save as' action.
                     dlg = FileDialog(

--- a/docs/source/toolkits.rst
+++ b/docs/source/toolkits.rst
@@ -47,7 +47,7 @@ toolkit object.  For all built-in toolkits, this is an instance of the
 backends may use their own objects.  The toolkit object for the toolkit that
 has been selected can be found as :py:obj:`pyface.toolkit.toolkit_object`.
 
-This is a callable object which expects to be given the an identifier for the
+This is a callable object which expects to be given an identifier for the
 widget in the form of a relative module name and the object name, separated by
 a ``':'``.  This is most often used when creating new widget types for Pyface.
 The API module for the new widget class typically looks something like this::


### PR DESCRIPTION
Addresses simple errors in #592.  

May be good to do another PR adjusting code examples to be more self-contained/show their outputs.