### PR TITLE
replacing assert_ with assertTrue to avoid deprecation warning

### DIFF
--- a/pyface/tasks/tests/test_editor_area_pane.py
+++ b/pyface/tasks/tests/test_editor_area_pane.py
@@ -28,7 +28,7 @@ class EditorAreaPaneTestCase(unittest.TestCase):
         """
         area = EditorAreaPane()
         area.register_factory(Editor, lambda obj: isinstance(obj, int))
-        self.assert_(isinstance(area.create_editor(0), Editor))
+        self.assertTrue(isinstance(area.create_editor(0), Editor))
 
     @unittest.skipIf(USING_WX, "EditorAreaPane is not implemented in WX")
     def test_factories(self):

--- a/pyface/tasks/tests/test_topological_sort.py
+++ b/pyface/tasks/tests/test_topological_sort.py
@@ -81,7 +81,7 @@ class TopologicalSortTestCase(unittest.TestCase):
         """
         pairs = [(1, 2), (3, 5), (4, 6), (1, 3), (1, 4), (1, 6), (2, 4)]
         result, has_cycles = topological_sort(pairs)
-        self.assert_(not has_cycles)
+        self.assertTrue(not has_cycles)
         self.assertEqual(result, [1, 2, 3, 4, 5, 6])
 
     def test_topological_sort_2(self):
@@ -89,7 +89,7 @@ class TopologicalSortTestCase(unittest.TestCase):
         """
         pairs = [(1, 2), (1, 3), (2, 4), (3, 4), (5, 6), (4, 5)]
         result, has_cycles = topological_sort(pairs)
-        self.assert_(not has_cycles)
+        self.assertTrue(not has_cycles)
         self.assertEqual(result, [1, 2, 3, 4, 5, 6])
 
     def test_topological_sort_3(self):
@@ -97,7 +97,7 @@ class TopologicalSortTestCase(unittest.TestCase):
         """
         pairs = [(1, 2), (2, 3), (3, 1)]
         result, has_cycles = topological_sort(pairs)
-        self.assert_(has_cycles)
+        self.assertTrue(has_cycles)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes #526 
This change address the first two bullets on issue #582
The remaining bullets will be done in separate PRs.