### PR TITLE
Remove all of the u prefix on strings

### DIFF
--- a/examples/application/python_editor/python_editor.py
+++ b/examples/application/python_editor/python_editor.py
@@ -53,7 +53,7 @@ class LineNumberDialog(HasStrictTraits):
     traits_view = View(
         Item(
             "line",
-            label=u"Line Number:",
+            label="Line Number:",
             editor=RangeEditor(low=1, high_name="max_line", mode="spinner"),
         ),
         buttons=OKCancelButtons,
@@ -131,7 +131,7 @@ class PythonEditor(TraitsEditor):
                 self.code = fp.read()
             self.obj = path
         else:
-            self.code = u""
+            self.code = ""
 
         if self.ui is not None:
             # reset history

--- a/examples/application/python_editor/python_editor_application.py
+++ b/examples/application/python_editor/python_editor_application.py
@@ -50,7 +50,7 @@ def main():
     parser.add_argument("files", nargs="*", help="the files to open")
     namespace = parser.parse_args()
     if len(namespace.files) == 0:
-        namespace.files.append(u"")
+        namespace.files.append("")
 
     # set up callback to open files once app is up and running
     def open_files():

--- a/examples/application/python_editor/python_editor_task.py
+++ b/examples/application/python_editor/python_editor_task.py
@@ -87,7 +87,7 @@ class PythonEditorTask(Task):
     id = "example.python_editor_task"
 
     #: The human-readable name of the task.
-    name = u"Python Editor"
+    name = "Python Editor"
 
     #: The currently active editor in the editor area, if any.
     active_editor = Property(

--- a/pyface/action/gui_application_action.py
+++ b/pyface/action/gui_application_action.py
@@ -68,7 +68,7 @@ class ActiveWindowAction(GUIApplicationAction):
 class CreateWindowAction(GUIApplicationAction):
     """ A standard 'New Window' menu action. """
 
-    name = u"New Window"
+    name = "New Window"
     accelerator = "Ctrl+N"
 
     def perform(self, event=None):
@@ -83,7 +83,7 @@ class ExitAction(GUIApplicationAction):
     method = "exit"
 
     def _name_default(self):
-        return (u"Exit " if IS_WINDOWS else u"Quit ") + self.application.name
+        return ("Exit " if IS_WINDOWS else "Quit ") + self.application.name
 
 
 class AboutAction(GUIApplicationAction):
@@ -92,7 +92,7 @@ class AboutAction(GUIApplicationAction):
     method = "do_about"
 
     def _name_default(self):
-        return u"About " + self.application.name
+        return "About " + self.application.name
 
 
 class CloseActiveWindowAction(ActiveWindowAction):
@@ -101,6 +101,6 @@ class CloseActiveWindowAction(ActiveWindowAction):
     This method closes the active window of the application.
     """
 
-    name = u"Close Window"
+    name = "Close Window"
     accelerator = "Ctrl+W"
     method = "close"

--- a/pyface/action/window_action.py
+++ b/pyface/action/window_action.py
@@ -48,6 +48,6 @@ class WindowAction(ListeningAction):
 class CloseWindowAction(WindowAction):
     """ Close the specified window """
 
-    name = u"Close"
+    name = "Close"
     accelerator = "Ctrl+W"
     method = "close"

--- a/pyface/splash_screen_log_handler.py
+++ b/pyface/splash_screen_log_handler.py
@@ -39,4 +39,4 @@ class SplashScreenLogHandler(Handler):
         record : logging record instance
             The log record to be displayed.
         """
-        self._splash_screen.text = str(record.getMessage()) + u"..."
+        self._splash_screen.text = str(record.getMessage()) + "..."

--- a/pyface/tasks/action/dock_pane_toggle_group.py
+++ b/pyface/tasks/action/dock_pane_toggle_group.py
@@ -64,7 +64,7 @@ class DockPaneToggleAction(Action):
         return self.dock_pane.name
 
     def _get_tooltip(self):
-        return u"Toggles the visibility of the %s pane." % self.name
+        return "Toggles the visibility of the %s pane." % self.name
 
     @on_trait_change("dock_pane.visible")
     def _update_checked(self):

--- a/pyface/tasks/action/task_toggle_group.py
+++ b/pyface/tasks/action/task_toggle_group.py
@@ -62,7 +62,7 @@ class TaskToggleAction(Action):
         return self.task.name
 
     def _get_tooltip(self):
-        return u"Switch to the %s task." % self.name
+        return "Switch to the %s task." % self.name
 
     @on_trait_change("task.window.active_task")
     def _update_checked(self):

--- a/pyface/tasks/action/task_window_toggle_group.py
+++ b/pyface/tasks/action/task_window_toggle_group.py
@@ -45,7 +45,7 @@ class TaskWindowToggleAction(Action):
     def _get_name(self):
         if self.window.title:
             return self.window.title
-        return u""
+        return ""
 
     @on_trait_change("window:activated")
     def _window_activated(self):

--- a/pyface/tasks/action/tasks_application_action.py
+++ b/pyface/tasks/action/tasks_application_action.py
@@ -23,7 +23,7 @@ class TasksApplicationAction(GUIApplicationAction):
 class CreateTaskWindowAction(TasksApplicationAction):
     """ A standard 'New Window' menu action. """
 
-    name = u"New Window"
+    name = "New Window"
     accelerator = "Ctrl+N"
 
     #: The task window wayout to use when creating the new window.

--- a/pyface/tests/test_clipboard.py
+++ b/pyface/tests/test_clipboard.py
@@ -42,12 +42,12 @@ class TestClipboard(unittest.TestCase):
         self.assertFalse(self.clipboard.has_object_data)
 
     def test_set_text_data_unicode(self):
-        self.clipboard.data = u"test"
+        self.clipboard.data = "test"
         self.assertTrue(self.clipboard.has_data)
         self.assertEqual(self.clipboard.data_type, "str")
-        self.assertEqual(self.clipboard.data, u"test")
+        self.assertEqual(self.clipboard.data, "test")
         self.assertTrue(self.clipboard.has_text_data)
-        self.assertEqual(self.clipboard.text_data, u"test")
+        self.assertEqual(self.clipboard.text_data, "test")
         self.assertFalse(self.clipboard.has_file_data)
         self.assertFalse(self.clipboard.has_object_data)
 

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -90,7 +90,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create_yes_renamed(self):
         # test that creation and destruction works as expected with ok_label
-        self.dialog.yes_label = u"Sure"
+        self.dialog.yes_label = "Sure"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -98,7 +98,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create_no_renamed(self):
         # test that creation and destruction works as expected with ok_label
-        self.dialog.no_label = u"No Way"
+        self.dialog.no_label = "No Way"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -191,10 +191,10 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
     )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_renamed_yes(self):
-        self.dialog.yes_label = u"Sure"
+        self.dialog.yes_label = "Sure"
         # test that Yes works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
+        tester.open_and_wait(when_opened=lambda x: x.click_widget("Sure"))
 
         self.assertEqual(tester.result, YES)
         self.assertEqual(self.dialog.return_code, YES)
@@ -224,10 +224,10 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
     )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_renamed_no(self):
-        self.dialog.no_label = u"No way"
+        self.dialog.no_label = "No way"
         # test that No works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_widget(u"No way"))
+        tester.open_and_wait(when_opened=lambda x: x.click_widget("No way"))
 
         self.assertEqual(tester.result, NO)
         self.assertEqual(self.dialog.return_code, NO)
@@ -259,10 +259,10 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_cancel_renamed(self):
         self.dialog.cancel = True
-        self.dialog.cancel_label = u"Back"
+        self.dialog.cancel_label = "Back"
         # test that Cancel works as expected
         tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Back"))
+        tester.open_and_wait(when_opened=lambda x: x.click_widget("Back"))
 
         self.assertEqual(tester.result, CANCEL)
         self.assertEqual(self.dialog.return_code, CANCEL)

--- a/pyface/tests/test_dialog.py
+++ b/pyface/tests/test_dialog.py
@@ -75,7 +75,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
-        self.dialog.ok_label = u"Sure"
+        self.dialog.ok_label = "Sure"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -83,7 +83,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create_cancel_renamed(self):
         # test that creation and destruction works as expected with cancel_label
-        self.dialog.cancel_label = u"I Don't Think So"
+        self.dialog.cancel_label = "I Don't Think So"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -100,7 +100,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
     def test_create_help_label(self):
         # test that creation and destruction works as expected with help
         self.dialog.help_id = "test_help"
-        self.dialog.help_label = u"Assistance"
+        self.dialog.help_label = "Assistance"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -174,10 +174,10 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
     )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_renamed_ok(self):
-        self.dialog.ok_label = u"Sure"
+        self.dialog.ok_label = "Sure"
         # test that OK works as expected if renames
         tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
+        tester.open_and_wait(when_opened=lambda x: x.click_widget("Sure"))
 
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
@@ -191,11 +191,11 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
     )  # noqa
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_renamed_cancel(self):
-        self.dialog.cancel_label = u"I Don't Think So"
+        self.dialog.cancel_label = "I Don't Think So"
         # test that OK works as expected if renames
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(
-            when_opened=lambda x: x.click_widget(u"I Don't Think So")
+            when_opened=lambda x: x.click_widget("I Don't Think So")
         )
 
         self.assertEqual(tester.result, CANCEL)
@@ -211,7 +211,7 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_help(self):
         def click_help_and_close(tester):
-            tester.click_widget(u"Help")
+            tester.click_widget("Help")
             tester.close(accept=True)
 
         self.dialog.help_id = "help_test"
@@ -232,11 +232,11 @@ class TestDialog(unittest.TestCase, GuiTestAssistant):
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_renamed_help(self):
         def click_help_and_close(tester):
-            tester.click_widget(u"Assistance")
+            tester.click_widget("Assistance")
             tester.close(accept=True)
 
         self.dialog.help_id = "help_test"
-        self.dialog.help_label = u"Assistance"
+        self.dialog.help_label = "Assistance"
         # test that OK works as expected if renames
         tester = ModalDialogTester(self.dialog.open)
         tester.open_and_wait(when_opened=click_help_and_close)

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -89,7 +89,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_create_ok_renamed(self):
         # test that creation and destruction works as expected with ok_label
-        self.dialog.ok_label = u"Sure"
+        self.dialog.ok_label = "Sure"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -97,7 +97,7 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_message(self):
         # test that creation and destruction works as expected with message
-        self.dialog.message = u"This is the message"
+        self.dialog.message = "This is the message"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -105,8 +105,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_informative(self):
         # test that creation and destruction works with informative
-        self.dialog.message = u"This is the message"
-        self.dialog.informative = u"This is the additional message"
+        self.dialog.message = "This is the message"
+        self.dialog.informative = "This is the additional message"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -114,9 +114,9 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_detail(self):
         # test that creation and destruction works with detail
-        self.dialog.message = u"This is the message"
-        self.dialog.informative = u"This is the additional message"
-        self.dialog.detail = u"This is the detail"
+        self.dialog.message = "This is the message"
+        self.dialog.informative = "This is the additional message"
+        self.dialog.detail = "This is the detail"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():
@@ -188,10 +188,10 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
     @unittest.skipIf(USING_QT, "Can't change OK label in Qt")
     @unittest.skipIf(no_modal_dialog_tester, "ModalDialogTester unavailable")
     def test_renamed_ok(self):
-        self.dialog.ok_label = u"Sure"
+        self.dialog.ok_label = "Sure"
         # test that OK works as expected if renamed
         tester = ModalDialogTester(self.dialog.open)
-        tester.open_and_wait(when_opened=lambda x: x.click_widget(u"Sure"))
+        tester.open_and_wait(when_opened=lambda x: x.click_widget("Sure"))
         self.assertEqual(tester.result, OK)
         self.assertEqual(self.dialog.return_code, OK)
 

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -78,7 +78,7 @@ class TestSingleChoiceDialog(unittest.TestCase, GuiTestAssistant):
 
     def test_message(self):
         # test that creation and destruction works as expected with message
-        self.dialog.message = u"This is the message"
+        self.dialog.message = "This is the message"
         with self.event_loop():
             self.dialog._create()
         with self.event_loop():

--- a/pyface/tests/test_splash_screen_log_handler.py
+++ b/pyface/tests/test_splash_screen_log_handler.py
@@ -17,7 +17,7 @@ from ..splash_screen_log_handler import SplashScreenLogHandler
 
 
 class DummySplashScreen(HasTraits):
-    text = Str(u"original")
+    text = Str("original")
 
 
 class DummyRecord(object):
@@ -34,12 +34,12 @@ class TestSplashScreenLogHandler(unittest.TestCase):
         self.sslh = SplashScreenLogHandler(self.ss)
 
     def test_unicode_message(self):
-        self.assertEqual(self.ss.text, u"original")
-        message = u"G\u00f6khan"
+        self.assertEqual(self.ss.text, "original")
+        message = "G\u00f6khan"
         self.sslh.emit(DummyRecord(message))
-        self.assertEqual(self.ss.text, message + u"...")
+        self.assertEqual(self.ss.text, message + "...")
 
     def test_ascii_message(self):
         message = "Goekhan"
         self.sslh.emit(DummyRecord(message))
-        self.assertEqual(self.ss.text, message + u"...")
+        self.assertEqual(self.ss.text, message + "...")

--- a/pyface/ui/qt4/code_editor/find_widget.py
+++ b/pyface/ui/qt4/code_editor/find_widget.py
@@ -19,7 +19,7 @@ class FindWidget(QtGui.QWidget):
         super(FindWidget, self).__init__(parent)
         self.adv_code_widget = weakref.ref(parent)
 
-        self.button_size = self.fontMetrics().width(u"Replace All") + 20
+        self.button_size = self.fontMetrics().width("Replace All") + 20
 
         form_layout = QtGui.QFormLayout()
         form_layout.addRow("Fin&d", self._create_find_control())

--- a/pyface/ui/qt4/code_editor/gutters.py
+++ b/pyface/ui/qt4/code_editor/gutters.py
@@ -97,7 +97,7 @@ class LineNumberWidget(GutterWidget):
             self.min_char_width, int(math.floor(math.log10(nlines) + 1))
         )
         width = max(
-            self.fontMetrics().width(u"0" * ndigits) + 3, self.min_width
+            self.fontMetrics().width("0" * ndigits) + 3, self.min_width
         )
         return width
 

--- a/pyface/ui/qt4/code_editor/pygments_highlighter.py
+++ b/pyface/ui/qt4/code_editor/pygments_highlighter.py
@@ -71,7 +71,7 @@ def get_tokens_unprocessed(self, text, stack=("root",)):
                     pos += 1
                     statestack = ["root"]
                     statetokens = tokendefs["root"]
-                    yield pos, Text, u"\n"
+                    yield pos, Text, "\n"
                     continue
                 yield pos, Error, text[pos]
                 pos += 1

--- a/pyface/ui/qt4/code_editor/replace_widget.py
+++ b/pyface/ui/qt4/code_editor/replace_widget.py
@@ -21,7 +21,7 @@ class ReplaceWidget(FindWidget):
         super(FindWidget, self).__init__(parent)
         self.adv_code_widget = weakref.ref(parent)
 
-        self.button_size = self.fontMetrics().width(u"Replace All") + 20
+        self.button_size = self.fontMetrics().width("Replace All") + 20
 
         form_layout = QtGui.QFormLayout()
         form_layout.addRow("Fin&d", self._create_find_control())

--- a/pyface/ui/qt4/mimedata.py
+++ b/pyface/ui/qt4/mimedata.py
@@ -36,8 +36,8 @@ class PyMimeData(QtCore.QMimeData):
     """
 
     # The MIME type for instances.
-    MIME_TYPE = u"application/x-ets-qt4-instance"
-    NOPICKLE_MIME_TYPE = u"application/x-ets-qt4-instance-no-pickle"
+    MIME_TYPE = "application/x-ets-qt4-instance"
+    NOPICKLE_MIME_TYPE = "application/x-ets-qt4-instance-no-pickle"
 
     def __init__(self, data=None, pickle=True):
         """ Initialise the instance.

--- a/pyface/ui/qt4/tests/test_message_dialog.py
+++ b/pyface/ui/qt4/tests/test_message_dialog.py
@@ -24,10 +24,10 @@ class TestMessageDialog(GuiTestAssistant, unittest.TestCase):
     def test_escape_button_no_details(self):
         dialog = MessageDialog(
             parent=None,
-            title=u"Dialog title",
-            message=u"Printer on fire",
-            informative=u"Your printer is on fire",
-            severity=u"error",
+            title="Dialog title",
+            message="Printer on fire",
+            informative="Your printer is on fire",
+            severity="error",
             size=(600, 400),
         )
 
@@ -41,11 +41,11 @@ class TestMessageDialog(GuiTestAssistant, unittest.TestCase):
     def test_escape_button_with_details(self):
         dialog = MessageDialog(
             parent=None,
-            title=u"Dialog title",
-            message=u"Printer on fire",
-            informative=u"Your printer is on fire",
-            details=u"Temperature exceeds 1000 degrees",
-            severity=u"error",
+            title="Dialog title",
+            message="Printer on fire",
+            informative="Your printer is on fire",
+            details="Temperature exceeds 1000 degrees",
+            severity="error",
             size=(600, 400),
         )
 

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -23,7 +23,7 @@ from .event_loop_helper import EventLoopHelper
 from .testing import find_qt_widget
 
 
-BUTTON_TEXT = {OK: u"OK", CANCEL: u"Cancel", YES: u"Yes", NO: u"No"}
+BUTTON_TEXT = {OK: "OK", CANCEL: "Cancel", YES: "Yes", NO: "No"}
 
 
 class ModalDialogTester(object):

--- a/pyface/ui/qt4/workbench/split_tab_widget.py
+++ b/pyface/ui/qt4/workbench/split_tab_widget.py
@@ -1020,7 +1020,7 @@ class _DragableTabBar(QtGui.QTabBar):
     def _setCurrentTabText(self):
         idx = self.currentIndex()
         text = self._title_edit.text()
-        self.setTabText(idx, u"\u25b6" + text)
+        self.setTabText(idx, "\u25b6" + text)
         self._root.tabTextChanged.emit(self.parent().widget(idx), text)
 
     def _resize_title_edit_to_current_tab(self):

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -1649,12 +1649,12 @@ class _GridTableBase(GridTableBase):
         if row == self._grid._current_sorted_row:
             if self._grid._row_sort_reversed:
                 if is_win32:
-                    ulabel = str(label, "ascii") + u"  \u00ab"
+                    ulabel = str(label, "ascii") + "  \u00ab"
                     label = ulabel.encode("latin-1")
                 else:
                     label += "  <<"
             elif is_win32:
-                ulabel = str(label, "ascii") + u"  \u00bb"
+                ulabel = str(label, "ascii") + "  \u00bb"
                 label = ulabel.encode("latin-1")
             else:
                 label += "  >>"
@@ -1669,12 +1669,12 @@ class _GridTableBase(GridTableBase):
         if col == self._grid._current_sorted_col:
             if self._grid._col_sort_reversed:
                 if is_win32:
-                    ulabel = str(label, "ascii") + u"  \u00ab"
+                    ulabel = str(label, "ascii") + "  \u00ab"
                     label = ulabel.encode("latin-1")
                 else:
                     label += "  <<"
             elif is_win32:
-                ulabel = str(label, "ascii") + u"  \u00bb"
+                ulabel = str(label, "ascii") + "  \u00bb"
                 label = ulabel.encode("latin-1")
             else:
                 label += "  >>"


### PR DESCRIPTION
addresses a part of #601 

ref python docs - https://docs.python.org/3/library/stdtypes.html#text-sequence-type-str

> Changed in version 3.3: For backwards compatibility with the Python 2 series, the `u` prefix is once again permitted on string literals. It has no effect on the meaning of string literals and cannot be combined with the `r` prefix.
