### PR TITLE
Toolkit independent color class for Pyface

### DIFF
--- a/pyface/color.py
+++ b/pyface/color.py
@@ -1,0 +1,260 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Color classes and corresponding trait types for Pyface.
+
+The base Color class holds red, green, blue and alpha channel values as
+a tuple of normalized values from 0.0 to 1.0.  Various property traits
+pull out the individual channel values and supply values for the HSV
+and HSL colour spaces (with and without alpha).
+
+The ``from_toolkit`` and ``to_toolkit`` methods allow conversion to and
+from native toolkit color objects.
+"""
+
+import colorsys
+
+from traits.api import (
+    HasStrictTraits, Property, Range, Tuple, cached_property
+)
+
+
+def channels_to_ints(channels, maximum=255):
+    """ Convert an iterable of floating point channel values to integers.
+
+    Values are rounded to the nearest integer, rather than truncated.
+
+    Parameters
+    ----------
+    channels : iterable of float
+        An iterable of channel values, each value between 0.0 and 1.0,
+        inclusive.
+    maximum : int
+        The maximum value of the integer range.  Common values are 15,
+        65535 or 255, which is the default.
+
+    Returns
+    -------
+    values : tuple of int
+        A tuple of values as integers between 0 and max, inclusive.
+    """
+    return tuple(int(round(channel * maximum)) for channel in channels)
+
+
+def ints_to_channels(values, maximum=255):
+    """ Convert an iterable of integers to floating point channel values.
+
+    Parameters
+    ----------
+    values : tuple of int
+        An iterable of values as integers between 0 and max, inclusive.
+    maximum : int
+        The maximum value of the integer range.  Common values are 15,
+        65535 or 255, which is the default.
+
+    Returns
+    -------
+    channels : iterable of float
+        A tuple of channel values, each value between 0.0 and 1.0,
+        inclusive.
+    """
+    return tuple(value / maximum for value in values)
+
+
+#: A trait holding a single channel value.
+Channel = Range(0.0, 1.0, value=1.0, channel=True)
+
+#: A trait holding three channel values.
+ChannelTuple = Tuple(Channel, Channel, Channel)
+
+#: A trait holding four channel values.
+AlphaChannelTuple = Tuple(Channel, Channel, Channel, Channel)
+
+
+class Color(HasStrictTraits):
+    """ A mutable specification of a color with alpha.
+
+    This is a class designed to be used by user interface elements which
+    need to color some or all of the interface element.  Each color has a
+    number of different representations as channel tuples, each channel
+    holding a value between 0.0 and 1.0, inclusive.  The standard red,
+    green, blue and alpha channels are also provided as convenience
+    properties.
+
+    Methods are provided to convert to and from toolkit-specific color
+    objects.
+
+    Colors implement equality testing, but are not hashable as they are
+    mutable, and so are not suitable for use as dictionary keys.  If you
+    need a dictionary key, use an appropriate channel tuple from the
+    object.
+    """
+
+    #: A tuple holding the red, green, blue, and alpha channels.
+    rgba = AlphaChannelTuple()
+
+    #: A tuple holding the red, green, and blue channels.
+    rgb = Property(ChannelTuple(), depends_on='rgba')
+
+    #: The red channel.
+    red = Property(Channel, depends_on='rgba')
+
+    #: The green channel.
+    green = Property(Channel, depends_on='rgba')
+
+    #: The blue channel.
+    blue = Property(Channel, depends_on='rgba')
+
+    #: The alpha channel.
+    alpha = Property(Channel, depends_on='rgba')
+
+    #: A tuple holding the hue, saturation, value, and alpha channels.
+    hsva = Property(AlphaChannelTuple, depends_on=['rgba'])
+
+    #: A tuple holding the hue, saturation, and value channels.
+    hsv = Property(ChannelTuple, depends_on=['rgb'])
+
+    #: A tuple holding the hue, lightness, saturation, and alpha channels.
+    hlsa = Property(AlphaChannelTuple, depends_on=['rgba'])
+
+    #: A tuple holding the hue, lightness, and saturation channels.
+    hls = Property(ChannelTuple, depends_on=['rgb'])
+
+    @classmethod
+    def from_toolkit(cls, toolkit_color, **traits):
+        """ Create a new Color object from a toolkit color object.
+
+        Parameters
+        ----------
+        toolkit_color : toolkit object
+            A toolkit color object, such as a Qt QColor or a Wx wx.Colour.
+        **traits
+            Any additional trait values to be passed as keyword arguments.
+        """
+        from pyface.toolkit import toolkit_object
+        toolkit_color_to_rgba = toolkit_object('color:toolkit_color_to_rgba')
+        rgba = toolkit_color_to_rgba(toolkit_color)
+        return cls(rgba=rgba, **traits)
+
+    def to_toolkit(self):
+        """ Create a new toolkit color object from a Color object.
+
+        Returns
+        -------
+        toolkit_color : toolkit object
+            A toolkit color object, such as a Qt QColor or a Wx wx.Colour.
+        """
+        from pyface.toolkit import toolkit_object
+        rgba_to_toolkit_color = toolkit_object('color:rgba_to_toolkit_color')
+        return rgba_to_toolkit_color(self.rgba)
+
+    def hex(self):
+        """ Provide a hex representation of the Color object.
+
+        Note that because the hex value is restricted to 0-255 integer values
+        for each channel, the representation is not exact.
+
+        Returns
+        -------
+        hex : str
+            A hex string in standard ``#RRGGBBAA`` format that represents
+            the color.
+        """
+        values = channels_to_ints(self.rgba)
+        return "#{:02X}{:02X}{:02X}{:02X}".format(*values)
+
+    def __eq__(self, other):
+        if isinstance(other, Color):
+            return self.rgba == other.rgba
+        return NotImplemented
+
+    def __str__(self):
+        return "({:0.5}, {:0.5}, {:0.5}, {:0.5})".format(*self.rgba)
+
+    def __repr__(self):
+        return "{}(rgba={!r})".format(self.__class__.__name__, self.rgba)
+
+    def _get_red(self):
+        return self.rgba[0]
+
+    def _set_red(self, value):
+        r, g, b, a = self.rgba
+        self.rgba = (value, g, b, a)
+
+    def _get_green(self):
+        return self.rgba[1]
+
+    def _set_green(self, value):
+        r, g, b, a = self.rgba
+        self.rgba = (r, value, b, a)
+
+    def _get_blue(self):
+        return self.rgba[2]
+
+    def _set_blue(self, value):
+        r, g, b, a = self.rgba
+        self.rgba = (r, g, value, a)
+
+    def _get_alpha(self):
+        return self.rgba[3]
+
+    def _set_alpha(self, value):
+        r, g, b, a = self.rgba
+        self.rgba = (r, g, b, value)
+
+    @cached_property
+    def _get_rgb(self):
+        return self.rgba[:-1]
+
+    def _set_rgb(self, value):
+        r, g, b = value
+        self.rgba = (r, g, b, self.rgba[3])
+
+    @cached_property
+    def _get_hsva(self):
+        r, g, b, a = self.rgba
+        h, s, v = colorsys.rgb_to_hsv(r, g, b)
+        return (h, s, v, a)
+
+    def _set_hsva(self, value):
+        h, s, v, a = value
+        r, g, b = colorsys.hsv_to_rgb(h, s, v)
+        self.rgba = (r, g, b, a)
+
+    @cached_property
+    def _get_hsv(self):
+        r, g, b = self.rgb
+        return colorsys.rgb_to_hsv(r, g, b)
+
+    def _set_hsv(self, value):
+        h, s, v = value
+        r, g, b = colorsys.hsv_to_rgb(h, s, v)
+        self.rgb = (r, g, b)
+
+    @cached_property
+    def _get_hlsa(self):
+        r, g, b, a = self.rgba
+        h, l, s = colorsys.rgb_to_hls(r, g, b)
+        return (h, l, s, a)
+
+    def _set_hlsa(self, value):
+        h, l, s, a = value
+        r, g, b = colorsys.hls_to_rgb(h, l, s)
+        self.rgba = (r, g, b, a)
+
+    @cached_property
+    def _get_hls(self):
+        r, g, b = self.rgb
+        return colorsys.rgb_to_hls(r, g, b)
+
+    def _set_hls(self, value):
+        h, l, s = value
+        r, g, b = colorsys.hls_to_rgb(h, l, s)
+        self.rgb = (r, g, b)

--- a/pyface/color.py
+++ b/pyface/color.py
@@ -116,16 +116,16 @@ class Color(HasStrictTraits):
     alpha = Property(Channel, depends_on='rgba')
 
     #: A tuple holding the hue, saturation, value, and alpha channels.
-    hsva = Property(AlphaChannelTuple, depends_on=['rgba'])
+    hsva = Property(AlphaChannelTuple, depends_on='rgba')
 
     #: A tuple holding the hue, saturation, and value channels.
-    hsv = Property(ChannelTuple, depends_on=['rgb'])
+    hsv = Property(ChannelTuple, depends_on='rgb')
 
     #: A tuple holding the hue, lightness, saturation, and alpha channels.
-    hlsa = Property(AlphaChannelTuple, depends_on=['rgba'])
+    hlsa = Property(AlphaChannelTuple, depends_on='rgba')
 
     #: A tuple holding the hue, lightness, and saturation channels.
-    hls = Property(ChannelTuple, depends_on=['rgb'])
+    hls = Property(ChannelTuple, depends_on='rgb')
 
     @classmethod
     def from_toolkit(cls, toolkit_color, **traits):

--- a/pyface/tests/test_color.py
+++ b/pyface/tests/test_color.py
@@ -58,8 +58,13 @@ class TestChannelConversion(TestCase):
                 self.assertEqual(result, (value,))
 
 
-
 class TestColor(UnittestTools, TestCase):
+
+    def assert_tuple_almost_equal(self, tuple_1, tuple_2):
+        self.assertEqual(len(tuple_1), len(tuple_2))
+
+        for x, y in zip(tuple_1, tuple_2):
+            self.assertAlmostEqual(x, y)
 
     def test_init(self):
         color = Color()
@@ -83,25 +88,19 @@ class TestColor(UnittestTools, TestCase):
 
     def test_init_hsva(self):
         color = Color(hsva=(0.4, 0.2, 0.6, 0.8))
-        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 0.8))
+        self.assert_tuple_almost_equal(color.rgba, (0.48, 0.6, 0.528, 0.8))
 
     def test_init_hsv(self):
         color = Color(hsv=(0.4, 0.2, 0.6))
-        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 1.0))
+        self.assert_tuple_almost_equal(color.rgba, (0.48, 0.6, 0.528, 1.0))
 
     def test_init_hlsa(self):
         color = Color(hlsa=(0.4, 0.2, 0.6, 0.8))
-        self.assertEqual(
-            color.rgba,
-            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 0.8)  # noqa: E501
-        )
+        self.assert_tuple_almost_equal(color.rgba, (0.08, 0.32, 0.176, 0.8))
 
     def test_init_hls(self):
         color = Color(hls=(0.4, 0.2, 0.6))
-        self.assertEqual(
-            color.rgba,
-            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 1.0)  # noqa: E501
-        )
+        self.assert_tuple_almost_equal(color.rgba, (0.08, 0.32, 0.176, 1.0))
 
     def test_toolkit_round_trip(self):
         color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
@@ -125,7 +124,7 @@ class TestColor(UnittestTools, TestCase):
         self.assertTrue(color_1 == color_2)
         self.assertFalse(color_1 != color_2)
 
-    def test_eq_not_eequal(self):
+    def test_eq_not_equal(self):
         color_1 = Color(rgba=(0.4, 0.2, 0.6, 0.8))
         color_2 = Color(rgba=(0.4, 0.4, 0.6, 0.8))
         self.assertTrue(color_1 != color_2)
@@ -199,48 +198,37 @@ class TestColor(UnittestTools, TestCase):
 
     def test_get_hsv(self):
         color = Color(rgba=(0.48, 0.6, 0.528, 0.8))
-        self.assertEqual(color.hsv, (0.4000000000000001, 0.2, 0.6))
+        self.assert_tuple_almost_equal(color.hsv, (0.4, 0.2, 0.6))
 
     def test_set_hsv(self):
         color = Color()
         color.hsv = (0.4, 0.2, 0.6)
-        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 1.0))
+        self.assert_tuple_almost_equal(color.rgba, (0.48, 0.6, 0.528, 1.0))
 
     def test_get_hsva(self):
         color = Color(rgba=(0.48, 0.6, 0.528, 0.8))
-        self.assertEqual(color.hsva, (0.4000000000000001, 0.2, 0.6, 0.8))
+        self.assert_tuple_almost_equal(color.hsva, (0.4, 0.2, 0.6, 0.8))
 
     def test_set_hsva(self):
         color = Color()
         color.hsva = (0.4, 0.2, 0.6, 0.8)
-        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 0.8))
+        self.assert_tuple_almost_equal(color.rgba, (0.48, 0.6, 0.528, 0.8))
 
     def test_get_hls(self):
         color = Color(rgba=(0.08, 0.32, 0.176, 0.8))
-        self.assertEqual(
-            color.hls,
-            (0.39999999999999997, 0.2, 0.6)
-        )
+        self.assert_tuple_almost_equal(color.hls, (0.4, 0.2, 0.6))
 
     def test_set_hls(self):
         color = Color()
         color.hls = (0.4, 0.2, 0.6)
-        self.assertEqual(
-            color.rgba,
-            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 1)
-        )
+        self.assert_tuple_almost_equal(color.rgba, (0.08, 0.32, 0.176, 1))
 
     def test_get_hlsa(self):
         color = Color(rgba=(0.08, 0.32, 0.176, 0.8))
-        self.assertEqual(
-            color.hlsa,
-            (0.39999999999999997, 0.2, 0.6, 0.8),
-        )
+        self.assert_tuple_almost_equal(color.hlsa, (0.4, 0.2, 0.6, 0.8))
 
     def test_set_hlsa(self):
         color = Color()
         color.hlsa = (0.4, 0.2, 0.6, 0.8)
-        self.assertEqual(
-            color.rgba,
-            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 0.8)  # noqa: E501
+        self.assert_tuple_almost_equal(color.rgba, (0.08, 0.32, 0.176, 0.8)
         )

--- a/pyface/tests/test_color.py
+++ b/pyface/tests/test_color.py
@@ -1,0 +1,246 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from unittest import TestCase
+
+from traits.testing.unittest_tools import UnittestTools
+
+from pyface.color import Color, channels_to_ints, ints_to_channels
+
+
+class TestChannelConversion(TestCase):
+
+    def test_ints_to_channels(self):
+        values = (102, 102, 0, 255)
+        channels = ints_to_channels(values)
+        self.assertEqual(channels, (0.4, 0.4, 0.0, 1.0))
+
+    def test_ints_to_channels_maximum(self):
+        values = (6, 6, 0, 15)
+        channels = ints_to_channels(values, maximum=15)
+        self.assertEqual(channels, (0.4, 0.4, 0.0, 1.0))
+
+    def test_channels_to_ints(self):
+        channels = (0.4, 0.4, 0.0, 1.0)
+        values = channels_to_ints(channels)
+        self.assertEqual(values, (102, 102, 0, 255))
+
+    def test_channels_to_ints_maximum(self):
+        channels = (0.4, 0.4, 0.0, 1.0)
+        values = channels_to_ints(channels, maximum=15)
+        self.assertEqual(values, (6, 6, 0, 15))
+
+    def test_round_trip(self):
+        """ Test to assert stability of values through round-trips """
+        for value in range(256):
+            with self.subTest(int=value):
+                result = channels_to_ints(ints_to_channels([value]))
+                self.assertEqual(result, (value,))
+
+    def test_round_trip_maximum(self):
+        """ Test to assert stability of values through round-trips """
+        for value in range(65536):
+            with self.subTest(int=value):
+                result = channels_to_ints(
+                    ints_to_channels(
+                        [value],
+                        maximum=65535,
+                    ),
+                    maximum=65535,
+                )
+                self.assertEqual(result, (value,))
+
+
+
+class TestColor(UnittestTools, TestCase):
+
+    def test_init(self):
+        color = Color()
+        self.assertEqual(color.rgba, (1.0, 1.0, 1.0, 1.0))
+
+    def test_init_rgba(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(color.rgba, (0.4, 0.2, 0.6, 0.8))
+
+    def test_init_rgb(self):
+        color = Color(rgb=(0.4, 0.2, 0.6))
+        self.assertEqual(color.rgba, (0.4, 0.2, 0.6, 1.0))
+
+    def test_init_r_g_b_a(self):
+        color = Color(red=0.4, green=0.2, blue=0.6, alpha=0.8)
+        self.assertEqual(color.rgba, (0.4, 0.2, 0.6, 0.8))
+
+    def test_init_r_g_b(self):
+        color = Color(red=0.4, green=0.2, blue=0.6)
+        self.assertEqual(color.rgba, (0.4, 0.2, 0.6, 1.0))
+
+    def test_init_hsva(self):
+        color = Color(hsva=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 0.8))
+
+    def test_init_hsv(self):
+        color = Color(hsv=(0.4, 0.2, 0.6))
+        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 1.0))
+
+    def test_init_hlsa(self):
+        color = Color(hlsa=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(
+            color.rgba,
+            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 0.8)  # noqa: E501
+        )
+
+    def test_init_hls(self):
+        color = Color(hls=(0.4, 0.2, 0.6))
+        self.assertEqual(
+            color.rgba,
+            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 1.0)  # noqa: E501
+        )
+
+    def test_toolkit_round_trip(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        toolkit_color = color.to_toolkit()
+        result = Color.from_toolkit(toolkit_color)
+        self.assertEqual(result.rgba, (0.4, 0.2, 0.6, 0.8))
+
+    def test_hex(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        hex_value = color.hex()
+        self.assertEqual(hex_value, "#663399CC")
+
+    def test_hex_black(self):
+        color = Color(rgba=(0.0, 0.0, 0.0, 1.0))
+        hex_value = color.hex()
+        self.assertEqual(hex_value, "#000000FF")
+
+    def test_eq(self):
+        color_1 = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color_2 = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertTrue(color_1 == color_2)
+        self.assertFalse(color_1 != color_2)
+
+    def test_eq_not_eequal(self):
+        color_1 = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color_2 = Color(rgba=(0.4, 0.4, 0.6, 0.8))
+        self.assertTrue(color_1 != color_2)
+        self.assertFalse(color_1 == color_2)
+
+    def test_eq_other(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertFalse(color == 1)
+        self.assertTrue(color != 1)
+
+    def test_not_eq(self):
+        color_1 = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color_2 = Color(rgba=(0.0, 0.0, 0.0, 1.0))
+        self.assertTrue(color_1 != color_2)
+        self.assertFalse(color_1 == color_2)
+
+    def test_str(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        result = str(color)
+        self.assertEqual(result, "(0.4, 0.2, 0.6, 0.8)")
+
+    def test_repr(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        result = repr(color)
+        self.assertEqual(result, "Color(rgba=(0.4, 0.2, 0.6, 0.8))")
+
+    def test_get_red(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(color.red, 0.4)
+
+    def test_set_red(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color.red = 1.0
+        self.assertEqual(color.rgba, (1.0, 0.2, 0.6, 0.8))
+
+    def test_get_green(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(color.green, 0.2)
+
+    def test_set_green(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color.green = 1.0
+        self.assertEqual(color.rgba, (0.4, 1.0, 0.6, 0.8))
+
+    def test_get_blue(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(color.blue, 0.6)
+
+    def test_set_blue(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color.blue = 1.0
+        self.assertEqual(color.rgba, (0.4, 0.2, 1.0, 0.8))
+
+    def test_get_alpha(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(color.alpha, 0.8)
+
+    def test_set_alpha(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color.alpha = 1.0
+        self.assertEqual(color.rgba, (0.4, 0.2, 0.6, 1.0))
+
+    def test_get_rgb(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        self.assertEqual(color.rgb, (0.4, 0.2, 0.6))
+
+    def test_set_rgb(self):
+        color = Color(rgba=(0.4, 0.2, 0.6, 0.8))
+        color.rgb = (0.6, 0.8, 0.4)
+        self.assertEqual(color.rgba, (0.6, 0.8, 0.4, 0.8))
+
+    def test_get_hsv(self):
+        color = Color(rgba=(0.48, 0.6, 0.528, 0.8))
+        self.assertEqual(color.hsv, (0.4000000000000001, 0.2, 0.6))
+
+    def test_set_hsv(self):
+        color = Color()
+        color.hsv = (0.4, 0.2, 0.6)
+        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 1.0))
+
+    def test_get_hsva(self):
+        color = Color(rgba=(0.48, 0.6, 0.528, 0.8))
+        self.assertEqual(color.hsva, (0.4000000000000001, 0.2, 0.6, 0.8))
+
+    def test_set_hsva(self):
+        color = Color()
+        color.hsva = (0.4, 0.2, 0.6, 0.8)
+        self.assertEqual(color.rgba, (0.48, 0.6, 0.528, 0.8))
+
+    def test_get_hls(self):
+        color = Color(rgba=(0.08, 0.32, 0.176, 0.8))
+        self.assertEqual(
+            color.hls,
+            (0.39999999999999997, 0.2, 0.6)
+        )
+
+    def test_set_hls(self):
+        color = Color()
+        color.hls = (0.4, 0.2, 0.6)
+        self.assertEqual(
+            color.rgba,
+            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 1)
+        )
+
+    def test_get_hlsa(self):
+        color = Color(rgba=(0.08, 0.32, 0.176, 0.8))
+        self.assertEqual(
+            color.hlsa,
+            (0.39999999999999997, 0.2, 0.6, 0.8),
+        )
+
+    def test_set_hlsa(self):
+        color = Color()
+        color.hlsa = (0.4, 0.2, 0.6, 0.8)
+        self.assertEqual(
+            color.rgba,
+            (0.07999999999999996, 0.32000000000000006, 0.17600000000000007, 0.8)  # noqa: E501
+        )

--- a/pyface/tests/test_color.py
+++ b/pyface/tests/test_color.py
@@ -10,7 +10,7 @@
 
 from unittest import TestCase
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.color import Color, channels_to_ints, ints_to_channels
 

--- a/pyface/ui/null/color.py
+++ b/pyface/ui/null/color.py
@@ -36,7 +36,7 @@ def toolkit_color_to_rgba(color):
 
 
 def rgba_to_toolkit_color(rgba):
-    """ Convertan RGBA tuple to a hex tuple.
+    """ Convert an RGBA tuple to a hex tuple.
 
     Parameters
     ----------

--- a/pyface/ui/null/color.py
+++ b/pyface/ui/null/color.py
@@ -1,0 +1,51 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" Color conversion routines for the null toolkit.
+
+This module provides a couple of utility methods to support the
+pyface.color.Color class to_toolkit and from_toolkit methods.
+
+For definiteness, the null toolkit uses tuples of RGBA values from 0 to 255
+to represent colors.
+"""
+
+from pyface.color import channels_to_ints, ints_to_channels
+
+
+def toolkit_color_to_rgba(color):
+    """ Convert a hex tuple to an RGBA tuple.
+
+    Parameters
+    ----------
+    color : tuple
+        A tuple of integer values from 0 to 255 inclusive.
+
+    Returns
+    -------
+    rgba : tuple
+        A tuple of 4 floating point values between 0.0 and 1.0 inclusive.
+    """
+    return ints_to_channels(color)
+
+
+def rgba_to_toolkit_color(rgba):
+    """ Convertan RGBA tuple to a hex tuple.
+
+    Parameters
+    ----------
+    color : tuple
+        A tuple of integer values from 0 to 255 inclusive.
+
+    Returns
+    -------
+    rgba : tuple
+        A tuple of 4 floating point values between 0.0 and 1.0 inclusive.
+    """
+    return channels_to_ints(rgba)

--- a/pyface/ui/qt4/color.py
+++ b/pyface/ui/qt4/color.py
@@ -1,0 +1,57 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" Color conversion routines for the Qt toolkit.
+
+This module provides a couple of utility methods to support the
+pyface.color.Color class to_toolkit and from_toolkit methods.
+"""
+
+from pyface.qt.QtGui import QColor
+
+from pyface.color import channels_to_ints, ints_to_channels
+
+
+def toolkit_color_to_rgba(qcolor):
+    """ Convert a QColor to an RGBA tuple.
+
+    Parameters
+    ----------
+    qcolor : QColor
+        A QColor object.
+
+    Returns
+    -------
+    rgba_tuple : tuple
+        A tuple of 4 floating point values between 0.0 and 1.0 inclusive.
+    """
+    values = (
+        qcolor.red(),
+        qcolor.green(),
+        qcolor.blue(),
+        qcolor.alpha(),
+    )
+    return ints_to_channels(values)
+
+
+def rgba_to_toolkit_color(rgba):
+    """ Convert an RGBA tuple to a QColor.
+
+    Parameters
+    ----------
+    rgba_tuple : tuple
+        A tuple of 4 floating point values between 0.0 and 1.0 inclusive.
+
+    Returns
+    -------
+    qcolor : QColor
+        A QColor object.
+    """
+    values = channels_to_ints(rgba)
+    return QColor(*values)

--- a/pyface/ui/wx/color.py
+++ b/pyface/ui/wx/color.py
@@ -1,0 +1,58 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" Color conversion routines for the wx toolkit.
+
+This module provides a couple of utility methods to support the
+pyface.color.Color class to_toolkit and from_toolkit methods.
+"""
+
+
+import wx
+
+from pyface.color import channels_to_ints, ints_to_channels
+
+
+def toolkit_color_to_rgba(wx_colour):
+    """ Convert a wx.Colour to an RGBA tuple.
+
+    Parameters
+    ----------
+    wx_color : wx.Colour
+        A wx.Colour object.
+
+    Returns
+    -------
+    rgba : tuple
+        A tuple of 4 floating point values between 0.0 and 1.0 inclusive.
+    """
+    values = (
+        wx_colour.Red(),
+        wx_colour.Green(),
+        wx_colour.Blue(),
+        wx_colour.Alpha(),
+    )
+    return ints_to_channels(values)
+
+
+def rgba_to_toolkit_color(rgba):
+    """ Convert an RGBA tuple to a wx.Colour.
+
+    Parameters
+    ----------
+    rgba : tuple
+        A tuple of 4 floating point values between 0.0 and 1.0 inclusive.
+
+    Returns
+    -------
+    wx_color : wx.Colour
+        A wx.Colour object.
+    """
+    values = channels_to_ints(rgba)
+    return wx.Colour(*values)


### PR DESCRIPTION
This is the color class from #534 pulled out into a separate PR.

This does not include any of the string parsing, trait type, or dialog classes.