### PR TITLE
Add test suite info to readme, not Pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -43,3 +43,17 @@ Pyface depends on:
 * Pygments for syntax highlighting in the Qt code editor widget.
 
 * some widgets may have additional optional dependencies.
+
+.. end_of_long_description
+
+Running the Test Suite
+----------------------
+
+To run the test suite, you will need to install Git and
+`EDM <http://docs.enthought.com/edm/>`__ as well as have a Python environment
+which has install `Click <http://click.pocoo.org/>`__ available. You can then
+follow the instructions in ``etstool.py``.  In particular::
+
+    > python etstool.py test-all
+
+will run tests in all supported environments automatically.

--- a/etstool.py
+++ b/etstool.py
@@ -51,7 +51,7 @@ which will create, install, run tests, and then clean-up the environment.  And
 you can run tests in all supported runtimes and toolkits (with cleanup)
 using::
 
-    python etstool.py test_all
+    python etstool.py test-all
 
 Currently supported runtime values are ``2.7`` and ``3.5``, and currently
 supported toolkits are ``null``, ``pyqt``, ``pyside`` and ``wx``.  Not all

--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
             if len(c.split()) > 0
         ],
         description="traits-capable windowing framework",
-        long_description=open("README.rst").read(),
+        long_description=open("README.rst").read().split(".. end_of_long_description")[0],
         long_description_content_type="text/x-rst",
         download_url="https://github.com/enthought/pyface",
         install_requires=__requires__,


### PR DESCRIPTION
Added a running the test suite section on readme.
Pypi description will now be first part of readme.  Full readme is what will appear on GitHub, with later sections being more tailored towards contributors.
Also changed etstool.py docstring and readme to specify test suite can be run by 
```
python etstool.py test-all
```
not 
```
python etstool.py test_all
```
As when I try to run with an _ I get an error but with - runs as expected.

fixes #570 