### PR TITLE
Reduce verbosity when installing package in CI

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -151,6 +151,7 @@ def cli():
 @click.option("--toolkit", default="pyqt", help="Toolkit and API to use")
 @click.option("--environment", default=None, help="EDM environment to use")
 @click.option('--source/--no-source', default=False)
+@click.option('--quiet/--no-quiet', default=True)
 def install(edm, runtime, toolkit, environment, source):
     """ Install project and dependencies into a clean EDM environment.
 
@@ -163,8 +164,15 @@ def install(edm, runtime, toolkit, environment, source):
         "{edm} install -y -e {environment} " + packages,
         "{edm} run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
         "{edm} run -e {environment} -- python setup.py clean --all",
-        "{edm} run -e {environment} -- python setup.py install --quiet",
     ]
+    if quiet:
+        commands.append(
+            "{edm} run -e {environment} -- python setup.py install --quiet"
+        )
+    else:
+        commands.append(
+            "{edm} run -e {environment} -- python setup.py install"
+        )
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
     if toolkit == "pyside2":
         commands.extend(

--- a/etstool.py
+++ b/etstool.py
@@ -152,7 +152,7 @@ def cli():
 @click.option("--environment", default=None, help="EDM environment to use")
 @click.option('--source/--no-source', default=False)
 @click.option('--quiet/--no-quiet', default=True)
-def install(edm, runtime, toolkit, environment, source):
+def install(edm, runtime, toolkit, environment, source, quiet):
     """ Install project and dependencies into a clean EDM environment.
 
     """

--- a/etstool.py
+++ b/etstool.py
@@ -163,7 +163,7 @@ def install(edm, runtime, toolkit, environment, source):
         "{edm} install -y -e {environment} " + packages,
         "{edm} run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
         "{edm} run -e {environment} -- python setup.py clean --all",
-        "{edm} run -e {environment} -- python setup.py install",
+        "{edm} run -e {environment} -- python setup.py install --quiet",
     ]
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
     if toolkit == "pyside2":

--- a/etstool.py
+++ b/etstool.py
@@ -153,35 +153,28 @@ def cli():
     help="Install main package in 'editable' mode?  [default: --not-editable]",
 )
 @click.option('--source/--no-source', default=False)
-@click.option('--quiet/--no-quiet', default=True)
-def install(edm, runtime, toolkit, environment, editable, source, quiet):
+def install(edm, runtime, toolkit, environment, editable, source):
     """ Install project and dependencies into a clean EDM environment.
 
     """
     parameters = get_parameters(edm, runtime, toolkit, environment)
     packages = " ".join(dependencies | extra_dependencies.get(toolkit, set()))
-    # edm commands to setup the development environment
-    commands = [
-        "{edm} environments create {environment} --force --version={runtime}",
-        "{edm} install -y -e {environment} " + packages,
-        "{edm} run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
-        "{edm} run -e {environment} -- python setup.py clean --all",
-    ]
-    if quiet:
-        commands.append(
-            "{edm} run -e {environment} -- python setup.py install --quiet"
-        )
-    else:
-        commands.append(
-            "{edm} run -e {environment} -- python setup.py install"
-        )
 
     # Install local source
     install_pyface = "{edm} run -e {environment} -- pip install "
     if editable:
         install_pyface += "--editable "
     install_pyface += "."
-    commands.append(install_pyface)
+
+    # edm commands to setup the development environment
+    commands = [
+        "{edm} environments create {environment} --force --version={runtime}",
+        "{edm} install -y -e {environment} " + packages,
+        "{edm} run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",
+        "{edm} run -e {environment} -- python setup.py clean --all",
+        install_pyface,
+    ]
+
 
     # pip install pyqt5 and pyside2, because we don't have them in EDM yet
     if toolkit == "pyside2":


### PR DESCRIPTION
fixes #626 
I tried to make passing quiet optional, but the default behavior.  I wasn't sure if you meant to make it the default behavior for the CI (making it optional but then when called in the travis/appveyor files they use quiet) or default within etstool which is what I tried.  