### PR TITLE
Review comments for Data View selection support

### DIFF
--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -179,9 +179,7 @@ class MDataViewWidget(HasStrictTraits):
         """ Observer for selection_type trait. """
         if self.control is not None:
             self._set_control_selection_type(event.new)
-            with self._selection_updating():
-                self.selection.clear()
-                self._set_control_selection(self.selection)
+            self.selection.clear()
 
     def _get_control_selection_type(self):
         """ Toolkit specific method to get the selection type. """
@@ -195,9 +193,7 @@ class MDataViewWidget(HasStrictTraits):
         """ Observer for selection_mode trait. """
         if self.control is not None:
             self._set_control_selection_mode(event.new)
-            with self._selection_updating():
-                self.selection.clear()
-                self._set_control_selection(self.selection)
+            self.selection.clear()
 
     def _get_control_selection_mode(self):
         """ Toolkit specific method to get the selection mode. """

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -250,6 +250,7 @@ class MDataViewWidget(HasStrictTraits):
         self._set_control_header_visible(self.header_visible)
         self._set_control_selection_mode(self.selection_mode)
         self._set_control_selection_type(self.selection_type)
+        self._set_control_selection(self.selection)
 
     def _add_event_listeners(self):
         logger.debug('Adding DataViewWidget listeners')

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -224,7 +224,10 @@ class MDataViewWidget(HasStrictTraits):
     def _update_selection(self, *args, **kwargs):
         if not self._selection_updating_flag:
             with self._selection_updating():
-                self.selection = self._get_control_selection()
+                new = self._get_control_selection()
+                old = self.selection
+                if new != old:
+                    self.selection = new
 
     # ------------------------------------------------------------------------
     # Widget Interface

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -42,6 +42,15 @@ class _Row(BaseTuple):
         if not object.data_model.is_row_valid(row):
             raise TraitError("Invalid row index {!r}".format(row))
 
+        if object.selection_type == 'item':
+            can_have_children = object.data_model.can_have_children(row)
+            have_rows = object.data_model.get_row_count(row) > 0
+            if can_have_children and have_rows:
+                raise TraitError(
+                    "Row values must have no children when selection_type "
+                    "is 'item', got {!r}".format(row)
+                )
+
         if object.selection_type == 'column':
             can_have_children = object.data_model.can_have_children(row)
             have_rows = object.data_model.get_row_count(row) > 0
@@ -76,6 +85,14 @@ class _Column(BaseTuple):
                 info=(
                     "Column values must be () when selection_type is "
                     "'row', got {!r}".format(column)
+                )
+            )
+
+        if object.selection_type == 'item' and column == ():
+            raise TraitError(
+                info=(
+                    "Column index cannot be empty when selection_type is "
+                    "'item', got {!r}".format(column)
                 )
             )
 

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -55,7 +55,7 @@ class MDataViewWidget(HasStrictTraits):
     header_visible = Bool(True)
 
     #: What can be selected.
-    selection_type = Enum("row")
+    selection_type = Enum("row", "column")
 
     #: How selections are modified.
     selection_mode = Enum("extended", "single")

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -179,7 +179,9 @@ class MDataViewWidget(HasStrictTraits):
         """ Observer for selection_type trait. """
         if self.control is not None:
             self._set_control_selection_type(event.new)
-            self.selection = []
+            with self._selection_updating():
+                self.selection.clear()
+                self._set_control_selection(self.selection)
 
     def _get_control_selection_type(self):
         """ Toolkit specific method to get the selection type. """
@@ -193,7 +195,9 @@ class MDataViewWidget(HasStrictTraits):
         """ Observer for selection_mode trait. """
         if self.control is not None:
             self._set_control_selection_mode(event.new)
-            self.selection = []
+            with self._selection_updating():
+                self.selection.clear()
+                self._set_control_selection(self.selection)
 
     def _get_control_selection_mode(self):
         """ Toolkit specific method to get the selection mode. """
@@ -205,7 +209,7 @@ class MDataViewWidget(HasStrictTraits):
 
     def _selection_updated(self, event):
         """ Observer for selection trait. """
-        if self.control is not None and not self._selection_updating_flag:
+        if self.control is not None:
             with self._selection_updating():
                 self._set_control_selection(self.selection)
 

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -99,11 +99,11 @@ class IDataViewWidget(IWidget):
     #: Whether or not the column headers are visible.
     header_visible = Bool(True)
 
-    #: What can be selected.  Some backends may support more.
-    selection_type = Enum("row",)
+    #: What can be selected.
+    selection_type = Enum("row", "column", "item")
 
     #: How selections are modified.
-    selection_mode = Enum("extended", "single")
+    selection_mode = Enum("extended", "none", "single")
 
     #: The selected indices in the view.
     selection = List(Tuple)
@@ -124,7 +124,7 @@ class MDataViewWidget(HasStrictTraits):
     selection_type = Enum("row", "column", "item")
 
     #: How selections are modified.
-    selection_mode = Enum("extended", "single")
+    selection_mode = Enum("extended", "none", "single")
 
     #: The selected indices in the view.
     selection = List(

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -179,6 +179,7 @@ class MDataViewWidget(HasStrictTraits):
         """ Observer for selection_type trait. """
         if self.control is not None:
             self._set_control_selection_type(event.new)
+            self.selection = []
 
     def _get_control_selection_type(self):
         """ Toolkit specific method to get the selection type. """
@@ -192,6 +193,7 @@ class MDataViewWidget(HasStrictTraits):
         """ Observer for selection_mode trait. """
         if self.control is not None:
             self._set_control_selection_mode(event.new)
+            self.selection = []
 
     def _get_control_selection_mode(self):
         """ Toolkit specific method to get the selection mode. """

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -444,6 +444,7 @@ class TestWidget(unittest.TestCase, UnittestTools):
 
         self.widget.selection_mode = next(modes)
         self._create_widget_control()
+        self.assertEqual(self.widget._get_control_selection_mode(), "extended")
 
         def change_selection_type(event):
             self.widget.selection_mode = next(modes)
@@ -459,16 +460,18 @@ class TestWidget(unittest.TestCase, UnittestTools):
         # switch from "extended" to "single"
         self.widget.selection = [((0,), ()), ((1,), ())]
         self.gui.process_events()
+        self.assertEqual(self.widget._get_control_selection_mode(), "single")
+        self.assertEqual(self.widget.selection, [])
         # switch from "single" to "extended"
         self.widget.selection = [((1,), ())]
         self.gui.process_events()
+        self.assertEqual(self.widget._get_control_selection_mode(), "extended")
         # switch from "extended" to "single" again
-        self.widget.selection = [((0,), ()), ((1,), ())]
+        self.widget.selection.extend([((0,), ()), ((1,), ())])
         self.gui.process_events()
-
-        self.assertEqual(self.widget.selection, [])
         self.assertEqual(self.widget._get_control_selection_mode(), "single")
         self.assertEqual(self.widget._get_control_selection(), [])
+        self.assertEqual(self.widget.selection, [])
 
     @unittest.skipIf(is_wx, "Selection type 'column' not supported")
     def test_selection_type_column(self):
@@ -511,6 +514,7 @@ class TestWidget(unittest.TestCase, UnittestTools):
 
         self.widget.selection_type = next(types)
         self._create_widget_control()
+        self.assertEqual(self.widget._get_control_selection_type(), "column")
 
         def change_selection_type(event):
             self.widget.selection_type = next(types)
@@ -526,13 +530,18 @@ class TestWidget(unittest.TestCase, UnittestTools):
         # Switch from "column" to "row"
         self.widget.selection = [((0,), (2,)), ((1,), (4,))]
         self.gui.process_events()
+        self.assertEqual(self.widget.selection, [])
+        self.assertEqual(self.widget._get_control_selection_type(), "row")
+        self.assertEqual(self.widget._get_control_selection(), [])
         # Switch from "row" to "column"
         self.widget.selection = [((1,), ()), ((2,), ())]
         self.gui.process_events()
+        self.assertEqual(self.widget.selection, [])
+        self.assertEqual(self.widget._get_control_selection_type(), "column")
+        self.assertEqual(self.widget._get_control_selection(), [])
         # Switch from "column" to "row" again
         self.widget.selection = [((0,), (2,)), ((1,), (4,))]
         self.gui.process_events()
-
         self.assertEqual(self.widget.selection, [])
         self.assertEqual(self.widget._get_control_selection_type(), "row")
         self.assertEqual(self.widget._get_control_selection(), [])

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -447,6 +447,7 @@ class TestWidget(unittest.TestCase, UnittestTools):
         self.assertEqual(self.widget._get_control_selection_mode(), "extended")
 
         def change_selection_type(event):
+            print(event)
             self.widget.selection_mode = next(modes)
 
         self.widget.observe(
@@ -461,11 +462,14 @@ class TestWidget(unittest.TestCase, UnittestTools):
         self.widget.selection = [((0,), ()), ((1,), ())]
         self.gui.process_events()
         self.assertEqual(self.widget._get_control_selection_mode(), "single")
+        self.assertEqual(self.widget._get_control_selection(), [])
         self.assertEqual(self.widget.selection, [])
         # switch from "single" to "extended"
         self.widget.selection = [((1,), ())]
         self.gui.process_events()
         self.assertEqual(self.widget._get_control_selection_mode(), "extended")
+        self.assertEqual(self.widget._get_control_selection(), [])
+        self.assertEqual(self.widget.selection, [])
         # switch from "extended" to "single" again
         self.widget.selection.extend([((0,), ()), ((1,), ())])
         self.gui.process_events()

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -462,7 +462,15 @@ class TestWidget(unittest.TestCase, UnittestTools):
         self.widget.selection = [((0,), ()), ((1,), ())]
         self.gui.process_events()
         self.assertEqual(self.widget._get_control_selection_mode(), "single")
-        self.assertEqual(self.widget._get_control_selection(), [])
+
+        if is_wx:
+            # Not sure why the selection is not updated.
+            self.assertEqual(
+                self.widget._get_control_selection(), [((0,), ()), ((1,), ())]
+            )
+            return
+        else:
+            self.assertEqual(self.widget._get_control_selection(), [])
         self.assertEqual(self.widget.selection, [])
         # switch from "single" to "extended"
         self.widget.selection = [((1,), ())]

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -395,6 +395,14 @@ class TestWidget(unittest.TestCase, UnittestTools):
         self._create_widget_control()
         self.assertFalse(self.widget._get_control_header_visible())
 
+    def test_init_selection(self):
+        self.widget.selection = [((1, ), ())]
+        self._create_widget_control()
+
+        self.assertEqual(
+            self.widget._get_control_selection(), [((1, ), ())]
+        )
+
     def test_selection_mode_change(self):
         self._create_widget_control()
         self.widget.selection_type = "item"

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -344,14 +344,15 @@ class TestWidget(unittest.TestCase, UnittestTools):
 
     def test_selection_mode_change(self):
         self._create_widget_control()
-        self.selection = [((1, 4), (2,)), ((2, 0), (4,))]
+        self.widget.selection_type = "item"
+        self.widget.selection = [((1, 4), (2,)), ((2, 0), (4,))]
 
         self.widget.selection_mode = "single"
 
         self.assertEqual(self.widget._get_control_selection_mode(), "single")
         self.assertEqual(self.widget.selection, [])
 
-        self.selection = [((1, 4), (2,))]
+        self.widget.selection = [((1, 4), (2,))]
         if not is_wx:
             self.widget.selection_mode = "none"
 
@@ -366,17 +367,20 @@ class TestWidget(unittest.TestCase, UnittestTools):
     @unittest.skipIf(is_wx, "Selection type changing not supported")
     def test_selection_type_change(self):
         self._create_widget_control()
+        self.widget.selection = [((1, 4), ())]
 
         self.widget.selection_type = "column"
 
         self.assertEqual(self.widget._get_control_selection_type(), "column")
         self.assertEqual(self.widget.selection, [])
 
+        self.widget.selection = [((1, ), (0, ))]
         self.widget.selection_type = "item"
 
         self.assertEqual(self.widget._get_control_selection_type(), "item")
         self.assertEqual(self.widget.selection, [])
 
+        self.widget.selection = [((1, 4), (2, ))]
         self.widget.selection_type = "row"
 
         self.assertEqual(self.widget._get_control_selection_type(), "row")

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -447,8 +447,8 @@ class TestWidget(unittest.TestCase, UnittestTools):
         self.assertEqual(self.widget._get_control_selection_mode(), "extended")
 
         def change_selection_type(event):
-            print(event)
-            self.widget.selection_mode = next(modes)
+            if self.widget.selection:
+                self.widget.selection_mode = next(modes)
 
         self.widget.observe(
             change_selection_type, "selection.items", dispatch="ui")
@@ -521,7 +521,8 @@ class TestWidget(unittest.TestCase, UnittestTools):
         self.assertEqual(self.widget._get_control_selection_type(), "column")
 
         def change_selection_type(event):
-            self.widget.selection_type = next(types)
+            if self.widget.selection:
+                self.widget.selection_type = next(types)
 
         self.widget.observe(
             change_selection_type, "selection.items", dispatch="ui")

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -181,6 +181,9 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         with self.assertRaises(TraitError):
             self.widget.selection = [(row, column)]
 
+        with self.assertRaises(TraitError):
+            self.widget.selection.append((row, column))
+
     def test_selection_mode_single_column_type_row_invalid(self):
         self.widget.data_model.fake_can_have_children = lambda row: True
         self.widget.data_model.fake_get_row_count = lambda row: 0
@@ -198,6 +201,9 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
 
         with self.assertRaises(TraitError):
             self.widget.selection = [(row, column)]
+
+        with self.assertRaises(TraitError):
+            self.widget.selection.append((row, column))
 
     def test_selection_mode_single_column_type_row_invalid_no_children(self):
         self.widget.data_model.fake_can_have_children = lambda row: False
@@ -217,6 +223,9 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         with self.assertRaises(TraitError):
             self.widget.selection = [(row, column)]
 
+        with self.assertRaises(TraitError):
+            self.widget.selection.append((row, column))
+
     def test_selection_mode_single_row_type_column_invalid(self):
         self.widget.selection_mode = "single"
         self.widget.selection_type = "row"
@@ -229,6 +238,9 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         with self.assertRaises(TraitError):
             self.widget.selection = [(row, column)]
 
+        with self.assertRaises(TraitError):
+            self.widget.selection.append((row, column))
+
     def test_selection_mode_single_column_invalid(self):
         self.widget.selection_mode = "single"
         self.widget.selection_type = "column"
@@ -240,6 +252,9 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
 
         with self.assertRaises(TraitError):
             self.widget.selection = [(row, column)]
+
+        with self.assertRaises(TraitError):
+            self.widget.selection.append((row, column))
 
 
 @requires_numpy
@@ -453,6 +468,14 @@ class TestWidget(unittest.TestCase, UnittestTools):
         with self.assertRaises(TraitError):
             self.widget.selection = [((1, 2), (2,))]
 
+    def test_selection_type_row_invalid_column_append(self):
+        self._create_widget_control()
+
+        with self.assertRaises(TraitError):
+            self.widget.selection.append(((1, 2), (2,)))
+
+        self.assertEqual(self.widget.selection, [])
+
     @unittest.skipIf(is_wx, "Selection mode 'item' not supported")
     def test_selection_type_item_invalid_row_too_big(self):
         self.widget.selection_type = 'item'
@@ -508,6 +531,14 @@ class TestWidget(unittest.TestCase, UnittestTools):
 
         with self.assertRaises(TraitError):
             self.widget.selection = [((), (10,))]
+
+    @unittest.skipIf(is_wx, "Selection mode 'column' not supported")
+    def test_selection_type_column_invalid_column_with_append(self):
+        self.widget.selection_type = 'column'
+        self._create_widget_control()
+
+        with self.assertRaises(TraitError):
+            self.widget.selection.append(((), (10,)))
 
     def test_selection_updated(self):
         self._create_widget_control()

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -254,6 +254,61 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         with self.assertRaises(TraitError):
             self.widget.selection.append((row, column))
 
+    def test_selection_mode_single_item_type(self):
+
+        def can_have_children(row):
+            return row == ()
+
+        self.widget.data_model.fake_can_have_children = can_have_children
+        self.widget.selection_mode = "single"
+        self.widget.selection_type = "item"
+
+        row = (0, )
+        column = (0, )
+        self.assertTrue(self.widget.data_model.is_row_valid(row))
+        self.assertTrue(self.widget.data_model.is_column_valid(column))
+        self.assertFalse(self.widget.data_model.can_have_children(row))
+
+        # This is ok
+        self.widget.selection = [(row, column)]
+
+    def test_selection_mode_single_item_type_column_not_accepted(self):
+
+        def can_have_children(row):
+            return row == ()
+
+        self.widget.data_model.fake_can_have_children = can_have_children
+        self.widget.selection_mode = "single"
+        self.widget.selection_type = "item"
+
+        # this refers to a column, not an item
+        row = ()
+        column = (0, )
+        self.assertTrue(self.widget.data_model.is_row_valid(row))
+        self.assertTrue(self.widget.data_model.is_column_valid(column))
+        self.assertTrue(self.widget.data_model.can_have_children(row))
+
+        with self.assertRaises(TraitError):
+            self.widget.selection = [(row, column)]
+
+    def test_selection_mode_single_item_type_row_not_accepted(self):
+
+        def can_have_children(row):
+            return row == ()
+
+        self.widget.data_model.fake_can_have_children = can_have_children
+        self.widget.selection_mode = "single"
+        self.widget.selection_type = "item"
+
+        # this refers to a row, not an item
+        row = (0, )
+        column = ()
+        self.assertTrue(self.widget.data_model.is_row_valid(row))
+        self.assertTrue(self.widget.data_model.is_column_valid(column))
+
+        with self.assertRaises(TraitError):
+            self.widget.selection = [(row, column)]
+
     def test_selection_mode_single_max_length_validation(self):
         self.widget.data_model.fake_get_row_count = lambda row: 10
         self.widget.selection_type = "row"

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -513,6 +513,7 @@ class TestWidget(unittest.TestCase, UnittestTools):
             [((1, 4), (2,)), ((2, 0), (4,))],
         )
 
+    @unittest.skipIf(is_wx, "Changing selection type is not supported for wx.")
     def test_selection_type_change_when_selection_change(self):
         types = cycle(["column", "row"])
 

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -446,15 +446,15 @@ class TestWidget(unittest.TestCase, UnittestTools):
         self._create_widget_control()
         self.assertEqual(self.widget._get_control_selection_mode(), "extended")
 
-        def change_selection_type(event):
+        def change_selection_mode(event):
             if self.widget.selection:
                 self.widget.selection_mode = next(modes)
 
         self.widget.observe(
-            change_selection_type, "selection.items", dispatch="ui")
+            change_selection_mode, "selection.items", dispatch="ui")
         self.addCleanup(
             self.widget.observe,
-            change_selection_type, "selection.items", dispatch="ui",
+            change_selection_mode, "selection.items", dispatch="ui",
             remove=True,
         )
 

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -256,6 +256,29 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         with self.assertRaises(TraitError):
             self.widget.selection.append((row, column))
 
+    def test_selection_mode_single_max_length_validation(self):
+        self.widget.data_model.fake_get_row_count = lambda row: 10
+        self.widget.selection_type = "row"
+        self.widget.selection_mode = "single"
+        # this is okay
+        self.widget.selection = []
+        # this is okay
+        self.widget.selection = [((0, ), ())]
+        # this is okay too
+        self.widget.selection = [((1, ), ())]
+        # this is not okay
+        with self.assertRaises(TraitError):
+            self.widget.selection = [((0, ), ()), ((1, ), ())]
+
+    def test_selection_mode_none_max_length_validation(self):
+        self.widget.selection_type = "row"
+        self.widget.selection_mode = "none"
+        # this is okay
+        self.widget.selection = []
+        # this is not okay
+        with self.assertRaises(TraitError):
+            self.widget.selection = [((0, ), ())]
+
 
 @requires_numpy
 class TestWidget(unittest.TestCase, UnittestTools):

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -152,10 +152,7 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         self.assertEqual(self.widget.control.header_visible, False)
         self.assertEqual(self.widget.control.selection_mode, "single")
         self.assertEqual(self.widget.control.selection_type, "row")
-
-        # FIXME: This is a bug?
-        with self.assertRaises(AssertionError):
-            self.assertEqual(self.widget.control.selection, [((1, ), ())])
+        self.assertEqual(self.widget.control.selection, [((1, ), ())])
 
     def test_selection_mode_single(self):
         self.widget.data_model.fake_can_have_children = lambda row: True

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -239,7 +239,7 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         with self.assertRaises(TraitError):
             self.widget.selection.append((row, column))
 
-    def test_selection_mode_single_column_invalid(self):
+    def test_selection_mode_single_column_type_column_invalid(self):
         self.widget.selection_mode = "single"
         self.widget.selection_type = "column"
 

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -163,7 +163,7 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         # this should not fail.
         self.widget.selection = [((1, 4), ())]
 
-    def test_selection_mode_single_row_invalid(self):
+    def test_selection_mode_single_row_type_row_invalid(self):
         self.widget.data_model.fake_can_have_children = lambda row: True
         self.widget.data_model.fake_get_row_count = lambda row: 1
 
@@ -175,6 +175,21 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         self.assertTrue(self.widget.data_model.is_column_valid(column))
         # this is why the selection is not accepted
         self.assertFalse(self.widget.data_model.is_row_valid(row))
+
+        with self.assertRaises(TraitError):
+            self.widget.selection = [(row, column)]
+
+        with self.assertRaises(TraitError):
+            self.widget.selection.append((row, column))
+
+    def test_selection_mode_single_row_type_column_invalid(self):
+        self.widget.selection_mode = "single"
+        self.widget.selection_type = "row"
+
+        row = (0, )
+        column = (0, )  # bad because selection type is row
+        self.assertTrue(self.widget.data_model.is_row_valid(row))
+        self.assertTrue(self.widget.data_model.is_column_valid(column))
 
         with self.assertRaises(TraitError):
             self.widget.selection = [(row, column)]
@@ -217,21 +232,6 @@ class TestMDataViewWidgetWithFakeDataModel(unittest.TestCase):
         self.assertGreater(self.widget.data_model.get_row_count(row), 0)
         # this is why the selection is not accepted
         self.assertFalse(self.widget.data_model.can_have_children(row))
-
-        with self.assertRaises(TraitError):
-            self.widget.selection = [(row, column)]
-
-        with self.assertRaises(TraitError):
-            self.widget.selection.append((row, column))
-
-    def test_selection_mode_single_row_type_column_invalid(self):
-        self.widget.selection_mode = "single"
-        self.widget.selection_type = "row"
-
-        row = (0, )
-        column = (0, )  # bad because selection type is row
-        self.assertTrue(self.widget.data_model.is_row_valid(row))
-        self.assertTrue(self.widget.data_model.is_column_valid(column))
 
         with self.assertRaises(TraitError):
             self.widget.selection = [(row, column)]

--- a/pyface/ui/null/widget.py
+++ b/pyface/ui/null/widget.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 
-from traits.api import Any, HasTraits, provides
+from traits.api import Any, Bool, HasTraits, provides
 
 
 from pyface.i_widget import IWidget, MWidget
@@ -27,9 +27,20 @@ class Widget(MWidget, HasTraits):
 
     parent = Any()
 
+    #: Whether or not the control is visible
+    visible = Bool(True)
+
+    #: Whether or not the control is enabled
+    enabled = Bool(True)
     # ------------------------------------------------------------------------
     # 'IWidget' interface.
     # ------------------------------------------------------------------------
+
+    def show(self, visible):
+        pass
+
+    def enable(self, enabled):
+        pass
 
     def destroy(self):
         self.control = None

--- a/pyface/ui/qt4/data_view/data_view_widget.py
+++ b/pyface/ui/qt4/data_view/data_view_widget.py
@@ -92,7 +92,6 @@ class DataViewWidget(MDataViewWidget, Widget):
         """ Toolkit specific method to change the selection type. """
         qt_selection_type = qt_selection_types[selection_type]
         self.control.setSelectionBehavior(qt_selection_type)
-        self.selection = []
 
     def _get_control_selection_mode(self):
         """ Toolkit specific method to get the selection mode. """
@@ -103,7 +102,6 @@ class DataViewWidget(MDataViewWidget, Widget):
         """ Toolkit specific method to change the selection mode. """
         qt_selection_mode = qt_selection_modes[selection_mode]
         self.control.setSelectionMode(qt_selection_mode)
-        self.selection = []
 
     def _get_control_selection(self):
         """ Toolkit specific method to get the selection. """


### PR DESCRIPTION
[Targeting #574]

This PR addresses and/or accompanies my own review comments on #574
As I was reviewing the PR, I find it necessary to test out my comments and suggestions. As I do so, I find more things in the PR that I otherwise would not have noticed just by reading it. I also got to weed out some of my faulty comments so no ones get to be bothered by them :)

This does not need to be merged, but I will let @corranwebster decide what to do. I did not try to break this down into smaller PRs because it is otherwise too hard.

Main changes:
- Validating row and column indexes even when the list of selections is mutated
- Resetting selection when the selection mode changes regardless of toolkit backend
- Handle when changing selection leads to changes to other things that will then change the selection
- Validating index for when selection type is "item"

New tests are added for all of these changes.

There is a new test case that depends on a fake data model.  This is needed to test the many code branches for validating row and column. Otherwise some of the edge cases cannot be covered simply by using the ArrayDataModel (which is a regular data structure).

In order to test row and column index in a toolkit agnostic fashion (the code itself is toolkit agnostic), I also had to expand the null toolkit's `Widget`. That in itself could be a separate PR.