### PR TITLE
fixed a syntax error encountered when running enaml example

### DIFF
--- a/examples/tasks/enaml/employee_view.enaml
+++ b/examples/tasks/enaml/employee_view.enaml
@@ -30,7 +30,7 @@ enamldef EmployeeForm(Form):
         text = 'Password'
     Field:
         echo_mode << 'password' if not pw_cb.checked else 'normal'
-        text :: print('Password:'), text
+        text :: print("Password:{}".format(text))
     Label:
         text = 'Show Password:'
     CheckBox: pw_cb:

--- a/examples/tasks/enaml/employee_view.enaml
+++ b/examples/tasks/enaml/employee_view.enaml
@@ -30,7 +30,7 @@ enamldef EmployeeForm(Form):
         text = 'Password'
     Field:
         echo_mode << 'password' if not pw_cb.checked else 'normal'
-        text :: print 'Password:', text
+        text :: print('Password:'), text
     Label:
         text = 'Show Password:'
     CheckBox: pw_cb:

--- a/examples/tasks/enaml/empty_form.enaml
+++ b/examples/tasks/enaml/empty_form.enaml
@@ -49,23 +49,4 @@ enamldef EmptyForm(Form):
             text = "Confirm email:"
         Field:
             pass
-        Label:
-            text = "Confirm email:"
-        Field:
-            pass
-        Label:
-            text = "Confirm email:"
-        Field:
-            pass
-        Label:
-            text = "Confirm email:"
-        Field:
-            pass
-        Label:
-            text = "Confirm email:"
-        Field:
-            pass
-        Label:
-            text = "Confirm email:"
-        Field:
-            pass
+


### PR DESCRIPTION

This is what the final window looks like after the fix.
The example is found in https://github.com/enthought/pyface/tree/master/examples/tasks/enaml

![Screen Shot 2020-07-28 at 9 01 22 AM](https://user-images.githubusercontent.com/36972686/88676380-9a9d2480-d0b1-11ea-9c3b-b67dca6ec413.png)
