### PR TITLE
Replace GetClippingBox() with GetClippingRect() to avoid wrong argument errors

### DIFF
--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -635,7 +635,7 @@ class DockItem(HasPrivateTraits):
         """
         dc.DestroyClippingRegion()
         if self._save_clip != no_clip:
-            dc.SetClippingRegion(*self._save_clip)
+            dc.SetClippingRegion(*self._save_clip[1:])
         self._save_clip = None
 
     # ---------------------------------------------------------------------------

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -622,7 +622,7 @@ class DockItem(HasPrivateTraits):
     def begin_draw(self, dc, ox=0, oy=0):
         """ Prepares for drawing into a device context.
         """
-        self._save_clip = dc.GetClippingBox()
+        self._save_clip = dc.GetClippingRect()
         x, y, dx, dy = self.bounds
         dc.SetClippingRegion(x + ox, y + oy, dx, dy)
 
@@ -635,7 +635,7 @@ class DockItem(HasPrivateTraits):
         """
         dc.DestroyClippingRegion()
         if self._save_clip != no_clip:
-            dc.SetClippingRegion(*self._save_clip[1:])
+            dc.SetClippingRegion(*self._save_clip)
         self._save_clip = None
 
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
fixes #558 
also fixes https://github.com/enthought/traitsui/issues/1074
In line 625 we set `self._save_clip = dc.GetClippingBox()` However, GetClippingBox returns a 5-tuple 

Returns
( bool, x, y, width, height )

Only the last 4 are needed as arguments to SetClippingRegion, so `GetClippingRect()` was used instead which returns the correct arguments.


