### PR TITLE
Add CI job targeting Traits 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2 wx"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt5" TRAITS_REQUIRES="^=6.0"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt5 wx" TRAITS_REQUIRES="^=6.0"
     - os: osx
       # Obtain newer libxml2 for QtWebKit
       osx_image: xcode11.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2 wx"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt5" TRAITS_REQUIRES="^=6.0"
     - os: osx
       # Obtain newer libxml2 for QtWebKit
       osx_image: xcode11.5

--- a/etstool.py
+++ b/etstool.py
@@ -87,7 +87,16 @@ supported_combinations = {
     "3.6": {"pyqt", "pyqt5", "pyside2", "wx"},
 }
 
-dependencies = {"traits", "numpy", "pygments", "coverage"}
+# Traits version requirement (empty string to mean no specific requirement).
+# The requirement is to be interpreted by EDM
+TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
+
+dependencies = {
+    "traits" + TRAITS_VERSION_REQUIRES,
+    "numpy",
+    "pygments",
+    "coverage",
+}
 
 # NOTE : traitsui is always installed from source
 source_dependencies = {

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -25,6 +25,7 @@ __extras_require__ = {
     "pyqt5": ["pyqt>=5", "pygments"],
     "pyside": ["pyside>=1.2", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
+    "test": ["packaging"],
 }
 
 

--- a/pyface/data_view/data_models/tests/test_array_data_model.py
+++ b/pyface/data_view/data_models/tests/test_array_data_model.py
@@ -22,7 +22,7 @@ if is_traits_version_ge("6.1"):
     from pyface.data_view.abstract_data_model import DataViewSetError
     from pyface.data_view.abstract_value_type import AbstractValueType
     from pyface.data_view.value_types.api import (
-        FloatValue, IntValue, TextValue, no_value
+        FloatValue, IntValue, no_value
     )
     from pyface.data_view.data_models.array_data_model import ArrayDataModel
 

--- a/pyface/data_view/data_models/tests/test_array_data_model.py
+++ b/pyface/data_view/data_models/tests/test_array_data_model.py
@@ -13,14 +13,21 @@ from unittest import TestCase
 from traits.testing.unittest_tools import UnittestTools
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
 
-from pyface.data_view.abstract_data_model import DataViewSetError
-from pyface.data_view.abstract_value_type import AbstractValueType
-from pyface.data_view.value_types.api import (
-    FloatValue, IntValue, TextValue, no_value
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
 )
-from pyface.data_view.data_models.array_data_model import ArrayDataModel
+
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.abstract_data_model import DataViewSetError
+    from pyface.data_view.abstract_value_type import AbstractValueType
+    from pyface.data_view.value_types.api import (
+        FloatValue, IntValue, TextValue, no_value
+    )
+    from pyface.data_view.data_models.array_data_model import ArrayDataModel
 
 
+@requires_traits_min_version("6.1")
 @requires_numpy
 class TestArrayDataModel(UnittestTools, TestCase):
 

--- a/pyface/data_view/tests/test_abstract_value_type.py
+++ b/pyface/data_view/tests/test_abstract_value_type.py
@@ -14,16 +14,22 @@ from unittest.mock import Mock
 from traits.api import Str
 from traits.testing.unittest_tools import UnittestTools
 
-from pyface.data_view.abstract_data_model import DataViewSetError
-from pyface.data_view.abstract_value_type import AbstractValueType
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
+)
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.abstract_data_model import DataViewSetError
+    from pyface.data_view.abstract_value_type import AbstractValueType
 
 
-class ValueType(AbstractValueType):
+    class ValueType(AbstractValueType):
 
-    #: a parameter which should fire the update trait
-    sample_parameter = Str(update_value_type=True)
+        #: a parameter which should fire the update trait
+        sample_parameter = Str(update_value_type=True)
 
 
+@requires_traits_min_version("6.1")
 class TestAbstractValueType(UnittestTools, TestCase):
 
     def setUp(self):

--- a/pyface/data_view/tests/test_abstract_value_type.py
+++ b/pyface/data_view/tests/test_abstract_value_type.py
@@ -22,7 +22,6 @@ if is_traits_version_ge("6.1"):
     from pyface.data_view.abstract_data_model import DataViewSetError
     from pyface.data_view.abstract_value_type import AbstractValueType
 
-
     class ValueType(AbstractValueType):
 
         #: a parameter which should fire the update trait

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -17,11 +17,17 @@ from traits.testing.unittest_tools import UnittestTools
 from pyface.gui import GUI
 from pyface.window import Window
 
-from pyface.data_view.data_models.api import ArrayDataModel
-from pyface.data_view.data_view_widget import DataViewWidget
-from pyface.data_view.value_types.api import FloatValue
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
+)
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.data_models.api import ArrayDataModel
+    from pyface.data_view.data_view_widget import DataViewWidget
+    from pyface.data_view.value_types.api import FloatValue
 
 
+@requires_traits_min_version("6.1")
 @requires_numpy
 class TestWidget(unittest.TestCase, UnittestTools):
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_constant_value.py
+++ b/pyface/data_view/value_types/tests/test_constant_value.py
@@ -13,9 +13,15 @@ from unittest.mock import Mock
 
 from traits.testing.unittest_tools import UnittestTools
 
-from pyface.data_view.value_types.constant_value import ConstantValue
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
+)
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.value_types.constant_value import ConstantValue
 
 
+@requires_traits_min_version("6.1")
 class TestConstantValue(UnittestTools, TestCase):
 
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_editable_value.py
+++ b/pyface/data_view/value_types/tests/test_editable_value.py
@@ -21,7 +21,6 @@ if is_traits_version_ge("6.1"):
     from pyface.data_view.abstract_data_model import DataViewSetError
     from pyface.data_view.value_types.editable_value import EditableValue
 
-
     class EditableWithValid(EditableValue):
 
         def is_valid(self, model, row, column, value):

--- a/pyface/data_view/value_types/tests/test_editable_value.py
+++ b/pyface/data_view/value_types/tests/test_editable_value.py
@@ -13,16 +13,22 @@ from unittest.mock import Mock
 
 from traits.testing.unittest_tools import UnittestTools
 
-from pyface.data_view.abstract_data_model import DataViewSetError
-from pyface.data_view.value_types.editable_value import EditableValue
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
+)
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.abstract_data_model import DataViewSetError
+    from pyface.data_view.value_types.editable_value import EditableValue
 
 
-class EditableWithValid(EditableValue):
+    class EditableWithValid(EditableValue):
 
-    def is_valid(self, model, row, column, value):
-        return value >= 0
+        def is_valid(self, model, row, column, value):
+            return value >= 0
 
 
+@requires_traits_min_version("6.1")
 class TestEditableValue(UnittestTools, TestCase):
 
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_no_value.py
+++ b/pyface/data_view/value_types/tests/test_no_value.py
@@ -11,9 +11,15 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from pyface.data_view.value_types.no_value import NoValue
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
+)
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.value_types.no_value import NoValue
 
 
+@requires_traits_min_version("6.1")
 class TestNoValue(TestCase):
 
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_numeric_value.py
+++ b/pyface/data_view/value_types/tests/test_numeric_value.py
@@ -11,12 +11,18 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from pyface.data_view.abstract_data_model import DataViewSetError
-from pyface.data_view.value_types.numeric_value import (
-    FloatValue, IntValue, NumericValue, format_locale
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
 )
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.abstract_data_model import DataViewSetError
+    from pyface.data_view.value_types.numeric_value import (
+        FloatValue, IntValue, NumericValue, format_locale
+    )
 
 
+@requires_traits_min_version("6.1")
 class TestNumericValue(TestCase):
 
     def setUp(self):
@@ -87,6 +93,7 @@ class TestNumericValue(TestCase):
         self.model.set_value.assert_not_called()
 
 
+@requires_traits_min_version("6.1")
 class TestIntValue(TestCase):
 
     def test_defaults(self):
@@ -94,6 +101,7 @@ class TestIntValue(TestCase):
         self.assertIs(value.evaluate, int)
 
 
+@requires_traits_min_version("6.1")
 class TestFloatValue(TestCase):
 
     def test_defaults(self):

--- a/pyface/data_view/value_types/tests/test_text_value.py
+++ b/pyface/data_view/value_types/tests/test_text_value.py
@@ -16,7 +16,6 @@ from pyface.util.testing import (
     requires_traits_min_version,
 )
 if is_traits_version_ge("6.1"):
-    from pyface.data_view.abstract_data_model import DataViewSetError
     from pyface.data_view.value_types.text_value import TextValue
 
 

--- a/pyface/data_view/value_types/tests/test_text_value.py
+++ b/pyface/data_view/value_types/tests/test_text_value.py
@@ -11,10 +11,16 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from pyface.data_view.abstract_data_model import DataViewSetError
-from pyface.data_view.value_types.text_value import TextValue
+from pyface.util.testing import (
+    is_traits_version_ge,
+    requires_traits_min_version,
+)
+if is_traits_version_ge("6.1"):
+    from pyface.data_view.abstract_data_model import DataViewSetError
+    from pyface.data_view.value_types.text_value import TextValue
 
 
+@requires_traits_min_version("6.1")
 class TestTextValue(TestCase):
 
     def setUp(self):

--- a/pyface/util/testing.py
+++ b/pyface/util/testing.py
@@ -7,9 +7,19 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
+import contextlib
 from functools import wraps
+import operator
 import re
-from unittest import TestSuite
+import unittest
+from unittest import (
+    mock,
+    TestSuite,
+)
+
+from packaging.version import Version
+
+from traits import __version__ as TRAITS_VERSION
 
 
 def filter_tests(test_suite, exclusion_pattern):
@@ -49,3 +59,31 @@ def skip_if_no_traitsui(test):
             self.skipTest("Can't import traitsui.")
 
     return new_test
+
+
+def is_traits_version_ge(version):
+    """ Return true if the traits version is greater than or equal to the
+    required value.
+
+    Parameters
+    ----------
+    version : str
+        Version to be parsed. e.g. "6.0"
+    """
+    traits_version = Version(TRAITS_VERSION)
+    given_version = Version(version)
+    return traits_version >= given_version
+
+
+def requires_traits_min_version(version):
+    """ Decorator factory for tests that require a minimum version of traits.
+
+    Parameters
+    ----------
+    version : str
+        Version to be parsed. e.g. "6.0"
+    """
+    return unittest.skipUnless(
+        is_traits_version_ge(version),
+        "Test requires Traits >= {}".format(version)
+    )


### PR DESCRIPTION
Closes #632

This PR adds a CI job to test against Traits 6.0.

Tests for the data views are skipped and associated imports requiring `traits.api.observe` are wrapped in a condition (in tests only).
Data view is a new feature not yet released so it is okay for it to depend on Traits 6.1 as downstream projects can opt-in.
