### PR TITLE
Maint: Remove a print call in test

### DIFF
--- a/pyface/ui/qt4/util/tests/test_image_helpers.py
+++ b/pyface/ui/qt4/util/tests/test_image_helpers.py
@@ -96,7 +96,6 @@ class TestImageHelpers(unittest.TestCase):
         self.assertEqual(qimage.width(), 32)
         self.assertEqual(qimage.height(), 64)
         self.assertEqual(qimage.format(), QImage.Format_ARGB32)
-        print(hex(qimage.pixel(1, 1)))
         self.assertTrue(all(
             qimage.pixel(i, j) == 0xee4488cc
             for i in range(32) for j in range(64)


### PR DESCRIPTION
This PR removes an invocation of `print` in a test. Probably left behind from debugging.