### PR TITLE
Skip tests requiring traits 6.0 using load_tests instead

### DIFF
--- a/pyface/data_view/data_models/tests/test_array_data_model.py
+++ b/pyface/data_view/data_models/tests/test_array_data_model.py
@@ -13,21 +13,14 @@ from unittest import TestCase
 from traits.testing.unittest_tools import UnittestTools
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
+from pyface.data_view.abstract_data_model import DataViewSetError
+from pyface.data_view.abstract_value_type import AbstractValueType
+from pyface.data_view.value_types.api import (
+    FloatValue, IntValue, no_value
 )
-
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.abstract_data_model import DataViewSetError
-    from pyface.data_view.abstract_value_type import AbstractValueType
-    from pyface.data_view.value_types.api import (
-        FloatValue, IntValue, no_value
-    )
-    from pyface.data_view.data_models.array_data_model import ArrayDataModel
+from pyface.data_view.data_models.array_data_model import ArrayDataModel
 
 
-@requires_traits_min_version("6.1")
 @requires_numpy
 class TestArrayDataModel(UnittestTools, TestCase):
 

--- a/pyface/data_view/tests/test_abstract_value_type.py
+++ b/pyface/data_view/tests/test_abstract_value_type.py
@@ -14,21 +14,15 @@ from unittest.mock import Mock
 from traits.api import Str
 from traits.testing.unittest_tools import UnittestTools
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
-)
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.abstract_data_model import DataViewSetError
-    from pyface.data_view.abstract_value_type import AbstractValueType
+from pyface.data_view.abstract_data_model import DataViewSetError
+from pyface.data_view.abstract_value_type import AbstractValueType
 
-    class ValueType(AbstractValueType):
+class ValueType(AbstractValueType):
 
-        #: a parameter which should fire the update trait
-        sample_parameter = Str(update_value_type=True)
+    #: a parameter which should fire the update trait
+    sample_parameter = Str(update_value_type=True)
 
 
-@requires_traits_min_version("6.1")
 class TestAbstractValueType(UnittestTools, TestCase):
 
     def setUp(self):

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -17,17 +17,11 @@ from traits.testing.unittest_tools import UnittestTools
 from pyface.gui import GUI
 from pyface.window import Window
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
-)
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.data_models.api import ArrayDataModel
-    from pyface.data_view.data_view_widget import DataViewWidget
-    from pyface.data_view.value_types.api import FloatValue
+from pyface.data_view.data_models.api import ArrayDataModel
+from pyface.data_view.data_view_widget import DataViewWidget
+from pyface.data_view.value_types.api import FloatValue
 
 
-@requires_traits_min_version("6.1")
 @requires_numpy
 class TestWidget(unittest.TestCase, UnittestTools):
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_constant_value.py
+++ b/pyface/data_view/value_types/tests/test_constant_value.py
@@ -13,15 +13,9 @@ from unittest.mock import Mock
 
 from traits.testing.unittest_tools import UnittestTools
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
-)
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.value_types.constant_value import ConstantValue
+from pyface.data_view.value_types.constant_value import ConstantValue
 
 
-@requires_traits_min_version("6.1")
 class TestConstantValue(UnittestTools, TestCase):
 
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_editable_value.py
+++ b/pyface/data_view/value_types/tests/test_editable_value.py
@@ -13,21 +13,15 @@ from unittest.mock import Mock
 
 from traits.testing.unittest_tools import UnittestTools
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
-)
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.abstract_data_model import DataViewSetError
-    from pyface.data_view.value_types.editable_value import EditableValue
+from pyface.data_view.abstract_data_model import DataViewSetError
+from pyface.data_view.value_types.editable_value import EditableValue
 
-    class EditableWithValid(EditableValue):
+class EditableWithValid(EditableValue):
 
-        def is_valid(self, model, row, column, value):
-            return value >= 0
+    def is_valid(self, model, row, column, value):
+        return value >= 0
 
 
-@requires_traits_min_version("6.1")
 class TestEditableValue(UnittestTools, TestCase):
 
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_no_value.py
+++ b/pyface/data_view/value_types/tests/test_no_value.py
@@ -11,15 +11,9 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
-)
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.value_types.no_value import NoValue
+from pyface.data_view.value_types.no_value import NoValue
 
 
-@requires_traits_min_version("6.1")
 class TestNoValue(TestCase):
 
     def setUp(self):

--- a/pyface/data_view/value_types/tests/test_numeric_value.py
+++ b/pyface/data_view/value_types/tests/test_numeric_value.py
@@ -11,18 +11,12 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
+from pyface.data_view.abstract_data_model import DataViewSetError
+from pyface.data_view.value_types.numeric_value import (
+    FloatValue, IntValue, NumericValue, format_locale
 )
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.abstract_data_model import DataViewSetError
-    from pyface.data_view.value_types.numeric_value import (
-        FloatValue, IntValue, NumericValue, format_locale
-    )
 
 
-@requires_traits_min_version("6.1")
 class TestNumericValue(TestCase):
 
     def setUp(self):
@@ -93,7 +87,6 @@ class TestNumericValue(TestCase):
         self.model.set_value.assert_not_called()
 
 
-@requires_traits_min_version("6.1")
 class TestIntValue(TestCase):
 
     def test_defaults(self):
@@ -101,7 +94,6 @@ class TestIntValue(TestCase):
         self.assertIs(value.evaluate, int)
 
 
-@requires_traits_min_version("6.1")
 class TestFloatValue(TestCase):
 
     def test_defaults(self):

--- a/pyface/data_view/value_types/tests/test_text_value.py
+++ b/pyface/data_view/value_types/tests/test_text_value.py
@@ -11,15 +11,9 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from pyface.util.testing import (
-    is_traits_version_ge,
-    requires_traits_min_version,
-)
-if is_traits_version_ge("6.1"):
-    from pyface.data_view.value_types.text_value import TextValue
+from pyface.data_view.value_types.text_value import TextValue
 
 
-@requires_traits_min_version("6.1")
 class TestTextValue(TestCase):
 
     def setUp(self):

--- a/pyface/util/testing.py
+++ b/pyface/util/testing.py
@@ -11,7 +11,6 @@ import contextlib
 from functools import wraps
 import operator
 import re
-import unittest
 from unittest import (
     mock,
     TestSuite,
@@ -73,17 +72,3 @@ def is_traits_version_ge(version):
     traits_version = Version(TRAITS_VERSION)
     given_version = Version(version)
     return traits_version >= given_version
-
-
-def requires_traits_min_version(version):
-    """ Decorator factory for tests that require a minimum version of traits.
-
-    Parameters
-    ----------
-    version : str
-        Version to be parsed. e.g. "6.0"
-    """
-    return unittest.skipUnless(
-        is_traits_version_ge(version),
-        "Test requires Traits >= {}".format(version)
-    )


### PR DESCRIPTION
Closes #662

Instead of wrapping import and individual test case with condition on traits version, this PR moves the skip over to `pyface.load_tests` to skip all tests with `.data_view.` in the test name.  The idea is that it would skip tests in `pyface.data_view.*`, `pyface.qt.data_view.*` etc. when we run `python -munittest discover pyface`

Side-effect:
- `pyface.data_view.index_manager` does not depend on Traits 6.1. Previously `pyface.data_view.tests.test_index_manager` is not skipped in the Traits ~6.0~ 6.1 test run. Now it is.
- The skip message has changed from `'Test requires Traits >= 6.1'` to `"Test excluded via pattern '\\.data_view\\.'"`

Note:
- The logic `load_tests` is only used when running the test suite using `unittest discover pyface`. The tests won't be skipped if the run command is, for example, `python -m unittest discover pyface.data_view`, nor `python -m unittest pyface.data_view.[module].[TestCase].[test_method]`.  This would only result in test error in an environment with Traits 6, but we think this is a rare use case.
- For skipping tests in `data_view` in `load_tests`, I opt for evaluating the traits version inside `load_tests` instead of requiring the developer to have set an environment variable. This will reduce confusion for contributors who don't use `etstool.py` for development purposes (for me, I only use `etstool.py` for its `install` command), as well as developers who want to verify their pyface installation from running `python -m unittest pyface`. Otherwise running `python -m unittest pyface` without `etstool.py` in an environment with Traits 6.0 is going to create a number of test errors.
