### PR TITLE
Mention in docstrings that examples aren't implemented on qt backend 

### DIFF
--- a/examples/explorer.py
+++ b/examples/explorer.py
@@ -8,8 +8,9 @@
 #
 # Thanks for using Enthought open source!
 
-""" A file explorer example. 
-    Note: This demo only works on the wx backend. """
+""" A file explorer example.
+    Note: This demo only works on the wx backend.
+"""
 
 
 import os

--- a/examples/explorer.py
+++ b/examples/explorer.py
@@ -8,7 +8,8 @@
 #
 # Thanks for using Enthought open source!
 
-""" A file explorer example. """
+""" A file explorer example. 
+    Note: This demo only works on the wx backend. """
 
 
 import os

--- a/examples/multi_toolbar_window.py
+++ b/examples/multi_toolbar_window.py
@@ -8,8 +8,9 @@
 #
 # Thanks for using Enthought open source!
 
-""" Mulit-tool bar example. 
-    Note: This demo only works on the wx backend. """
+""" Mulit-tool bar example.
+    Note: This demo only works on the wx backend.
+"""
 
 
 import os, sys

--- a/examples/multi_toolbar_window.py
+++ b/examples/multi_toolbar_window.py
@@ -8,7 +8,8 @@
 #
 # Thanks for using Enthought open source!
 
-""" Mulit-tool bar example. """
+""" Mulit-tool bar example. 
+    Note: This demo only works on the wx backend. """
 
 
 import os, sys

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -310,12 +310,12 @@ class _Table(wx.ListCtrl):  # (ULC.UltimateListCtrl):#
 
         # Set up attributes to show alternate rows with a different background
         # colour.
-        self._even_row_attribute = wx.ItemAttr()
+        self._even_row_attribute = wx.ListItemAttr()
         self._even_row_attribute.SetBackgroundColour(
             self._viewer.even_row_background
         )
 
-        self._odd_row_attribute = wx.ItemAttr()
+        self._odd_row_attribute = wx.ListItemAttr()
         self._odd_row_attribute.SetBackgroundColour(
             self._viewer.odd_row_background
         )

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -310,12 +310,12 @@ class _Table(wx.ListCtrl):  # (ULC.UltimateListCtrl):#
 
         # Set up attributes to show alternate rows with a different background
         # colour.
-        self._even_row_attribute = wx.ListItemAttr()
+        self._even_row_attribute = wx.ItemAttr()
         self._even_row_attribute.SetBackgroundColour(
             self._viewer.even_row_background
         )
 
-        self._odd_row_attribute = wx.ListItemAttr()
+        self._odd_row_attribute = wx.ItemAttr()
         self._odd_row_attribute.SetBackgroundColour(
             self._viewer.odd_row_background
         )


### PR DESCRIPTION
fixes #647 

Also, there was a deprecation warning when running explorer.py on wx that I tried to fix here.  It probably could have been in its own PR, but it was so small I just added it here.  

Also as a side note I don't really understand what exactly the multi_toolbar_window.py is really supposed to demonstrate.  It also seems like the window isn't displaying correctly.  

<img width="405" alt="Screen Shot 2020-08-13 at 4 12 47 PM" src="https://user-images.githubusercontent.com/36972686/90187716-d9083400-dd7f-11ea-8305-498780accf8d.png">

Notice the "Foo" and "Bus" seem to overlap.  I will open a separate issue for this. 
