### PR TITLE
adding trivial docstrings

### DIFF
--- a/examples/data_view/array_example.py
+++ b/examples/data_view/array_example.py
@@ -8,6 +8,9 @@
 #
 # Thanks for using Enthought open source!
 
+""" Example showing DataView for ArrayDataModel. """
+
+
 from traits.api import Array, Instance
 
 from pyface.api import ApplicationWindow, GUI

--- a/examples/data_view/column_example.py
+++ b/examples/data_view/column_example.py
@@ -8,6 +8,9 @@
 #
 # Thanks for using Enthought open source!
 
+""" Example showing DataView for ColumnDataModel using row info. """
+
+
 from functools import partial
 from random import choice, randint
 

--- a/examples/menu_manager.py
+++ b/examples/menu_manager.py
@@ -8,6 +8,8 @@
 #
 # Thanks for using Enthought open source!
 
+""" Menu Manager example. """
+
 
 import os, sys
 

--- a/examples/tool_palette.py
+++ b/examples/tool_palette.py
@@ -8,6 +8,8 @@
 #
 # Thanks for using Enthought open source!
 
+""" Example of a Tool Palette. """
+
 
 import wx
 


### PR DESCRIPTION
fixes #639 

The docstrings are all still very trivial and could be added to, but these are consistent with the other examples. 