### PR TITLE
replacing ListItemAttr with ItemAttr to avoid deprecation warning

### DIFF
--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -310,12 +310,12 @@ class _Table(wx.ListCtrl):  # (ULC.UltimateListCtrl):#
 
         # Set up attributes to show alternate rows with a different background
         # colour.
-        self._even_row_attribute = wx.ListItemAttr()
+        self._even_row_attribute = wx.ItemAttr()
         self._even_row_attribute.SetBackgroundColour(
             self._viewer.even_row_background
         )
 
-        self._odd_row_attribute = wx.ListItemAttr()
+        self._odd_row_attribute = wx.ItemAttr()
         self._odd_row_attribute.SetBackgroundColour(
             self._viewer.odd_row_background
         )


### PR DESCRIPTION
See comments on #667.

We do not currently see the deprecation warning when using a wx environment created by the etstool in pyface as the development environment has pinned an older version of wxPython.
However, when using an environment with newer wx, there was the following deprecation warning (found when running the explorer.py example):
```
/Users/aayres/Desktop/pyface/pyface/ui/wx/viewer/table_viewer.py:313: wxPyDeprecationWarning: Using deprecated class. Use ItemAttr instead
  self._even_row_attribute = wx.ListItemAttr()
/Users/aayres/Desktop/pyface/pyface/ui/wx/viewer/table_viewer.py:318: wxPyDeprecationWarning: Using deprecated class. Use ItemAttr instead
  self._odd_row_attribute = wx.ListItemAttr()
```