### PR TITLE
Fix Wx/linux clipboard test failures

### DIFF
--- a/pyface/ui/wx/clipboard.py
+++ b/pyface/ui/wx/clipboard.py
@@ -44,7 +44,7 @@ def _ensure_clipboard():
         try:
             yield
         finally:
-            cb.UsePrimarySelection(False)
+            cb.UsePrimarySelection(True)
     else:
         yield
 
@@ -58,13 +58,14 @@ class Clipboard(BaseClipboard):
 
     def _get_has_data(self):
         result = False
-        if cb.Open():
-            result = (
-                cb.IsSupported(TextFormat)
-                or cb.IsSupported(FileFormat)
-                or cb.IsSupported(PythonObjectFormat)
-            )
-            cb.Close()
+        with _ensure_clipboard():
+            if cb.Open():
+                result = (
+                    cb.IsSupported(TextFormat)
+                    or cb.IsSupported(FileFormat)
+                    or cb.IsSupported(PythonObjectFormat)
+                )
+                cb.Close()
         return result
 
     # ---------------------------------------------------------------------------
@@ -104,8 +105,8 @@ class Clipboard(BaseClipboard):
         return self._has_this_data(PythonObjectFormat)
 
     def _get_object_type(self):
+        result = ""
         with _ensure_clipboard():
-            result = ""
             if cb.Open():
                 try:
                     if cb.IsSupported(PythonObjectFormat):
@@ -182,7 +183,8 @@ class Clipboard(BaseClipboard):
 
     def _has_this_data(self, format):
         result = False
-        if cb.Open():
-            result = cb.IsSupported(format)
-            cb.Close()
-        return result
+        with _ensure_clipboard():
+            if cb.Open():
+                result = cb.IsSupported(format)
+                cb.Close()
+            return result


### PR DESCRIPTION
Fixes #674

Under X11-based systems, Wx can pull values to be pasted either from the clipboard, or from the current ("primary") selection. This change ensures that the Pyface clipboard is always getting data from the clipboard, and never from the current selection.

This is implemented via a context manager which ensures that the wider application state controlling the source of paste data is unmodified, minimizing the likelihood of problems in the wider application (particularly if Pyface is being used as a library). The context manager will do nothing if called from a non-X11 system.