### PR TITLE
Update Wx CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - pulseaudio
     - libpulse-mainloop-glib0
     # Wx dependencies
-    - libsdl1.2debian
+    - libsdl2.0debian
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ addons:
     - pulseaudio
     - libpulse-mainloop-glib0
     # Wx dependencies
-    - libsdl2.0debian
+    - libsdl2-2.0-0
 
 env:
   global:

--- a/etstool.py
+++ b/etstool.py
@@ -208,7 +208,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
         elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-14.04/ wxPython<4.1"  # noqa: E501
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-16.04/ wxPython<4.1"  # noqa: E501
             )
         else:
             commands.append(


### PR DESCRIPTION
This updates the Wx CI to use the wxPython package for Ubuntu 16.04, which is now the default version of Ubuntu used in Travis CI (updated from 14.04 when wxPython testing was last updated).

It also turns on Python's faulthandler when running tests via etstool, so segfaults and other hard crashes should give better feedback.

This needs #676 to be merged first.