### PR TITLE
Tooltips for DataViews

### DIFF
--- a/pyface/data_view/abstract_value_type.py
+++ b/pyface/data_view/abstract_value_type.py
@@ -182,6 +182,49 @@ class AbstractValueType(ABCHasStrictTraits):
         """
         raise DataViewSetError("Cannot set value.")
 
+    def has_tooltip(self, model, row, column):
+        """ Whether or not the value has a tooltip.
+
+        The default implementation returns True if ``get_tooltip``
+        returns a non-empty value.
+
+        Parameters
+        ----------
+        model : AbstractDataModel
+            The data model holding the data.
+        row : sequence of int
+            The row in the data model being queried.
+        column : sequence of int
+            The column in the data model being queried.
+
+        Returns
+        -------
+        has_tooltip : bool
+            Whether or not the value has a textual representation.
+        """
+        return self.get_tooltip(model, row, column) != ""
+
+    def get_tooltip(self, model, row, column):
+        """ The tooltip for the underlying value.
+
+        The default implementation returns an empty string.
+
+        Parameters
+        ----------
+        model : AbstractDataModel
+            The data model holding the data.
+        row : sequence of int
+            The row in the data model being queried.
+        column : sequence of int
+            The column in the data model being queried.
+
+        Returns
+        -------
+        tooltip : str
+            The textual representation of the underlying value.
+        """
+        return ""
+
     @observe('+update_value_type')
     def update_value_type(self, event=None):
         """ Fire update event when marked traits change. """

--- a/pyface/data_view/value_types/constant_value.py
+++ b/pyface/data_view/value_types/constant_value.py
@@ -24,8 +24,14 @@ class ConstantValue(AbstractValueType):
     #: The text value to display.
     text = Str(update_value_type=True)
 
+    #: The tooltip value to display.
+    tooltip = Str(update_value_type=True)
+
     def has_editor_value(self, model, row, column):
         return False
 
     def get_text(self, model, row, column):
         return self.text
+
+    def get_tooltip(self, model, row, column):
+        return self.tooltip

--- a/pyface/data_view/value_types/no_value.py
+++ b/pyface/data_view/value_types/no_value.py
@@ -20,6 +20,9 @@ class NoValue(AbstractValueType):
     def has_text(self, model, row, column):
         return False
 
+    def has_tooltip(self, model, row, column):
+        return False
+
 
 #: Standard instance of the NoValue class, since it has no state.
 no_value = NoValue()

--- a/pyface/data_view/value_types/tests/test_constant_value.py
+++ b/pyface/data_view/value_types/tests/test_constant_value.py
@@ -24,6 +24,7 @@ class TestConstantValue(UnittestTools, TestCase):
     def test_defaults(self):
         value_type = ConstantValue()
         self.assertEqual(value_type.text, "")
+        self.assertEqual(value_type.tooltip, "")
 
     def test_has_editor_value(self):
         value_type = ConstantValue()
@@ -49,3 +50,24 @@ class TestConstantValue(UnittestTools, TestCase):
         with self.assertTraitChanges(value_type, 'updated'):
             value_type.text = 'something'
         self.assertEqual(value_type.text, 'something')
+
+    def test_has_tooltip(self):
+        value_type = ConstantValue()
+        self.assertFalse(value_type.has_tooltip(self.model, [0], [0]))
+
+    def test_has_tooltip_true(self):
+        value_type = ConstantValue(tooltip="something")
+        self.assertTrue(value_type.has_tooltip(self.model, [0], [0]))
+
+    def test_get_tooltip(self):
+        value_type = ConstantValue(tooltip="something")
+        self.assertEqual(
+            value_type.get_tooltip(self.model, [0], [0]),
+            "something"
+        )
+
+    def test_tooltip_changed(self):
+        value_type = ConstantValue()
+        with self.assertTraitChanges(value_type, 'updated'):
+            value_type.tooltip = 'something'
+        self.assertEqual(value_type.tooltip, 'something')

--- a/pyface/data_view/value_types/tests/test_no_value.py
+++ b/pyface/data_view/value_types/tests/test_no_value.py
@@ -26,3 +26,7 @@ class TestNoValue(TestCase):
     def test_has_text(self):
         value_type = NoValue()
         self.assertFalse(value_type.has_text(self.model, [0], [0]))
+
+    def test_has_tooltip(self):
+        value_type = NoValue()
+        self.assertFalse(value_type.has_tooltip(self.model, [0], [0]))

--- a/pyface/ui/qt4/data_view/data_view_item_model.py
+++ b/pyface/ui/qt4/data_view/data_view_item_model.py
@@ -148,6 +148,9 @@ class DataViewItemModel(QAbstractItemModel):
         elif role == Qt.EditRole:
             if value_type.has_editor_value(self.model, row, column):
                 return value_type.get_editor_value(self.model, row, column)
+        elif role == Qt.ToolTipRole:
+            if value_type.has_tooltip(self.model, row, column):
+                return value_type.get_tooltip(self.model, row, column)
 
         return None
 

--- a/pyface/ui/wx/data_view/data_view_model.py
+++ b/pyface/ui/wx/data_view/data_view_model.py
@@ -176,8 +176,8 @@ class DataViewModel(wxDataViewModel):
         return self.model.get_column_count() + 1
 
     def GetColumnType(self, column):
-        value_type = self.model.get_value_type((), (column-1,))
-        return type_hint_to_variant.get(value_type.type_hint, "string")
+        # XXX This may need refinement when we deal with different editor types
+        return "string"
 
     def _to_row_index(self, item):
         id = item.GetID()


### PR DESCRIPTION
Straight-forward addition of a tooltip channel for data view `ValueTypes`.  There is some incompleteness around what the default tooltip should be for numeric and text values, so for now it is something to be handled by subclassing.  Appropriate usage may become clear after sufficient use.

Only works on Qt backend.