### PR TITLE
logger.warn is deprecated, use logger.warning instead

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,7 +150,7 @@ try:
 except ImportError as exc:
     import warnings
     msg = "Can't find Enthought Sphinx Theme, using default.\nException was:\n{}"
-    warnings.warn(RuntimeWarning(msg.format(exc)))
+    warnings.warning(RuntimeWarning(msg.format(exc)))
 
     # old defaults
     html_logo = "e-logo-rev.jpg"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -150,7 +150,7 @@ try:
 except ImportError as exc:
     import warnings
     msg = "Can't find Enthought Sphinx Theme, using default.\nException was:\n{}"
-    warnings.warning(RuntimeWarning(msg.format(exc)))
+    warnings.warn(RuntimeWarning(msg.format(exc)))
 
     # old defaults
     html_logo = "e-logo-rev.jpg"

--- a/pyface/tasks/i_editor_area_pane.py
+++ b/pyface/tasks/i_editor_area_pane.py
@@ -173,7 +173,7 @@ class MEditorAreaPane(HasTraits):
         # If not, create an editor for it.
         editor = self.create_editor(obj, factory)
         if editor is None:
-            logger.warn("Cannot create editor for obj %r", obj)
+            logger.warning("Cannot create editor for obj %r", obj)
 
         else:
             self.add_editor(editor)

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -162,7 +162,7 @@ class TaskWindow(ApplicationWindow):
             self._active_state = state
             task.activated()
         elif not state:
-            logger.warn(
+            logger.warning(
                 "Cannot activate task %r: task does not belong to the "
                 "window." % task
             )
@@ -220,7 +220,7 @@ class TaskWindow(ApplicationWindow):
             self._destroy_state(state)
             self._states.remove(state)
         else:
-            logger.warn(
+            logger.warning(
                 "Cannot remove task %r: task does not belong to the "
                 "window." % task
             )
@@ -332,7 +332,7 @@ class TaskWindow(ApplicationWindow):
             if state:
                 state.layout = layout
             else:
-                logger.warn(
+                logger.warning(
                     "Cannot apply layout for task %r: task does not "
                     "belong to the window." % layout.id
                 )

--- a/pyface/tree/node_manager.py
+++ b/pyface/tree/node_manager.py
@@ -96,7 +96,7 @@ class NodeManager(HasPrivateTraits):
                 node_type = None
 
         if node_type is None:
-            logger.warn("no node type for %s" % str(node))
+            logger.warning("no node type for %s" % str(node))
 
         return node_type
 

--- a/pyface/ui/wx/tree/tree.py
+++ b/pyface/ui/wx/tree/tree.py
@@ -468,7 +468,7 @@ class Tree(Widget):
         except KeyError:
             # fixme: No, really, this is a serious one... How do we get in this
             # situation.  It came up when using the canvas stuff...
-            logger.warn("removing node: %s" % str(node))
+            logger.warning("removing node: %s" % str(node))
 
     def _get_style(self):
         """ Returns the wx style flags for creating the tree control. """

--- a/pyface/ui/wx/workbench/editor_set_structure_handler.py
+++ b/pyface/ui/wx/workbench/editor_set_structure_handler.py
@@ -70,7 +70,7 @@ class EditorSetStructureHandler(SetStructureHandler):
             window.editors.append(editor)
 
         except:
-            logger.warn("could not restore editor [%s]", id)
+            logger.warning("could not restore editor [%s]", id)
             control = None
 
         return control

--- a/pyface/ui/wx/workbench/view_set_structure_handler.py
+++ b/pyface/ui/wx/workbench/view_set_structure_handler.py
@@ -60,7 +60,7 @@ class ViewSetStructureHandler(SetStructureHandler):
             control = window_layout._wx_get_view_control(view)
 
         else:
-            logger.warn("could not restore view [%s]", id)
+            logger.warning("could not restore view [%s]", id)
             control = None
 
         return control

--- a/pyface/workbench/i_view.py
+++ b/pyface/workbench/i_view.py
@@ -94,7 +94,7 @@ class MView(MWorkbenchPart, PerspectiveItem):
         """ Trait initializer. """
 
         id = "%s.%s" % (type(self).__module__, type(self).__name__)
-        logger.warn("view %s has no Id - using <%s>" % (self, id))
+        logger.warning("view %s has no Id - using <%s>" % (self, id))
 
         # If no Id is specified then use the name.
         return id
@@ -103,7 +103,7 @@ class MView(MWorkbenchPart, PerspectiveItem):
         """ Trait initializer. """
 
         name = camel_case_to_words(type(self).__name__)
-        logger.warn("view %s has no name - using <%s>" % (self, name))
+        logger.warning("view %s has no name - using <%s>" % (self, name))
 
         return name
 

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -362,7 +362,7 @@ class WorkbenchWindow(ApplicationWindow):
         editor = self.create_editor(obj, kind)
 
         if editor is None:
-            logger.warn("no editor for object %s", obj)
+            logger.warning("no editor for object %s", obj)
 
         self.add_editor(editor)
         self.activate_editor(editor)
@@ -614,7 +614,7 @@ class WorkbenchWindow(ApplicationWindow):
 
         # If we have no known perspectives, make a new blank one up.
         else:
-            logger.warn("no known perspectives - creating a new one")
+            logger.warning("no known perspectives - creating a new one")
             perspective = Perspective()
 
         return perspective
@@ -632,7 +632,7 @@ class WorkbenchWindow(ApplicationWindow):
         if len(id) > 0:
             perspective = self.get_perspective_by_id(id)
             if perspective is None:
-                logger.warn("default perspective %s no longer available", id)
+                logger.warning("default perspective %s no longer available", id)
 
         else:
             perspective = None
@@ -652,7 +652,7 @@ class WorkbenchWindow(ApplicationWindow):
         if len(id) > 0:
             perspective = self.get_perspective_by_id(id)
             if perspective is None:
-                logger.warn("previous perspective %s no longer available", id)
+                logger.warning("previous perspective %s no longer available", id)
 
         else:
             perspective = None


### PR DESCRIPTION
Ref : https://docs.python.org/3.6/library/logging.html#logging.Logger.warning