### PR TITLE
Update copyright header

### DIFF
--- a/pyface/util/guisupport.py
+++ b/pyface/util/guisupport.py
@@ -1,4 +1,4 @@
-# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# (C) Copyright 2010-2020 Enthought, Inc., Austin, TX
 # All rights reserved.
 #
 # This software is provided without warranty under the terms of the BSD


### PR DESCRIPTION
`pyface.util.guisupport` is taken from the IPython codebase, which has copyright till 2010 and we can only claim copyright for changes during/after 2010.

(It might be worth while to see what changes have happened to the original `guisupport` module to see if we can incorporate any meaningful changes back into the module.)