### PR TITLE
Add a new shell click command

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -244,6 +244,23 @@ def install(edm, runtime, toolkit, environment, editable, source):
 @click.option("--runtime", default="3.6", help="Python version to use")
 @click.option("--toolkit", default="pyqt", help="Toolkit and API to use")
 @click.option("--environment", default=None, help="EDM environment to use")
+def shell(edm, runtime, toolkit, environment):
+    """ Create a shell into the EDM development environment
+    (aka 'activate' it).
+
+    """
+    parameters = get_parameters(edm ,runtime, toolkit, environment)
+    commands = [
+        "{edm} shell -e {environment}",
+    ]
+    execute(commands, parameters)
+
+
+@cli.command()
+@edm_option
+@click.option("--runtime", default="3.6", help="Python version to use")
+@click.option("--toolkit", default="pyqt", help="Toolkit and API to use")
+@click.option("--environment", default=None, help="EDM environment to use")
 @click.option(
     "--no-environment-vars",
     is_flag=True,


### PR DESCRIPTION
This PR adds a new `shell` click command - which when run activates the development environment for traits. The usual command line options are available to choose the environment name and the runtime/toolkit version of the development environment. Underneath the hood, the click command just uses the `edm shell` command with the appropriate environment name, which is why the docstring for the click command is _almost_ the same as that of `edm shell`.
