### PR TITLE
Remove border from Qt HeadingText.

### DIFF
--- a/pyface/ui/qt4/heading_text.py
+++ b/pyface/ui/qt4/heading_text.py
@@ -57,8 +57,6 @@ class HeadingText(MHeadingText, Widget):
         self.control = QtGui.QLabel(parent)
         self._set_text(self.text)
 
-        self.control.setFrameShape(QtGui.QFrame.StyledPanel)
-        self.control.setFrameShadow(QtGui.QFrame.Raised)
         self.control.setSizePolicy(
             QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed
         )


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/600761/93792300-433cb000-fc2d-11ea-93b1-2626e2915ccd.png" width="50%" height="50%">

Fixes #664 
