### PR TITLE
DataView drop handler

### DIFF
--- a/examples/data_view/array_example.py
+++ b/examples/data_view/array_example.py
@@ -10,14 +10,21 @@
 
 """ Example showing DataView for ArrayDataModel. """
 
+import logging
 
-from traits.api import Array, Instance
+import numpy as np
+
+from traits.api import Array, Instance, observe
 
 from pyface.api import ApplicationWindow, GUI
+from pyface.drop_handler import FileDropHandler
 from pyface.data_view.data_models.array_data_model import ArrayDataModel
 from pyface.data_view.i_data_view_widget import IDataViewWidget
 from pyface.data_view.data_view_widget import DataViewWidget
 from pyface.data_view.value_types.api import FloatValue
+
+
+logger = logging.getLogger(__name__)
 
 
 class MainWindow(ApplicationWindow):
@@ -26,6 +33,12 @@ class MainWindow(ApplicationWindow):
     data = Array()
 
     data_view = Instance(IDataViewWidget)
+
+    def load_data(self, path):
+        try:
+            self.data = np.load(path)
+        except Exception:
+            logger.exception()
 
     def _create_contents(self, parent):
         """ Creates the left hand side or top depending on the style. """
@@ -36,21 +49,30 @@ class MainWindow(ApplicationWindow):
                 data=self.data,
                 value_type=FloatValue(),
             ),
+            drop_handlers=[
+                FileDropHandler(extensions=['.npy'], open_file=self.load_data),
+            ],
         )
         self.data_view._create()
         return self.data_view.control
-
-    def _data_default(self):
-        import numpy
-        return numpy.random.uniform(size=(10000, 10, 10))*1000000
 
     def destroy(self):
         self.data_view.destroy()
         super().destroy()
 
+    @observe('data')
+    def _data_updated(self, event):
+        if self.data_view is not None:
+            self.data_view.data_model.data = self.data
+
+    def _data_default(self):
+        return np.random.uniform(size=(10000, 10, 10))*1000000
+
 
 # Application entry point.
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+
     # Create the GUI (this does NOT start the GUI event loop).
     gui = GUI()
 

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -17,6 +17,7 @@ from traits.api import (
 )
 
 from pyface.data_view.abstract_data_model import AbstractDataModel
+from pyface.i_drop_handler import IDropHandler
 from pyface.i_widget import IWidget
 
 
@@ -31,6 +32,12 @@ class IDataViewWidget(IWidget):
 
     #: Whether or not the column headers are visible.
     header_visible = Bool(True)
+
+    #: The global drop handlers for the data view.  These are intended to
+    #: handle drop actions which either affect the whole data view, or where
+    #: the data handler can work out how to change the underlying data without
+    #: additional input.
+    drop_handlers = List(Instance(IDropHandler))
 
     #: What can be selected.  Implementations may optionally allow "column"
     #: and "item" selection types.
@@ -55,6 +62,12 @@ class MDataViewWidget(HasStrictTraits):
 
     #: Whether or not the column headers are visible.
     header_visible = Bool(True)
+
+    #: The global drop handlers for the data view.  These are intended to
+    #: handle drop actions which either affect the whole data view, or where
+    #: the data handler can work out how to change the underlying data without
+    #: additional input.
+    drop_handlers = List(Instance(IDropHandler))
 
     #: The selected indices in the view.  This should never be mutated, any
     #: changes should be by replacement of the entire list.

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -37,7 +37,7 @@ class IDataViewWidget(IWidget):
     #: handle drop actions which either affect the whole data view, or where
     #: the data handler can work out how to change the underlying data without
     #: additional input.
-    drop_handlers = List(Instance(IDropHandler))
+    drop_handlers = List(Instance(IDropHandler, allow_none=False))
 
     #: What can be selected.  Implementations may optionally allow "column"
     #: and "item" selection types.
@@ -67,7 +67,7 @@ class MDataViewWidget(HasStrictTraits):
     #: handle drop actions which either affect the whole data view, or where
     #: the data handler can work out how to change the underlying data without
     #: additional input.
-    drop_handlers = List(Instance(IDropHandler))
+    drop_handlers = List(Instance(IDropHandler, allow_none=False))
 
     #: The selected indices in the view.  This should never be mutated, any
     #: changes should be by replacement of the entire list.

--- a/pyface/ui/qt4/data_view/data_view_widget.py
+++ b/pyface/ui/qt4/data_view/data_view_widget.py
@@ -75,7 +75,7 @@ class DataViewTreeView(QTreeView):
                 if drop_handler.can_handle_drop(event, self):
                     event.acceptProposedAction()
                     return
-        super().dragEnterEvent(event)
+        super().dragLeaveEvent(event)
 
     def dropEvent(self, event):
         if self._widget is not None:

--- a/pyface/ui/qt4/data_view/data_view_widget.py
+++ b/pyface/ui/qt4/data_view/data_view_widget.py
@@ -51,41 +51,41 @@ class DataViewTreeView(QTreeView):
     _widget = None
 
     def dragEnterEvent(self, event):
-        if self._widget is not None:
-            widget = self._widget
-            for drop_handler in widget.drop_handlers:
-                if drop_handler.can_handle_drop(event, self):
-                    event.acceptProposedAction()
-                    return
-        super().dragEnterEvent(event)
+        drop_handler = self._get_drop_handler(event)
+        if drop_handler is not None:
+            event.acceptProposedAction()
+        else:
+            super().dragEnterEvent(event)
 
     def dragMoveEvent(self, event):
-        if self._widget is not None:
-            widget = self._widget
-            for drop_handler in widget.drop_handlers:
-                if drop_handler.can_handle_drop(event, self):
-                    event.acceptProposedAction()
-                    return
-        super().dragMoveEvent(event)
+        drop_handler = self._get_drop_handler(event)
+        if drop_handler is not None:
+            event.acceptProposedAction()
+        else:
+            super().dragMoveEvent(event)
 
     def dragLeaveEvent(self, event):
-        if self._widget is not None:
-            widget = self._widget
-            for drop_handler in widget.drop_handlers:
-                if drop_handler.can_handle_drop(event, self):
-                    event.acceptProposedAction()
-                    return
-        super().dragLeaveEvent(event)
+        drop_handler = self._get_drop_handler(event)
+        if drop_handler is not None:
+            event.acceptProposedAction()
+        else:
+            super().dragLeaveEvent(event)
 
     def dropEvent(self, event):
+        drop_handler = self._get_drop_handler(event)
+        if drop_handler is not None:
+            drop_handler.handle_drop(event, self)
+            event.acceptProposedAction()
+        else:
+            super().dropEvent(event)
+
+    def _get_drop_handler(self, event):
         if self._widget is not None:
             widget = self._widget
             for drop_handler in widget.drop_handlers:
                 if drop_handler.can_handle_drop(event, self):
-                    drop_handler.handle_drop(event, self)
-                    event.acceptProposedAction()
-                    return
-        super().dropEvent(event)
+                    return drop_handler
+        return None
 
 
 @provides(IDataViewWidget)

--- a/pyface/ui/qt4/data_view/data_view_widget.py
+++ b/pyface/ui/qt4/data_view/data_view_widget.py
@@ -10,13 +10,13 @@
 
 import logging
 
-from traits.api import Bool, Enum, Instance, observe, provides
+from traits.api import Callable, Enum, Instance, observe, provides
 
-from pyface.qt.QtCore import QAbstractItemModel
+from pyface.qt.QtCore import QAbstractItemModel, QEvent, QObject
 from pyface.qt.QtGui import (
-    QAbstractItemView, QItemSelection, QItemSelectionModel, QTreeView
+    QAbstractItemView, QItemSelection, QItemSelectionModel, QPalette,
+    QTreeView
 )
-from pyface.data_view.abstract_data_model import AbstractDataModel
 from pyface.data_view.i_data_view_widget import (
     IDataViewWidget, MDataViewWidget
 )
@@ -45,9 +45,55 @@ pyface_selection_modes = {
 }
 
 
+class DataViewTreeView(QTreeView):
+    """ QTreeView subclass that handles drag and drop via DropHandlers. """
+
+    _widget = None
+
+    def dragEnterEvent(self, event):
+        if self._widget is not None:
+            widget = self._widget
+            for drop_handler in widget.drop_handlers:
+                if drop_handler.can_handle_drop(event, self):
+                    event.acceptProposedAction()
+                    return
+        super().dragEnterEvent(event)
+
+    def dragMoveEvent(self, event):
+        if self._widget is not None:
+            widget = self._widget
+            for drop_handler in widget.drop_handlers:
+                if drop_handler.can_handle_drop(event, self):
+                    event.acceptProposedAction()
+                    return
+        super().dragMoveEvent(event)
+
+    def dragLeaveEvent(self, event):
+        if self._widget is not None:
+            widget = self._widget
+            for drop_handler in widget.drop_handlers:
+                if drop_handler.can_handle_drop(event, self):
+                    event.acceptProposedAction()
+                    return
+        super().dragEnterEvent(event)
+
+    def dropEvent(self, event):
+        if self._widget is not None:
+            widget = self._widget
+            for drop_handler in widget.drop_handlers:
+                if drop_handler.can_handle_drop(event, self):
+                    drop_handler.handle_drop(event, self)
+                    event.acceptProposedAction()
+                    return
+        super().dropEvent(event)
+
+
 @provides(IDataViewWidget)
 class DataViewWidget(MDataViewWidget, Widget):
     """ The Qt implementation of the DataViewWidget. """
+
+    #: Factory for the underlying Qt control, to facilitate replacement
+    control_factory = Callable(DataViewTreeView)
 
     # IDataViewWidget Interface traits --------------------------------------
 
@@ -173,19 +219,26 @@ class DataViewWidget(MDataViewWidget, Widget):
         """ Create the DataViewWidget's toolkit control. """
         self._create_item_model()
 
-        control = QTreeView(parent)
+        control = self.control_factory(parent)
+        control._widget = self
         control.setUniformRowHeights(True)
         control.setAnimated(True)
         control.setModel(self._item_model)
+        control.setAcceptDrops(True)
+        control.setDropIndicatorShown(True)
         return control
 
     def destroy(self):
         """ Perform any actions required to destroy the control.
         """
-        self.control.setModel(None)
+        if self.control is not None:
+            self.control.setModel(None)
+
+            # ensure that we release references
+            self.control._widget = None
+            self._item_model = None
+
         super().destroy()
-        # ensure that we release the reference to the item model
-        self._item_model = None
 
     # ------------------------------------------------------------------------
     # Private methods


### PR DESCRIPTION
This is basic drop support using the existing `IDropHandler` interface.  This is designed mainly for supporting entire-table drop actions (eg. dropping a file with alternative data onto a table, or dropping an object that will be inserted into a location automatically).

With some toolkit-specific code could be used for deeper introspection of the drop target and handle dropping to replace, insert, or even move values.  However, at some point we would like to expose an additional API that makes these sorts of operations easier.

This PR includes adding support for dropping `.npy` format files onto the array example to replace the array being viewed with one loaded from the `.npy` file.