### PR TITLE
DataView Color clean-up

### DIFF
--- a/examples/data_view/column_example.py
+++ b/examples/data_view/column_example.py
@@ -10,14 +10,12 @@
 
 """ Example showing DataView for ColumnDataModel using row info. """
 
-from functools import partial
 import logging
-from random import choice, randint, uniform
 
 from traits.api import Bool, Dict, HasStrictTraits, Instance, Int, Str, List
 
 from pyface.api import ApplicationWindow, GUI, Image, ImageResource
-from pyface.color import Color
+from pyface.ui_traits import PyfaceColor
 from pyface.data_view.i_data_view_widget import IDataViewWidget
 from pyface.data_view.data_view_widget import DataViewWidget
 from pyface.data_view.value_types.api import (
@@ -42,22 +40,22 @@ flags = {
 
 class Address(HasStrictTraits):
 
-    street = Str
+    street = Str()
 
-    city = Str
+    city = Str()
 
-    country = Str
+    country = Str()
 
 
 class Person(HasStrictTraits):
 
-    name = Str
+    name = Str()
 
-    age = Int
+    age = Int()
 
-    favorite_color = Instance(Color)
+    favorite_color = PyfaceColor()
 
-    contacted = Bool
+    contacted = Bool()
 
     address = Instance(Address)
 

--- a/examples/data_view/row_table_example.py
+++ b/examples/data_view/row_table_example.py
@@ -13,7 +13,7 @@ import logging
 from traits.api import Bool, HasStrictTraits, Instance, Int, Str, List
 
 from pyface.api import ApplicationWindow, GUI
-from pyface.color import Color
+from pyface.ui_traits import PyfaceColor
 from pyface.data_view.data_models.data_accessors import AttributeDataAccessor
 from pyface.data_view.data_models.row_table_data_model import (
     RowTableDataModel
@@ -49,9 +49,9 @@ class Person(HasStrictTraits):
 
     age = Int()
 
-    favorite_color = Instance(Color)
+    favorite_color = PyfaceColor()
 
-    contacted = Bool
+    contacted = Bool()
 
     address = Instance(Address, ())
 

--- a/pyface/data_view/value_types/color_value.py
+++ b/pyface/data_view/value_types/color_value.py
@@ -44,7 +44,7 @@ class ColorValue(EditableValue):
         """
         return isinstance(value, Color)
 
-    def get_editable(self, model, row, column):
+    def get_editor_value(self, model, row, column):
         """ Get the editable representation of the underlying value.
 
         The default uses a text hex representation of the color.
@@ -65,7 +65,7 @@ class ColorValue(EditableValue):
         """
         return model.get_value(row, column).hex()
 
-    def set_editable(self, model, row, column, value):
+    def set_editor_value(self, model, row, column, value):
         """ Set the editable representation of the underlying value.
 
         The default expects a string that can be parsed to a color value.
@@ -90,7 +90,7 @@ class ColorValue(EditableValue):
             color = Color.from_str(value)
         except Exception:
             raise DataViewSetError()
-        return super().set_editable(model, row, column, color)
+        return super().set_editor_value(model, row, column, color)
 
     def get_text(self, model, row, column):
         """ Get the textual representation of the underlying value.
@@ -130,7 +130,7 @@ class ColorValue(EditableValue):
         success : bool
             Whether or not the value was successfully set.
         """
-        return self.set_editable(model, row, column, text)
+        return self.set_editor_value(model, row, column, text)
 
     def has_color(self, model, row, column):
         """ Whether or not the value has color data.

--- a/pyface/data_view/value_types/constant_value.py
+++ b/pyface/data_view/value_types/constant_value.py
@@ -8,9 +8,9 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Instance, Str, observe
+from traits.api import Str, Union, observe
 
-from pyface.color import Color
+from pyface.ui_traits import PyfaceColor
 from pyface.data_view.abstract_value_type import AbstractValueType
 from pyface.ui_traits import Image
 
@@ -27,7 +27,7 @@ class ConstantValue(AbstractValueType):
     text = Str(update_value_type=True)
 
     #: The color value to display or None if no color.
-    color = Instance(Color)
+    color = Union(None, PyfaceColor)
 
     #: The image value to display.
     image = Image(update_value_type=True)

--- a/pyface/data_view/value_types/tests/test_color_value.py
+++ b/pyface/data_view/value_types/tests/test_color_value.py
@@ -37,35 +37,45 @@ class TestColorValue(TestCase):
     def test_get_editor_value(self):
         value = ColorValue()
         editable = value.get_editor_value(self.model, [0], [0])
-        self.assertEqual(editable, Color(rgba=(0.4, 0.2, 0.6, 0.8)))
+        self.assertEqual(editable, "#663399CC")
 
     def test_set_editor_value(self):
         value = ColorValue()
-        value.set_editor_value(self.model, [0], [0], Color())
-        self.model.set_value.assert_called_once_with([0], [0], Color())
+        value.set_editor_value(self.model, [0], [0], "#3399CC66")
+        self.model.set_value.assert_called_once_with(
+            [0],
+            [0],
+            Color(rgba=(0.2, 0.6, 0.8, 0.4)),
+        )
 
     def test_get_text(self):
         value = ColorValue()
         editable = value.get_text(self.model, [0], [0])
         self.assertEqual(editable, "#663399CC")
 
-    @expectedFailure
     def test_set_text(self):
         value = ColorValue()
         value.set_text(self.model, [0], [0], "red")
-        self.model.set_value.assert_called_once_with([0], [0], Color(red=1.0))
+        self.model.set_value.assert_called_once_with(
+            [0],
+            [0],
+            Color(rgba=(1.0, 0.0, 0.0, 1.0)),
+        )
 
     def test_set_text_error(self):
         value = ColorValue()
         with self.assertRaises(DataViewSetError):
             value.set_text(self.model, [0], [0], "not a real color")
 
-    @expectedFailure
     def test_set_text_no_set_value(self):
         self.model.can_set_value = Mock(return_value=False)
         value = ColorValue()
         value.set_text(self.model, [0], [0], "red")
-        self.model.set_value.assert_called_once_with([0], [0], Color(red=1.0))
+        self.model.set_value.assert_called_once_with(
+            [0],
+            [0],
+            Color(rgba=(1.0, 0.0, 0.0, 1.0)),
+        )
 
     def test_get_color(self):
         value = ColorValue()

--- a/pyface/data_view/value_types/tests/test_constant_value.py
+++ b/pyface/data_view/value_types/tests/test_constant_value.py
@@ -53,12 +53,6 @@ class TestConstantValue(UnittestTools, TestCase):
             value_type.text = 'something'
         self.assertEqual(value_type.text, 'something')
 
-    def test_text_changed(self):
-        value_type = ConstantValue()
-        with self.assertTraitChanges(value_type, 'updated'):
-            value_type.text = 'something'
-        self.assertEqual(value_type.text, 'something')
-
     def test_has_color_default(self):
         value_type = ConstantValue()
         self.assertFalse(value_type.has_color(self.model, [0], [0]))
@@ -72,10 +66,10 @@ class TestConstantValue(UnittestTools, TestCase):
         self.assertIsNone(value_type.get_color(self.model, [0], [0]))
 
     def test_get_color(self):
-        value_type = ConstantValue(color=Color(rgba=(0.4, 0.2, 0.6, 0.8)))
+        value_type = ConstantValue(color='rebeccapurple')
         self.assertEqual(
             value_type.get_color(self.model, [0], [0]),
-            Color(rgba=(0.4, 0.2, 0.6, 0.8))
+            Color(rgba=(0.4, 0.2, 0.6, 1.0))
         )
 
     def test_get_color_changed(self):


### PR DESCRIPTION
This PR does two things:

- switches from `Instance(Color)` to `PyfaceColor` traits
- fixes #708 (`ColorValue` was using an older iteration of the `ValueType` API)

We will probably revisit `ColorValue` again once there are custom editors available.


