### PR TITLE
Fix QFontMetrics.width deprecation warning

### DIFF
--- a/pyface/ui/qt4/code_editor/code_widget.py
+++ b/pyface/ui/qt4/code_editor/code_widget.py
@@ -473,7 +473,12 @@ class CodeWidget(QtGui.QPlainTextEdit):
         style = self.style()
         opt = QtGui.QStyleOptionHeader()
         font_metrics = QtGui.QFontMetrics(self.document().defaultFont())
-        width = font_metrics.width(" ") * 80
+        # QFontMetrics.width() is deprecated and Qt docs suggest using
+        # horizontalAdvance() instead, but is only available since Qt 5.11
+        if QtCore.__version_info__ >= (5, 11):
+            width = font_metrics.horizontalAdvance(" ") * 80
+        else:
+            width = font_metrics.width(" ") * 80
         width += self.line_number_widget.sizeHint().width()
         width += self.status_widget.sizeHint().width()
         width += style.pixelMetric(QtGui.QStyle.PM_ScrollBarExtent, opt, self)

--- a/pyface/ui/qt4/code_editor/find_widget.py
+++ b/pyface/ui/qt4/code_editor/find_widget.py
@@ -19,7 +19,12 @@ class FindWidget(QtGui.QWidget):
         super(FindWidget, self).__init__(parent)
         self.adv_code_widget = weakref.ref(parent)
 
-        self.button_size = self.fontMetrics().width("Replace All") + 20
+        # QFontMetrics.width() is deprecated and Qt docs suggest using
+        # horizontalAdvance() instead, but is only available since Qt 5.11
+        if QtCore.__version_info__ >= (5, 11):
+            self.button_size = self.fontMetrics().horizontalAdvance("Replace All") + 20
+        else:
+            self.button_size = self.fontMetrics().width("Replace All") + 20
 
         form_layout = QtGui.QFormLayout()
         form_layout.addRow("Fin&d", self._create_find_control())

--- a/pyface/ui/qt4/code_editor/gutters.py
+++ b/pyface/ui/qt4/code_editor/gutters.py
@@ -96,9 +96,17 @@ class LineNumberWidget(GutterWidget):
         ndigits = max(
             self.min_char_width, int(math.floor(math.log10(nlines) + 1))
         )
-        width = max(
-            self.fontMetrics().width("0" * ndigits) + 3, self.min_width
-        )
+        # QFontMetrics.width() is deprecated and Qt docs suggest using
+        # horizontalAdvance() instead, but is only available since Qt 5.11
+        if QtCore.__version_info__ >= (5, 11):
+            width = max(
+                self.fontMetrics().horizontalAdvance("0" * ndigits) + 3,
+                self.min_width
+            )
+        else:
+            width = max(
+                self.fontMetrics().width("0" * ndigits) + 3, self.min_width
+            )
         return width
 
     def sizeHint(self):

--- a/pyface/ui/qt4/code_editor/replace_widget.py
+++ b/pyface/ui/qt4/code_editor/replace_widget.py
@@ -21,7 +21,12 @@ class ReplaceWidget(FindWidget):
         super(FindWidget, self).__init__(parent)
         self.adv_code_widget = weakref.ref(parent)
 
-        self.button_size = self.fontMetrics().width("Replace All") + 20
+        # QFontMetrics.width() is deprecated and Qt docs suggest using
+        # horizontalAdvance() instead, but is only available since Qt 5.11
+        if QtCore.__version_info__ >= (5, 11):
+            self.button_size = self.fontMetrics().horizontalAdvance("Replace All") + 20
+        else:
+            self.button_size = self.fontMetrics().width("Replace All") + 20
 
         form_layout = QtGui.QFormLayout()
         form_layout.addRow("Fin&d", self._create_find_control())


### PR DESCRIPTION
fixes #653 

This PR simply uses QFontMetrics().horizontalAdvance() instead of QFontMetrics().width()when possible (horizontalAdvance was introduced in Qt 5.11) to avoid a deprecation warning.

Same fix was done in an open PR on traitsui: https://github.com/enthought/traitsui/pull/1315