### PR TITLE
Fix deprecation warning from Qt SystemMetrics width and height computation

### DIFF
--- a/pyface/ui/qt4/system_metrics.py
+++ b/pyface/ui/qt4/system_metrics.py
@@ -12,7 +12,7 @@
 # However, when used with the GPL version of PyQt the additional terms described in the PyQt GPL exception also apply
 
 
-from pyface.qt import QtGui
+from pyface.qt import QtCore, QtGui
 
 
 from traits.api import HasTraits, Int, Property, provides, Tuple
@@ -40,12 +40,24 @@ class SystemMetrics(MSystemMetrics, HasTraits):
     # ------------------------------------------------------------------------
 
     def _get_screen_width(self):
-        return QtGui.QApplication.instance().desktop().screenGeometry().width()
+        # QDesktopWidget.screenGeometry() is deprecated and Qt docs
+        # suggest using screens() instead, but screens in not available in qt4
+        if QtCore.__version_info__ >= (5, 0):
+            return QtGui.QApplication.instance().screens()[0].geometry().width()
+        else:
+            return QtGui.QApplication.instance().desktop().screenGeometry().width()
 
     def _get_screen_height(self):
-        return (
-            QtGui.QApplication.instance().desktop().screenGeometry().height()
-        )
+        # QDesktopWidget.screenGeometry(int screen) is deprecated and Qt docs
+        # suggest using screens() instead, but screens in not available in qt4
+        if QtCore.__version_info__ >= (5, 0):
+            return (
+                QtGui.QApplication.instance().screens()[0].geometry().height()
+            )
+        else:
+            return (
+                QtGui.QApplication.instance().desktop().screenGeometry().height()
+            )
 
     def _get_dialog_background_color(self):
         color = (


### PR DESCRIPTION
fixes #718 

This PR replaces `QtGui.QApplication.instance().desktop(`) with `QtGui.QApplication.instance().screens()[0]` when possible (when qt version is recent enough to have `screens()`) so that screen geometry can be obtained on a `QScreen` object (where it is not a deprecated method) rather than on a `QDesktopWidget` object.