### PR TITLE
Use availableGeometry when computing screen size to only get available space on scree

### DIFF
--- a/pyface/ui/qt4/system_metrics.py
+++ b/pyface/ui/qt4/system_metrics.py
@@ -54,11 +54,11 @@ class SystemMetrics(MSystemMetrics, HasTraits):
         # see issue: enthought/pyface#721
         if is_qt5:
             return (
-                QtGui.QApplication.instance().screens()[0].geometry().height()
+                QtGui.QApplication.instance().screens()[0].availableGeometry().height()
             )
         else:
             return (
-                QtGui.QApplication.instance().desktop().screenGeometry().height()
+                QtGui.QApplication.instance().desktop().availableGeometry().height()
             )
 
     def _get_dialog_background_color(self):

--- a/pyface/ui/qt4/system_metrics.py
+++ b/pyface/ui/qt4/system_metrics.py
@@ -44,9 +44,9 @@ class SystemMetrics(MSystemMetrics, HasTraits):
         # suggest using screens() instead, but screens in not available in qt4
         # see issue: enthought/pyface#721
         if is_qt5:
-            return QtGui.QApplication.instance().screens()[0].geometry().width()
+            return QtGui.QApplication.instance().screens()[0].availableGeometry().width()
         else:
-            return QtGui.QApplication.instance().desktop().screenGeometry().width()
+            return QtGui.QApplication.instance().desktop().availableGeometry().width()
 
     def _get_screen_height(self):
         # QDesktopWidget.screenGeometry(int screen) is deprecated and Qt docs


### PR DESCRIPTION
fixes #724 

For discussion of the motivation see https://github.com/enthought/traitsui/pull/1322

This PR simply replaces calls to `screeGeometry` and `geometry` with calls to `availableGeometry` as we are really interested in the available screen space not the full screen space. 