### PR TITLE
Have mixins inherit from HasTraits

### DIFF
--- a/pyface/i_about_dialog.py
+++ b/pyface/i_about_dialog.py
@@ -11,7 +11,7 @@
 """ The interface for a simple 'About' dialog. """
 
 
-from traits.api import Instance, List, Str
+from traits.api import HasTraits, Instance, List, Str
 
 
 from pyface.i_dialog import IDialog
@@ -33,7 +33,7 @@ class IAboutDialog(IDialog):
     image = Instance(ImageResource, ImageResource("about"))
 
 
-class MAboutDialog(object):
+class MAboutDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IAboutDialog interface.
     """

--- a/pyface/i_application_window.py
+++ b/pyface/i_application_window.py
@@ -11,7 +11,7 @@
 """ The interface of a top-level application window. """
 
 
-from traits.api import Instance, List
+from traits.api import HasTraits, Instance, List
 
 
 from pyface.action.api import MenuBarManager, StatusBarManager, ToolBarManager
@@ -109,7 +109,7 @@ class IApplicationWindow(IWindow):
         """ Sets the window icon (if required). """
 
 
-class MApplicationWindow(object):
+class MApplicationWindow(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the :py:class:`IApplicationWindow` interface.
 

--- a/pyface/i_confirmation_dialog.py
+++ b/pyface/i_confirmation_dialog.py
@@ -11,7 +11,7 @@
 """ The interface for a dialog that prompts the user for confirmation. """
 
 
-from traits.api import Bool, Enum, Instance, Str
+from traits.api import Bool, Enum, HasTraits, Instance, Str
 
 
 from pyface.constant import CANCEL, NO, YES
@@ -50,7 +50,7 @@ class IConfirmationDialog(IDialog):
     yes_label = Str()
 
 
-class MConfirmationDialog(object):
+class MConfirmationDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IConfirmationDialog interface.
     """

--- a/pyface/i_dialog.py
+++ b/pyface/i_dialog.py
@@ -11,7 +11,7 @@
 """ The abstract interface for all pyface dialogs. """
 
 
-from traits.api import Bool, Enum, Int, Str
+from traits.api import Bool, Enum, HasTraits, Int, Str
 
 
 from pyface.constant import OK
@@ -134,7 +134,7 @@ class IDialog(IWindow):
         """
 
 
-class MDialog(object):
+class MDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IDialog interface.
 

--- a/pyface/i_directory_dialog.py
+++ b/pyface/i_directory_dialog.py
@@ -12,7 +12,7 @@
 """
 
 
-from traits.api import Bool, Str
+from traits.api import Bool, HasTraits, Str
 
 
 from pyface.i_dialog import IDialog
@@ -42,7 +42,7 @@ class IDirectoryDialog(IDialog):
     path = Str()
 
 
-class MDirectoryDialog(object):
+class MDirectoryDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IDirectoryDialog interface.
     """

--- a/pyface/i_file_dialog.py
+++ b/pyface/i_file_dialog.py
@@ -14,7 +14,7 @@
 import sys
 
 
-from traits.api import Enum, Str, Int
+from traits.api import Enum, HasTraits, Int, Str
 
 
 from pyface.i_dialog import IDialog
@@ -56,7 +56,7 @@ class IFileDialog(IDialog):
     wildcard_index = Int(0)
 
 
-class MFileDialog(object):
+class MFileDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IFileDialog interface.
 

--- a/pyface/i_gui.py
+++ b/pyface/i_gui.py
@@ -16,7 +16,7 @@ import os
 
 
 from traits.etsconfig.api import ETSConfig
-from traits.api import Bool, Interface, Str
+from traits.api import Bool, HasTraits, Interface, Str
 
 
 # Logging.
@@ -159,7 +159,7 @@ class IGUI(Interface):
         """ Stop the GUI event loop. """
 
 
-class MGUI(object):
+class MGUI(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IGUI interface.
 

--- a/pyface/i_heading_text.py
+++ b/pyface/i_heading_text.py
@@ -11,7 +11,7 @@
 """ Heading text. """
 
 
-from traits.api import Instance, Int, Interface, Str
+from traits.api import HasTraits, Instance, Int, Interface, Str
 
 
 from pyface.i_image_resource import IImageResource
@@ -35,7 +35,7 @@ class IHeadingText(Interface):
     image = Instance(IImageResource)
 
 
-class MHeadingText(object):
+class MHeadingText(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IHeadingText interface.
     """

--- a/pyface/i_image_cache.py
+++ b/pyface/i_image_cache.py
@@ -11,7 +11,7 @@
 """ The interface for an image cache. """
 
 
-from traits.api import Interface
+from traits.api import HasTraits, Interface
 
 
 class IImageCache(Interface):
@@ -70,7 +70,7 @@ class IImageCache(Interface):
         """
 
 
-class MImageCache(object):
+class MImageCache(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IImageCache interface.
     """

--- a/pyface/i_image_resource.py
+++ b/pyface/i_image_resource.py
@@ -13,7 +13,7 @@ from collections.abc import Sequence
 
 from pyface.resource_manager import resource_manager
 from pyface.resource.resource_path import resource_module, resource_path
-from traits.api import Interface, List, Str
+from traits.api import HasTraits, Interface, List, Str
 
 
 class IImageResource(Interface):
@@ -113,7 +113,7 @@ class IImageResource(Interface):
         """
 
 
-class MImageResource(object):
+class MImageResource(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IImageResource interface.
 

--- a/pyface/i_message_dialog.py
+++ b/pyface/i_message_dialog.py
@@ -11,7 +11,7 @@
 """ The interface for a dialog that displays a message. """
 
 
-from traits.api import Enum, Str
+from traits.api import Enum, HasTraits, Str
 
 
 from pyface.i_dialog import IDialog
@@ -35,7 +35,7 @@ class IMessageDialog(IDialog):
     severity = Enum("information", "warning", "error")
 
 
-class MMessageDialog(object):
+class MMessageDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IMessageDialog interface.
     """

--- a/pyface/i_progress_dialog.py
+++ b/pyface/i_progress_dialog.py
@@ -11,7 +11,7 @@
 """ The interface for a dialog that allows the user to open/save files etc. """
 
 
-from traits.api import Any, Bool, Int, Str
+from traits.api import Any, Bool, HasTraits, Int, Str
 
 
 from pyface.i_dialog import IDialog
@@ -74,7 +74,7 @@ class IProgressDialog(IDialog):
         """
 
 
-class MProgressDialog(object):
+class MProgressDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IProgressDialog interface.
 

--- a/pyface/i_python_editor.py
+++ b/pyface/i_python_editor.py
@@ -11,7 +11,7 @@
 """ A widget for editing Python code. """
 
 
-from traits.api import Bool, Event, Interface, Str
+from traits.api import Bool, Event, HasTraits, Interface, Str
 
 
 from pyface.key_pressed_event import KeyPressedEvent
@@ -77,7 +77,7 @@ class IPythonEditor(Interface):
         """
 
 
-class MPythonEditor(object):
+class MPythonEditor(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IPythonEditor interface.
 

--- a/pyface/i_python_shell.py
+++ b/pyface/i_python_shell.py
@@ -11,7 +11,7 @@
 """ The interface for an interactive Python shell. """
 
 
-from traits.api import Event
+from traits.api import Event, HasTraits
 
 
 from pyface.key_pressed_event import KeyPressedEvent
@@ -100,7 +100,7 @@ class IPythonShell(IWidget):
         """
 
 
-class MPythonShell(object):
+class MPythonShell(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IPythonShell interface.
 

--- a/pyface/i_single_choice_dialog.py
+++ b/pyface/i_single_choice_dialog.py
@@ -11,7 +11,7 @@
 """ The interface for a dialog that prompts for a choice from a list. """
 
 
-from traits.api import Any, List, Str
+from traits.api import Any, HasTraits, List, Str
 
 
 from pyface.i_dialog import IDialog
@@ -35,7 +35,7 @@ class ISingleChoiceDialog(IDialog):
     message = Str()
 
 
-class MSingleChoiceDialog(object):
+class MSingleChoiceDialog(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IConfirmationDialog interface.
     """

--- a/pyface/i_splash_screen.py
+++ b/pyface/i_splash_screen.py
@@ -14,7 +14,7 @@
 import logging
 
 
-from traits.api import Any, Bool, Instance, Int, Tuple, Str
+from traits.api import Any, Bool, HasTraits, Instance, Int, Tuple, Str
 
 
 from pyface.image_resource import ImageResource
@@ -58,7 +58,7 @@ class ISplashScreen(IWindow):
     text_location = Tuple(5, 5)
 
 
-class MSplashScreen(object):
+class MSplashScreen(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the ISplashScreen interface.
 

--- a/pyface/i_split_widget.py
+++ b/pyface/i_split_widget.py
@@ -11,7 +11,7 @@
 """ Mix-in class for split widgets. """
 
 
-from traits.api import Callable, Enum, Float, Interface
+from traits.api import Callable, Enum, Float, HasTraits, Interface
 
 
 class ISplitWidget(Interface):
@@ -86,7 +86,7 @@ class ISplitWidget(Interface):
         """
 
 
-class MSplitWidget(object):
+class MSplitWidget(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the ISplitWidget interface.
     """

--- a/pyface/i_system_metrics.py
+++ b/pyface/i_system_metrics.py
@@ -11,7 +11,7 @@
 """ The interface to system metrics (screen width and height etc). """
 
 
-from traits.api import Int, Interface, Tuple
+from traits.api import HasTraits, Int, Interface, Tuple
 
 
 class ISystemMetrics(Interface):
@@ -31,7 +31,7 @@ class ISystemMetrics(Interface):
     dialog_background_color = Tuple()
 
 
-class MSystemMetrics(object):
+class MSystemMetrics(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the ISystemMetrics interface.
     """

--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -90,7 +90,7 @@ class IWidget(Interface):
         """ Remove toolkit-specific bindings for events """
 
 
-class MWidget(object):
+class MWidget(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IWidget interface.
     """

--- a/pyface/i_window.py
+++ b/pyface/i_window.py
@@ -13,7 +13,7 @@
 """ The abstract interface for all pyface top-level windows. """
 
 
-from traits.api import Event, Tuple, Str, Vetoable, VetoableEvent
+from traits.api import Event, HasTraits, Tuple, Str, Vetoable, VetoableEvent
 
 
 from pyface.constant import NO
@@ -170,7 +170,7 @@ class IWindow(IWidget):
         """
 
 
-class MWindow(object):
+class MWindow(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IWindow interface.
 

--- a/pyface/wizard/i_wizard.py
+++ b/pyface/wizard/i_wizard.py
@@ -11,7 +11,7 @@
 """ The interface for all pyface wizards. """
 
 
-from traits.api import Bool, Instance, List, Str
+from traits.api import Bool, HasTraits, Instance, List, Str
 from pyface.i_dialog import IDialog
 
 
@@ -50,7 +50,7 @@ class IWizard(IDialog):
         """ Return to the previous page in the wizard. """
 
 
-class MWizard(object):
+class MWizard(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IWizard interface.
 

--- a/pyface/wizard/i_wizard_page.py
+++ b/pyface/wizard/i_wizard_page.py
@@ -11,7 +11,7 @@
 """ The interface for a page in a wizard. """
 
 
-from traits.api import Bool, Interface, Str, Tuple, Str
+from traits.api import Bool, HasTraits, Interface, Str, Tuple, Str
 
 
 class IWizardPage(Interface):
@@ -63,7 +63,7 @@ class IWizardPage(Interface):
         """ Creates the actual page content. """
 
 
-class MWizardPage(object):
+class MWizardPage(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IWizardPage interface.
 


### PR DESCRIPTION
This is a simple search and replace of `class MFoo(object):` with `class MFoo(HasTraits):`, combined with fixing of the imports where necessary.

Fixes #730.

This not intended to be part of the 7.1.0 release.