### PR TITLE
Widget observer framework

### DIFF
--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -91,13 +91,17 @@ class IWidget(Interface):
         """ Remove toolkit-specific bindings for events """
 
 
-class MWidget(object):
+class MWidget(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IWidget interface.
     """
 
     def destroy(self):
-        """ Destroy the control if it exists. """
+        """ Destroy the control if it exists.
+
+        Subclasses of this mixin should ensure that they call super()
+        if they override this method.
+        """
         if self.control is not None:
             self._remove_event_listeners()
             self.control = None
@@ -111,12 +115,17 @@ class MWidget(object):
 
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
+
+        Subclasses of this mixin should ensure that they call super()
+        if they override this method.
         """
         self.control = self._create_control(self.parent)
         self._add_event_listeners()
 
     def _create_control(self, parent):
         """ Create toolkit specific control that represents the widget.
+
+        Subclasses of this mixin should implement this method.
 
         Parameters
         ----------
@@ -141,9 +150,7 @@ class MWidget(object):
         super() to ensure superclass listeners are also connected.
         """
         for name, trait in self.traits(widget_observer=not_none).items():
-            observer = trait.widget_observer
-            if isinstance(observer, str):
-                observer = getattr(self, observer)
+            observer = getattr(self, trait.widget_observer)
             self.observe(observer, name, dispatch='ui')
 
     def _remove_event_listeners(self):

--- a/pyface/ui/qt4/widget.py
+++ b/pyface/ui/qt4/widget.py
@@ -80,6 +80,7 @@ class Widget(MWidget, HasTraits):
             self.control = None
 
     def _add_event_listeners(self):
+        super()._add_event_listeners()
         self.control.installEventFilter(self._event_filter)
 
     def _remove_event_listeners(self):
@@ -87,6 +88,7 @@ class Widget(MWidget, HasTraits):
             if self.control is not None:
                 self.control.removeEventFilter(self._event_filter)
             self._event_filter = None
+        super()._remove_event_listeners()
 
     # Trait change handlers --------------------------------------------------
 

--- a/pyface/ui/wx/widget.py
+++ b/pyface/ui/wx/widget.py
@@ -70,4 +70,4 @@ class Widget(MWidget, HasTraits):
     def destroy(self):
         if self.control is not None:
             self.control.Destroy()
-            self.control = None
+        super().destroy()


### PR DESCRIPTION
This adds the infrastructure for simple widget observer configuration via trait metadata.

This adds code to the `MWidget` implementation of the current private API methods `_add_event_listeners` and `_remove_event_listeners` to automatically hook up methods to trait observers where the `widget_observer` metadata holds the name of the method to handle the calls.

Some changes are needed to the various `Widget` classes to make sure that things are always called correctly: the addition of several `super()` calls, and the addition of a base implementation of `dispose` on `MWidget`.

Other than in a test, this does not change any widget to use the framework, and so should have no impact on behaviour.

This is the first step of #732.