### PR TITLE
Add a create method for IWidget

### DIFF
--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -11,7 +11,7 @@
 """ The base interface for all pyface widgets. """
 
 
-from traits.api import Any, Bool, Interface
+from traits.api import Any, Bool, HasTraits, Interface
 
 
 class IWidget(Interface):

--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -11,7 +11,7 @@
 """ The base interface for all pyface widgets. """
 
 
-from traits.api import Any, Bool, HasTraits, Interface
+from traits.api import Any, Bool, Interface
 
 
 class IWidget(Interface):
@@ -54,19 +54,19 @@ class IWidget(Interface):
             The enabled state to set the widget to.
         """
 
+    def create(self):
+        """ Creates the toolkit specific control.
+
+        This method should create the control and assign it to the
+        :py:attr:``control`` trait.
+        """
+
     def destroy(self):
         """ Destroy the control if it exists. """
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.
     # ------------------------------------------------------------------------
-
-    def _create(self):
-        """ Creates the toolkit specific control.
-
-        This method should create the control and assign it to the
-        :py:attr:``control`` trait.
-        """
 
     def _create_control(self, parent):
         """ Create toolkit specific control that represents the widget.
@@ -94,6 +94,13 @@ class MWidget(object):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IWidget interface.
     """
+
+    def create(self):
+        """ Creates the toolkit specific control.
+
+        The default implementation simply calls _create()
+        """
+        self._create()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -53,6 +53,11 @@ class TestWidget(unittest.TestCase, UnittestTools):
     def test_create(self):
         # create is not Implemented
         with self.assertRaises(NotImplementedError):
+            self.widget.create()
+
+    def test__create(self):
+        # _create is not Implemented
+        with self.assertRaises(NotImplementedError):
             self.widget._create()
 
     def test_destroy(self):
@@ -99,7 +104,7 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
 
     def test_lifecycle(self):
         with self.event_loop():
-            self.widget._create()
+            self.widget.create()
         with self.event_loop():
             self.widget.destroy()
 
@@ -107,14 +112,14 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
         self.widget.visible = False
         self.widget.enabled = False
         with self.event_loop():
-            self.widget._create()
+            self.widget.create()
 
         self.assertFalse(self.widget.control.isVisible())
         self.assertFalse(self.widget.control.isEnabled())
 
     def test_show(self):
         with self.event_loop():
-            self.widget._create()
+            self.widget.create()
 
         with self.assertTraitChanges(self.widget, "visible", count=1):
             with self.event_loop():
@@ -124,7 +129,7 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
 
     def test_visible(self):
         with self.event_loop():
-            self.widget._create()
+            self.widget.create()
 
         with self.assertTraitChanges(self.widget, "visible", count=1):
             with self.event_loop():
@@ -134,7 +139,7 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
 
     def test_enable(self):
         with self.event_loop():
-            self.widget._create()
+            self.widget.create()
 
         with self.assertTraitChanges(self.widget, "enabled", count=1):
             with self.event_loop():
@@ -144,7 +149,7 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
 
     def test_enabled(self):
         with self.event_loop():
-            self.widget._create()
+            self.widget.create()
 
         with self.assertTraitChanges(self.widget, "enabled", count=1):
             with self.event_loop():


### PR DESCRIPTION
This adds `create` as a synonym for `_create` and uses it for `Widget` class tests.

This is the first part of #729.