### PR TITLE
avoid importing ArrayDataModel if numpy is not installed

### DIFF
--- a/pyface/data_view/data_models/tests/test_array_data_model.py
+++ b/pyface/data_view/data_models/tests/test_array_data_model.py
@@ -10,6 +10,7 @@
 
 from unittest import TestCase
 
+from traits.api import TraitError
 from traits.testing.unittest_tools import UnittestTools
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
 
@@ -18,7 +19,12 @@ from pyface.data_view.abstract_value_type import AbstractValueType
 from pyface.data_view.value_types.api import (
     FloatValue, IntValue, no_value
 )
-from pyface.data_view.data_models.array_data_model import ArrayDataModel
+# This import results in an error without numpy installed
+# see enthought/pyface#742
+try:
+    from pyface.data_view.data_models.api import ArrayDataModel
+except TraitError:
+    pass
 
 
 @requires_numpy

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -19,7 +19,12 @@ from pyface.gui import GUI
 from pyface.toolkit import toolkit
 from pyface.window import Window
 
-from pyface.data_view.data_models.api import ArrayDataModel
+# This import results in an error without numpy installed
+# see enthought/pyface#742
+try:
+    from pyface.data_view.data_models.api import ArrayDataModel
+except TraitError:
+    pass
 from pyface.data_view.data_view_widget import DataViewWidget
 from pyface.data_view.value_types.api import FloatValue
 

--- a/pyface/ui/qt4/data_view/tests/test_data_view_item_model.py
+++ b/pyface/ui/qt4/data_view/tests/test_data_view_item_model.py
@@ -10,10 +10,16 @@
 
 from unittest import TestCase
 
+from traits.api import TraitError
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
 
 from pyface.qt.QtCore import QMimeData
-from pyface.data_view.data_models.api import ArrayDataModel
+# This import results in an error without numpy installed
+# see enthought/pyface#742
+try:
+    from pyface.data_view.data_models.api import ArrayDataModel
+except TraitError:
+    pass
 from pyface.data_view.exporters.row_exporter import RowExporter
 from pyface.data_view.data_formats import table_format
 from pyface.data_view.value_types.api import FloatValue


### PR DESCRIPTION
fixes #742 

In this PR I simply catch the error that occurs when trying to import `ArrayDataModel` without `numpy` being installed.  The tests themselves all are decorated with `@requires_numpy`, so they aren't run regardless. This change simply prevents the errors we were seeing in issue 742.  
This is clearly a work around and does not solve the root of the problem.  See related comment: https://github.com/enthought/pyface/issues/740#issuecomment-707238226

Also I am not sure if this PR should be based on top of master or `maint/7.1`.  I will happily change if needed. 