### PR TITLE
Add api.py to data view packages

### DIFF
--- a/docs/source/examples/data_model_indices.py
+++ b/docs/source/examples/data_model_indices.py
@@ -10,8 +10,7 @@
 
 from traits.api import Instance, Int, List
 
-from pyface.data_view.abstract_data_model import AbstractDataModel
-from pyface.data_view.index_manager import TupleIndexManager
+from pyface.data_view.api import AbstractDataModel, TupleIndexManager
 
 
 class IndexDataModel(AbstractDataModel):

--- a/docs/source/examples/dict_data_model.py
+++ b/docs/source/examples/dict_data_model.py
@@ -10,11 +10,9 @@
 
 from traits.api import ComparisonMode, Dict, Instance, Str, observe
 
-from pyface.data_view.abstract_data_model import (
-    AbstractDataModel, DataViewSetError
+from pyface.data_view.api import (
+    AbstractDataModel, AbstractValueType, DataViewSetError, IntIndexManager
 )
-from pyface.data_view.abstract_value_type import AbstractValueType
-from pyface.data_view.index_manager import IntIndexManager
 
 
 class DictDataModel(AbstractDataModel):
@@ -121,7 +119,6 @@ if __name__ == '__main__':
     from pyface.data_view.data_view_widget import DataViewWidget
     from pyface.data_view.value_types.api import IntValue, TextValue
 
-
     class MainWindow(ApplicationWindow):
         """ The main application window. """
 
@@ -143,7 +140,6 @@ if __name__ == '__main__':
         def destroy(self):
             self.data_view.destroy()
             super().destroy()
-
 
     # Create the GUI (this does NOT start the GUI event loop).
     gui = GUI()

--- a/examples/data_view/array_example.py
+++ b/examples/data_view/array_example.py
@@ -17,13 +17,13 @@ import numpy as np
 from traits.api import Array, Instance, observe
 
 from pyface.api import ApplicationWindow, GUI
-from pyface.drop_handler import FileDropHandler
-from pyface.data_view.data_models.array_data_model import ArrayDataModel
-from pyface.data_view.exporters.row_exporter import RowExporter
-from pyface.data_view.data_formats import table_format, csv_format, npy_format
-from pyface.data_view.data_view_widget import DataViewWidget
-from pyface.data_view.i_data_view_widget import IDataViewWidget
+from pyface.data_view.api import (
+    DataViewWidget, IDataViewWidget, table_format, csv_format, npy_format
+)
+from pyface.data_view.data_models.api import ArrayDataModel
+from pyface.data_view.exporters.api import RowExporter
 from pyface.data_view.value_types.api import FloatValue
+from pyface.drop_handler import FileDropHandler
 
 
 logger = logging.getLogger(__name__)

--- a/examples/data_view/column_data_model.py
+++ b/examples/data_view/column_data_model.py
@@ -16,11 +16,9 @@ from traits.api import (
 )
 from traits.trait_base import xgetattr, xsetattr
 
-from pyface.data_view.abstract_data_model import (
-    AbstractDataModel, DataViewSetError
+from pyface.data_view.api import (
+    AbstractDataModel, AbstractValueType, DataViewSetError, TupleIndexManager
 )
-from pyface.data_view.abstract_value_type import AbstractValueType
-from pyface.data_view.index_manager import TupleIndexManager
 from pyface.data_view.value_types.api import TextValue
 
 

--- a/examples/data_view/column_example.py
+++ b/examples/data_view/column_example.py
@@ -15,10 +15,10 @@ import logging
 from traits.api import Bool, Dict, HasStrictTraits, Instance, Int, Str, List
 
 from pyface.api import ApplicationWindow, GUI, Image, ImageResource
-from pyface.data_view.exporters.row_exporter import RowExporter
-from pyface.data_view.data_formats import table_format, csv_format
-from pyface.data_view.data_view_widget import DataViewWidget
-from pyface.data_view.i_data_view_widget import IDataViewWidget
+from pyface.data_view.api import (
+    DataViewWidget, IDataViewWidget, table_format, csv_format
+)
+from pyface.data_view.exporters.api import RowExporter
 from pyface.data_view.value_types.api import (
     BoolValue, ColorValue, IntValue, TextValue, no_value
 )

--- a/examples/data_view/row_table_example.py
+++ b/examples/data_view/row_table_example.py
@@ -14,12 +14,10 @@ from traits.api import Bool, Dict, HasStrictTraits, Instance, Int, Str, List
 
 from pyface.api import ApplicationWindow, GUI, Image, ImageResource
 from pyface.ui_traits import PyfaceColor
-from pyface.data_view.data_models.data_accessors import AttributeDataAccessor
-from pyface.data_view.data_models.row_table_data_model import (
-    RowTableDataModel
+from pyface.data_view.data_models.api import (
+    AttributeDataAccessor, RowTableDataModel
 )
-from pyface.data_view.data_view_widget import DataViewWidget
-from pyface.data_view.i_data_view_widget import IDataViewWidget
+from pyface.data_view.api import DataViewWidget, IDataViewWidget
 from pyface.data_view.value_types.api import (
     BoolValue, ColorValue, IntValue, TextValue
 )

--- a/pyface/data_view/api.py
+++ b/pyface/data_view/api.py
@@ -19,7 +19,7 @@ from pyface.data_view.data_formats import (  # noqa: 401
     csv_column_format, csv_format, csv_row_format, from_csv, from_csv_column,
     from_csv_row, from_json, from_npy, html_format, npy_format,
     standard_text_format, to_csv, to_csv_column, to_csv_row, to_json, to_npy,
-    table_format, text_column_format, text_format, text_row_format
+    table_format, text_column_format, text_row_format
 )
 from pyface.data_view.data_view_errors import (  # noqa: 401
     DataViewError, DataViewGetError, DataViewSetError
@@ -29,7 +29,9 @@ from pyface.data_view.data_wrapper import DataWrapper  # noqa: 401
 from pyface.data_view.i_data_view_widget import (  # noqa: 401
     IDataViewWidget, MDataViewWidget
 )
-from pyface.data_view.i_data_wrapper import IDataWrapper, MDataWrapper  # noqa: 401
+from pyface.data_view.i_data_wrapper import (  # noqa: 401
+    DataFormat, IDataWrapper, MDataWrapper, text_format
+)
 from pyface.data_view.index_manager import (  # noqa: 401
     AbstractIndexManager, IntIndexManager, TupleIndexManager
 )

--- a/pyface/data_view/api.py
+++ b/pyface/data_view/api.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+# NOTE: this public-facing API is provisional and may change in future
+# minor releases through until Pyface 8
+
+from pyface.data_view.abstract_data_exporter import AbstractDataExporter  # noqa: 401
+from pyface.data_view.abstract_data_model import AbstractDataModel  # noqa: 401
+from pyface.data_view.abstract_value_type import AbstractValueType  # noqa: 401
+from pyface.data_view.data_formats import (  # noqa: 401
+    csv_column_format, csv_format, csv_row_format, from_csv, from_csv_column,
+    from_csv_row, from_json, from_npy, html_format, npy_format,
+    standard_text_format, to_csv, to_csv_column, to_csv_row, to_json, to_npy,
+    table_format, text_column_format, text_format, text_row_format
+)
+from pyface.data_view.data_view_errors import (  # noqa: 401
+    DataViewError, DataViewGetError, DataViewSetError
+)
+from pyface.data_view.data_view_widget import DataViewWidget  # noqa: 401
+from pyface.data_view.data_wrapper import DataWrapper  # noqa: 401
+from pyface.data_view.i_data_view_widget import (  # noqa: 401
+    IDataViewWidget, MDataViewWidget
+)
+from pyface.data_view.i_data_wrapper import IDataWrapper, MDataWrapper  # noqa: 401
+from pyface.data_view.index_manager import (  # noqa: 401
+    AbstractIndexManager, IntIndexManager, TupleIndexManager
+)

--- a/pyface/data_view/api.py
+++ b/pyface/data_view/api.py
@@ -26,11 +26,9 @@ from pyface.data_view.data_view_errors import (  # noqa: 401
 )
 from pyface.data_view.data_view_widget import DataViewWidget  # noqa: 401
 from pyface.data_view.data_wrapper import DataWrapper  # noqa: 401
-from pyface.data_view.i_data_view_widget import (  # noqa: 401
-    IDataViewWidget, MDataViewWidget
-)
+from pyface.data_view.i_data_view_widget import IDataViewWidget  # noqa: 401
 from pyface.data_view.i_data_wrapper import (  # noqa: 401
-    DataFormat, IDataWrapper, MDataWrapper, text_format
+    DataFormat, IDataWrapper, text_format
 )
 from pyface.data_view.index_manager import (  # noqa: 401
     AbstractIndexManager, IntIndexManager, TupleIndexManager

--- a/pyface/data_view/data_models/api.py
+++ b/pyface/data_view/data_models/api.py
@@ -8,7 +8,14 @@
 #
 # Thanks for using Enthought open source!
 
-from .array_data_model import ArrayDataModel  # noqa: F401
+try:
+    import numpy  # noqa: F401
+except ImportError:
+    pass
+else:
+    del numpy
+    from .array_data_model import ArrayDataModel  # noqa: F401
+
 from .data_accessors import (  # noqa: F401
     AbstractDataAccessor, AttributeDataAccessor, ConstantDataAccessor,
     IndexDataAccessor, KeyDataAccessor

--- a/pyface/data_view/data_models/tests/test_api.py
+++ b/pyface/data_view/data_models/tests/test_api.py
@@ -1,0 +1,57 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test the api module. """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    def test_all_imports_exclude_numpy_dependencies(self):
+        # These objects do not depend on NumPy
+        from pyface.data_view.data_models.api import (  # noqa: F401
+            AbstractDataAccessor,
+            AttributeDataAccessor,
+            ConstantDataAccessor,
+            IndexDataAccessor,
+            KeyDataAccessor,
+            RowTableDataModel,
+        )
+
+    def test_import_with_numpy_dependency(self):
+        # These objects require NumPy.
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("NumPy not available.")
+
+        from pyface.data_view.data_models.api import (  # noqa: F401
+            ArrayDataModel,
+        )
+
+    def test_api_items_count(self):
+        # This test helps developer to keep the above list
+        # up-to-date. Bump the number when the API content changes.
+        from pyface.data_view.data_models import api
+
+        expected_count = 6
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            expected_count += 1
+
+        items_in_api = {
+            name
+            for name in dir(api)
+            if not name.startswith("_")
+        }
+        self.assertEqual(len(items_in_api), expected_count)

--- a/pyface/data_view/exporters/api.py
+++ b/pyface/data_view/exporters/api.py
@@ -8,9 +8,5 @@
 #
 # Thanks for using Enthought open source!
 
-from .array_data_model import ArrayDataModel  # noqa: F401
-from .data_accessors import (  # noqa: F401
-    AbstractDataAccessor, AttributeDataAccessor, ConstantDataAccessor,
-    IndexDataAccessor, KeyDataAccessor
-)
-from .row_table_data_model import RowTableDataModel  # noqa: F401
+from .item_exporter import ItemExporter
+from .row_exporter import RowExporter

--- a/pyface/data_view/exporters/tests/test_api.py
+++ b/pyface/data_view/exporters/tests/test_api.py
@@ -1,0 +1,32 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test the api module. """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    def test_all_imports(self):
+        from pyface.data_view.exporters.api import (  # noqa: F401
+            ItemExporter,
+            RowExporter,
+        )
+
+    def test_api_items_count(self):
+        # This test helps developer to keep the above list
+        # up-to-date. Bump the number when the API content changes.
+        from pyface.data_view.exporters import api
+        items_in_api = {
+            name
+            for name in dir(api)
+            if not name.startswith("_")
+        }
+        self.assertEqual(len(items_in_api), 2)

--- a/pyface/data_view/tests/test_api.py
+++ b/pyface/data_view/tests/test_api.py
@@ -1,0 +1,65 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test the api module. """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    def test_all_imports(self):
+        from pyface.data_view.api import (  # noqa: F401
+            AbstractDataExporter,
+            AbstractDataModel,
+            AbstractValueType,
+            csv_column_format,
+            csv_format,
+            csv_row_format,
+            from_csv,
+            from_csv_column,
+            from_csv_row,
+            from_json,
+            from_npy,
+            html_format,
+            npy_format,
+            standard_text_format,
+            to_csv,
+            to_csv_column,
+            to_csv_row,
+            to_json,
+            to_npy,
+            table_format,
+            text_column_format,
+            text_format,
+            text_row_format,
+            DataViewError,
+            DataViewGetError,
+            DataViewSetError,
+            DataViewWidget,
+            DataWrapper,
+            IDataViewWidget,
+            MDataViewWidget,
+            IDataWrapper,
+            MDataWrapper,
+            AbstractIndexManager,
+            IntIndexManager,
+            TupleIndexManager,
+        )
+
+    def test_api_items_count(self):
+        # This test helps developer to keep the above list
+        # up-to-date. Bump the number when the API content changes.
+        from pyface.data_view import api
+        items_in_api = {
+            name
+            for name in dir(api)
+            if not name.startswith("_")
+        }
+        self.assertEqual(len(items_in_api), 35)

--- a/pyface/data_view/tests/test_api.py
+++ b/pyface/data_view/tests/test_api.py
@@ -45,12 +45,11 @@ class TestApi(unittest.TestCase):
             DataViewWidget,
             DataWrapper,
             IDataViewWidget,
-            MDataViewWidget,
             IDataWrapper,
-            MDataWrapper,
             AbstractIndexManager,
             IntIndexManager,
             TupleIndexManager,
+            DataFormat,
         )
 
     def test_api_items_count(self):
@@ -62,4 +61,4 @@ class TestApi(unittest.TestCase):
             for name in dir(api)
             if not name.startswith("_")
         }
-        self.assertEqual(len(items_in_api), 35)
+        self.assertEqual(len(items_in_api), 34)

--- a/pyface/ui/qt4/system_metrics.py
+++ b/pyface/ui/qt4/system_metrics.py
@@ -44,9 +44,9 @@ class SystemMetrics(MSystemMetrics, HasTraits):
         # suggest using screens() instead, but screens in not available in qt4
         # see issue: enthought/pyface#721
         if is_qt5:
-            return QtGui.QApplication.instance().screens()[0].geometry().width()
+            return QtGui.QApplication.instance().screens()[0].availableGeometry().width()
         else:
-            return QtGui.QApplication.instance().desktop().screenGeometry().width()
+            return QtGui.QApplication.instance().desktop().availableGeometry().width()
 
     def _get_screen_height(self):
         # QDesktopWidget.screenGeometry(int screen) is deprecated and Qt docs
@@ -54,11 +54,11 @@ class SystemMetrics(MSystemMetrics, HasTraits):
         # see issue: enthought/pyface#721
         if is_qt5:
             return (
-                QtGui.QApplication.instance().screens()[0].geometry().height()
+                QtGui.QApplication.instance().screens()[0].availableGeometry().height()
             )
         else:
             return (
-                QtGui.QApplication.instance().desktop().screenGeometry().height()
+                QtGui.QApplication.instance().desktop().availableGeometry().height()
             )
 
     def _get_dialog_background_color(self):


### PR DESCRIPTION
This PR adds `api.py` modules to the various `data_view` sub-packages.  It also modifies examples and documentation to use the these modules when importing objects.

This fixes #740.