### PR TITLE
Update Appveyor config to accept builds targeting maintenance branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ matrix:
 branches:
   only:
     - master
+    - /maint\/.*/
 
 cache:
   - C:\Users\appveyor\.cache -> appveyor-clean-cache.txt


### PR DESCRIPTION
This PR updates the Appveyor configuration to accept builds from maintenance branches. Without this setting, PRs targeting a maintenance branch won't be built on Appveyor.

This is such that in the future when new maintenance branches are created from master, there is no need to change this setting again.

See https://www.appveyor.com/docs/branches/#white--and-blacklisting