### PR TITLE
Test API modules in pyface.data_view

### DIFF
--- a/pyface/data_view/data_models/api.py
+++ b/pyface/data_view/data_models/api.py
@@ -8,7 +8,14 @@
 #
 # Thanks for using Enthought open source!
 
-from .array_data_model import ArrayDataModel  # noqa: F401
+try:
+    import numpy  # noqa: F401
+except ImportError:
+    pass
+else:
+    del numpy
+    from .array_data_model import ArrayDataModel  # noqa: F401
+
 from .data_accessors import (  # noqa: F401
     AbstractDataAccessor, AttributeDataAccessor, ConstantDataAccessor,
     IndexDataAccessor, KeyDataAccessor

--- a/pyface/data_view/data_models/tests/test_api.py
+++ b/pyface/data_view/data_models/tests/test_api.py
@@ -26,7 +26,7 @@ class TestApi(unittest.TestCase):
         )
 
     def test_import_with_numpy_dependency(self):
-        # These objects that require NumPy.
+        # These objects require NumPy.
         try:
             import numpy  # noqa: F401
         except ImportError:

--- a/pyface/data_view/data_models/tests/test_api.py
+++ b/pyface/data_view/data_models/tests/test_api.py
@@ -35,3 +35,23 @@ class TestApi(unittest.TestCase):
         from pyface.data_view.data_models.api import (  # noqa: F401
             ArrayDataModel,
         )
+
+    def test_api_items_count(self):
+        # This test helps developer to keep the above list
+        # up-to-date. Bump the number when the API content changes.
+        from pyface.data_view.data_models import api
+
+        expected_count = 6
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            pass
+        else:
+            expected_count += 1
+
+        items_in_api = {
+            name
+            for name in dir(api)
+            if not name.startswith("_")
+        }
+        self.assertEqual(len(items_in_api), expected_count)

--- a/pyface/data_view/data_models/tests/test_api.py
+++ b/pyface/data_view/data_models/tests/test_api.py
@@ -1,0 +1,37 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test the api module. """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    def test_all_imports_exclude_numpy_dependencies(self):
+        # These objects do not depend on NumPy
+        from pyface.data_view.data_models.api import (  # noqa: F401
+            AbstractDataAccessor,
+            AttributeDataAccessor,
+            ConstantDataAccessor,
+            IndexDataAccessor,
+            KeyDataAccessor,
+            RowTableDataModel,
+        )
+
+    def test_import_with_numpy_dependency(self):
+        # These objects that require NumPy.
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("NumPy not available.")
+
+        from pyface.data_view.data_models.api import (  # noqa: F401
+            ArrayDataModel,
+        )

--- a/pyface/data_view/exporters/tests/test_api.py
+++ b/pyface/data_view/exporters/tests/test_api.py
@@ -1,0 +1,21 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test the api module. """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    def test_all_imports(self):
+        from pyface.data_view.exporters.api import (  # noqa: F401
+            ItemExporter,
+            RowExporter,
+        )

--- a/pyface/data_view/exporters/tests/test_api.py
+++ b/pyface/data_view/exporters/tests/test_api.py
@@ -19,3 +19,14 @@ class TestApi(unittest.TestCase):
             ItemExporter,
             RowExporter,
         )
+
+    def test_api_items_count(self):
+        # This test helps developer to keep the above list
+        # up-to-date. Bump the number when the API content changes.
+        from pyface.data_view.exporters import api
+        items_in_api = {
+            name
+            for name in dir(api)
+            if not name.startswith("_")
+        }
+        self.assertEqual(len(items_in_api), 2)

--- a/pyface/data_view/tests/test_api.py
+++ b/pyface/data_view/tests/test_api.py
@@ -1,0 +1,54 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test the api module. """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    def test_all_imports(self):
+        from pyface.data_view.api import (  # noqa: F401
+            AbstractDataExporter,
+            AbstractDataModel,
+            AbstractValueType,
+            csv_column_format,
+            csv_format,
+            csv_row_format,
+            from_csv,
+            from_csv_column,
+            from_csv_row,
+            from_json,
+            from_npy,
+            html_format,
+            npy_format,
+            standard_text_format,
+            to_csv,
+            to_csv_column,
+            to_csv_row,
+            to_json,
+            to_npy,
+            table_format,
+            text_column_format,
+            text_format,
+            text_row_format,
+            DataViewError,
+            DataViewGetError,
+            DataViewSetError,
+            DataViewWidget,
+            DataWrapper,
+            IDataViewWidget,
+            MDataViewWidget,
+            IDataWrapper,
+            MDataWrapper,
+            AbstractIndexManager,
+            IntIndexManager,
+            TupleIndexManager,
+        )

--- a/pyface/data_view/tests/test_api.py
+++ b/pyface/data_view/tests/test_api.py
@@ -52,3 +52,14 @@ class TestApi(unittest.TestCase):
             IntIndexManager,
             TupleIndexManager,
         )
+
+    def test_api_items_count(self):
+        # This test helps developer to keep the above list
+        # up-to-date. Bump the number when the API content changes.
+        from pyface.data_view import api
+        items_in_api = {
+            name
+            for name in dir(api)
+            if not name.startswith("_")
+        }
+        self.assertEqual(len(items_in_api), 35)


### PR DESCRIPTION
Targeting #750

This PR
- Adds tests for the api modules.
- Allows NumPy to be absent and still be able to import data models that don't require NumPy

The treatment mirrors the import of ArrayEditor in TraitsUI:
https://github.com/enthought/traitsui/blob/7b53731606959dfaa7b2e3e8089d00e7a771e312/traitsui/api.py#L29-L33

Ideally we should have a CI job that has the most minimal requirements, and in the case of Qt, NumPy is not an install requirement. I just ran the tests locally with NumPy removed from my environment.