### PR TITLE
Use TraitsUI maintenance branch for Pyface 7.1 maintenance branch

### DIFF
--- a/ci-src-requirements.txt
+++ b/ci-src-requirements.txt
@@ -1,1 +1,1 @@
-git+http://github.com/enthought/traitsui.git#egg=traitsui
+git+http://github.com/enthought/traitsui.git@maint/7.1#egg=traitsui


### PR DESCRIPTION
[Targeting maint/7.1]

Little did I know pyface also installs traitsui's master. So we need to set the source dependency to point to TraitsUI maintenance branch for Pyface maintenance branch.

(Added this step in #714 for future reference.)