### PR TITLE
Mention the data view API being provisional in the User Manual

### DIFF
--- a/docs/source/data_view.rst
+++ b/docs/source/data_view.rst
@@ -4,6 +4,10 @@ Pyface DataViews
 The Pyface DataView API allows visualization of hierarchical and
 non-hierarchical tabular data.
 
+.. note::
+   As of Pyface 7.1.0, the public API for DataView is provisional and may
+   change in the future minor releases through until Pyface 8.0
+
 Indexing
 --------
 

--- a/docs/source/data_view.rst
+++ b/docs/source/data_view.rst
@@ -8,6 +8,8 @@ non-hierarchical tabular data.
    As of Pyface 7.1.0, the public API for DataView is provisional and may
    change in the future minor releases through until Pyface 8.0
 
+.. See enthought/pyface#756 for removing the note.
+
 Indexing
 --------
 

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -53,7 +53,10 @@ class IDataViewWidget(IWidget):
     selection = List(Tuple)
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(Instance(AbstractDataExporter))
+    exporters = List(
+        Instance(AbstractDataExporter),
+        comparison_mode=ComparisonMode.identity,
+    )
 
 
 class MDataViewWidget(HasStrictTraits):
@@ -78,7 +81,10 @@ class MDataViewWidget(HasStrictTraits):
     selection = Property(depends_on='_selection[]')
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(Instance(AbstractDataExporter))
+    exporters = List(
+        Instance(AbstractDataExporter),
+        comparison_mode=ComparisonMode.identity,
+    )
 
     # Private traits --------------------------------------------------------
 

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -53,10 +53,7 @@ class IDataViewWidget(IWidget):
     selection = List(Tuple)
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(
-        Instance(AbstractDataExporter),
-        comparison_mode=ComparisonMode.identity,
-    )
+    exporters = List(Instance(AbstractDataExporter))
 
 
 class MDataViewWidget(HasStrictTraits):
@@ -81,10 +78,7 @@ class MDataViewWidget(HasStrictTraits):
     selection = Property(depends_on='_selection[]')
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(
-        Instance(AbstractDataExporter),
-        comparison_mode=ComparisonMode.identity,
-    )
+    exporters = List(Instance(AbstractDataExporter))
 
     # Private traits --------------------------------------------------------
 


### PR DESCRIPTION
Closes #741

This PR adds a mention that the data view API is provisional for the 7.x series.
A similar mention will be included in the release of 7.1.0, but since this applies to the 7.x series, it is more efficient and discoverable to simply mentions this in the user manual.

See #756 for removing these mentions when the API is no longer provisional.