### PR TITLE
Set comparison mode to identity for MDataViewWidget.exporters

### DIFF
--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -53,7 +53,10 @@ class IDataViewWidget(IWidget):
     selection = List(Tuple)
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(Instance(AbstractDataExporter))
+    exporters = List(
+        Instance(AbstractDataExporter),
+        comparison_mode=ComparisonMode.identity,
+    )
 
 
 class MDataViewWidget(HasStrictTraits):
@@ -78,7 +81,10 @@ class MDataViewWidget(HasStrictTraits):
     selection = Property(depends_on='_selection[]')
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(Instance(AbstractDataExporter))
+    exporters = List(
+        Instance(AbstractDataExporter),
+        comparison_mode=ComparisonMode.identity,
+    )
 
     # Private traits --------------------------------------------------------
 


### PR DESCRIPTION
Fix #743

The warning is triggered when this observer is used:
https://github.com/enthought/pyface/blob/86c9a9c629d7a77ac06fae563f54e0aba231c554/pyface/ui/qt4/data_view/data_view_widget.py#L245
which is defined in a different place to where the trait is defined. I had to dive into some private states on the class to find it.