### PR TITLE
Add the missing gitattributes for git archive commit hash

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# For archives, substitute the commit hash in the setup.py file.
+/setup.py export-subst


### PR DESCRIPTION
https://github.com/enthought/pyface/pull/747 should have included this change such that the archive commit hash is replaced properly.

This PR fixes the omission.