### PR TITLE
Install pyside2 using edm instead of pip

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -105,8 +105,7 @@ source_dependencies = {
 
 extra_dependencies = {
     "pyside": {"pyside"},
-    # XXX once pyside2 is available in EDM, we will want it here
-    "pyside2": set(),
+    "pyside2": {"pyside2"},
     "pyqt": {"pyqt<4.12"},  # FIXME: build of 4.12-1 appears to be bad
     "pyqt5": {"pyqt5"},
     # XXX once wxPython 4 is available in EDM, we will want it here
@@ -193,15 +192,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
         install_pyface,
     ])
 
-    # pip install pyqt5 and pyside2, because we don't have them in EDM yet
-    if toolkit == "pyside2":
-        commands.extend(
-            [
-                "{edm} run -e {environment} -- pip install shiboken2",
-                "{edm} run -e {environment} -- pip install pyside2",
-            ]
-        )
-    elif toolkit == "wx":
+    if toolkit == "wx":
         if sys.platform == "darwin":
             commands.append(
                 "{edm} run -e {environment} -- python -m pip install wxPython<4.1"  # noqa: E501

--- a/etstool.py
+++ b/etstool.py
@@ -185,8 +185,13 @@ def install(edm, runtime, toolkit, environment, editable, source):
             "edm environments create {environment} --force --version={runtime}"
         ]
 
+    if toolkit == "pyside2":
+        additional_repositories = "--add-repository enthought/lgpl"
+    else:
+        additional_repositories = ""
+
     commands.extend([
-        "{edm} install -y -e {environment} " + packages,
+        "{edm} install -y -e {environment} " + packages + " " + additional_repositories,
         "{edm} run -e {environment} -- pip install -r ci-src-requirements.txt --no-dependencies",  # noqa: E501
         "{edm} run -e {environment} -- python setup.py clean --all",
         install_pyface,


### PR DESCRIPTION
This PR updates `etstool.py` to install `PySide2` using EDM instead of installing it using pip. This is now possible because `PySide2` v 5.14.1 is available via EDM.