### PR TITLE
Rename api-docs click command to docs

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -378,7 +378,7 @@ def update(edm, runtime, toolkit, environment):
 @click.option("--runtime", default="3.6", help="Python version to use")
 @click.option("--toolkit", default="pyqt", help="Toolkit and API to use")
 @click.option("--environment", default=None, help="EDM environment to use")
-def api_docs(edm, runtime, toolkit, environment):
+def docs(edm, runtime, toolkit, environment):
     """ Autogenerate documentation
 
     """


### PR DESCRIPTION
This PR renames the `api-docs` click command to `docs`. Now, traitsui and pyface have the same command name - reducing
unnecessary cognitive overhead.

traitsui - 
```
> edm run -e bootstrap -- python -m etstool
Usage: etstool.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  cleanup     Remove a development environment.
  docs        Autogenerate documentation
  flake8      Run a flake8 check in a given environment.
  install     Install project and dependencies into a clean EDM environment.
  shell       Create a shell into the EDM development environment (aka...
  test        Run the test suite in a given environment with the specified...
  test-all    Run test_clean across all supported environment combinations.
  test-clean  Run tests in a clean environment, cleaning up afterwards
```

pyface - 

```
> edm run -e bootstrap -- python -m etstool
Usage: etstool.py [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  cleanup     Remove a development environment.
  docs        Autogenerate documentation
  install     Install project and dependencies into a clean EDM environment.
  shell       Create a shell into the EDM development environment (aka...
  test        Run the test suite in a given environment with the specified...
  test-all    Run test_clean across all supported environment combinations.
  test-clean  Run tests in a clean environment, cleaning up afterwards
  update      Update/Reinstall package into environment.
```