### PR TITLE
Fix a docstring in a GUITestAssistant method.

### DIFF
--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -194,7 +194,7 @@ class GuiTestAssistant(UnittestTools):
             The extended trait name of trait changes to listen to.
         condition : callable
             A callable to determine if the stop criteria have been met. This
-            should accept no arguments.
+            takes obj as the only argument.
         count : int
             The expected number of times the event should be fired. The default
             is to expect one event.


### PR DESCRIPTION
fixes #445 

This PR updates the docstring for `GUITestAssitant.assertTraitChangesInEventLoop` - stating that the `condition` takes `obj` as the argument.