### PR TITLE
Fix PySide2 bytearrays

### DIFF
--- a/pyface/ui/qt4/data_view/data_wrapper.py
+++ b/pyface/ui/qt4/data_view/data_wrapper.py
@@ -47,7 +47,7 @@ class DataWrapper(MDataWrapper):
         mimedata : bytes
             The mime media data as bytes.
         """
-        return self.toolkit_data.data(mimetype)
+        return self.toolkit_data.data(mimetype).data()
 
     def set_mimedata(self, mimetype, raw_data):
         """ Set raw data for the given media type.

--- a/pyface/ui/qt4/data_view/tests/test_data_view_item_model.py
+++ b/pyface/ui/qt4/data_view/tests/test_data_view_item_model.py
@@ -57,7 +57,7 @@ class TestDataViewItemModel(TestCase):
         self.assertIsInstance(mime_data, QMimeData)
         self.assertTrue(mime_data.hasFormat('text/plain'))
 
-        raw_data = mime_data.data('text/plain')
+        raw_data = mime_data.data('text/plain').data()
         data = table_format.deserialize(bytes(raw_data))
         np.testing.assert_array_equal(
             data,

--- a/pyface/ui/qt4/data_view/tests/test_data_wrapper.py
+++ b/pyface/ui/qt4/data_view/tests/test_data_wrapper.py
@@ -30,4 +30,7 @@ class TestDataWrapper(TestCase):
         toolkit_data = data_wrapper.toolkit_data
 
         self.assertEqual(set(toolkit_data.formats()), {'text/plain'})
-        self.assertEqual(toolkit_data.data('text/plain'), b'hello world')
+        self.assertEqual(
+            toolkit_data.data('text/plain').data(),
+            b'hello world'
+        )


### PR DESCRIPTION
This makes sure that data is explicitly extracted from QByteArrays rather than relying on toolkit wrappers to autoconvert to bytes-like things.