### PR TITLE
Dont install traitsui from git source

### DIFF
--- a/ci-src-requirements.txt
+++ b/ci-src-requirements.txt
@@ -1,1 +1,0 @@
-git+http://github.com/enthought/traitsui.git#egg=traitsui

--- a/etstool.py
+++ b/etstool.py
@@ -93,12 +93,12 @@ TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
 
 dependencies = {
     "traits" + TRAITS_VERSION_REQUIRES,
+    "traitsui",
     "numpy",
     "pygments",
     "coverage",
 }
 
-# NOTE : traitsui is always installed from source
 source_dependencies = {
     "traits": "git+http://github.com/enthought/traits.git#egg=traits",
 }

--- a/etstool.py
+++ b/etstool.py
@@ -101,6 +101,7 @@ dependencies = {
 
 source_dependencies = {
     "traits": "git+http://github.com/enthought/traits.git#egg=traits",
+    "traitsui": "git+http://github.com/enthought/traitsui.git#egg=traitsui",
 }
 
 extra_dependencies = {


### PR DESCRIPTION
fixes #775 

This PR updates CI/etstool module to install traitsui using edm instead of installing it from git source.