### PR TITLE
Fix deprecation warning at compile time

### DIFF
--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -74,7 +74,7 @@ def load_tests(loader, standard_tests, pattern):
     # We will skip tests in data_view package in Traits 6.0 environment
     # Remove this when Traits 6.0 is dropped for the entire code base.
     if not is_traits_version_ge("6.1"):
-        exclusion_patterns.append("\.data_view\.")
+        exclusion_patterns.append(r"\.data_view\.")
 
     filtered_package_tests = TestSuite()
     for test_suite in package_tests:


### PR DESCRIPTION
This PR resolves the following deprecation warning.

```
/Users/kchoi/.edm/envs/my_env/lib/python3.6/site-packages/pyface/__init__.py:77: DeprecationWarning: invalid escape sequence \.
  exclusion_patterns.append("\.data_view\.")
```

Such warnings are even harder to spot than import time deprecation warning: They only occur the first time the Python file is byte-compiled, usually when the distribution is freshly installed.

The particular line being changed will be removed for #781. But this PR alone is justified and can be backported for bug fix releases.