### PR TITLE
Use importlib_metadata instead of pkg_resources for toolkit entry points

### DIFF
--- a/docs/source/toolkits.rst
+++ b/docs/source/toolkits.rst
@@ -76,9 +76,9 @@ widgets, if needed.
 Toolkit Entrypoints
 ===================
 
-Pyface uses the standard ``pkg_resources`` "entry point" system to allow other
-libraries to contribute new toolkit implementations to Pyface.  The toolkit
-selection process discussed above looks for things contributed to the
+Pyface uses the standard ``importlib_metadata`` "entry point" system to allow
+other libraries to contribute new toolkit implementations to Pyface.  The
+toolkit selection process discussed above looks for things contributed to the
 ``pyface.toolkits`` entry point.  These are specified in the ``setup.py`` of
 the third party library, something like this::
 

--- a/etstool.py
+++ b/etstool.py
@@ -92,6 +92,7 @@ supported_combinations = {
 TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
 
 dependencies = {
+    "importlib_metadata",
     "traits" + TRAITS_VERSION_REQUIRES,
     "traitsui",
     "numpy",

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     __version__ = "not-built"
 
 
-__requires__ = ["traits>=6"]
+__requires__ = ["importlib-metadata", "traits>=6"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -224,8 +224,11 @@ def import_toolkit(toolkit_name, entry_point="pyface.toolkits"):
         raise RuntimeError(msg)
     elif len(plugins) > 1:
         msg = "multiple %r plugins found for toolkit %r: %s"
-        modules = ", ".join(plugin.module_name for plugin in plugins)
-        logger.warning(msg, entry_point, toolkit_name, modules)
+        module_names = []
+        for plugin in plugins:
+            module_names.append(plugin.value.split(":")[0])
+        module_names = ", ".join(module_names)
+        logger.warning(msg, entry_point, toolkit_name, module_names)
 
     for plugin in plugins:
         try:
@@ -233,7 +236,8 @@ def import_toolkit(toolkit_name, entry_point="pyface.toolkits"):
             return toolkit_object
         except (ImportError, AttributeError) as exc:
             msg = "Could not load plugin %r from %r"
-            logger.info(msg, plugin.name, plugin.module_name)
+            module_name = plugin.value.split(":")[0]
+            logger.info(msg, plugin.name, module_name)
             logger.debug(exc, exc_info=True)
 
     msg = "No {} plugin could be loaded for {}"
@@ -288,7 +292,8 @@ def find_toolkit(entry_point, toolkits=None, priorities=default_priorities):
                 return toolkit
         except (ImportError, AttributeError, RuntimeError) as exc:
             msg = "Could not load %s plugin %r from %r"
-            logger.info(msg, entry_point, plugin.name, plugin.module_name)
+            module_name = plugin.value.split(":")[0]
+            logger.info(msg, entry_point, plugin.name, module_name)
             logger.debug(exc, exc_info=True)
 
     # if all else fails, try to import the null toolkit.

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -33,7 +33,7 @@ class TestToolkit(unittest.TestCase):
 
     def test_core_plugins(self):
         # test that we can see appropriate core entrypoints
-        plugins = set(ep.name for ep in entry_points()['pyface.toolkits'])
+        plugins = {ep.name for ep in entry_points()['pyface.toolkits']}
         self.assertLessEqual({"qt4", "wx", "qt", "null"}, plugins)
 
     def test_toolkit_object(self):

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -7,8 +7,14 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-import pkg_resources
 import unittest
+
+try:
+    # Starting Python 3.8, importlib.metadata is available in the Python
+    # standard library.
+    from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
 
 import pyface.toolkit
 
@@ -27,13 +33,7 @@ class TestToolkit(unittest.TestCase):
 
     def test_core_plugins(self):
         # test that we can see appropriate core entrypoints
-        plugins = set(
-            entry_point.name
-            for entry_point in pkg_resources.iter_entry_points(
-                "pyface.toolkits"
-            )
-        )
-
+        plugins = set(ep.name for ep in entry_points()['pyface.toolkits'])
         self.assertLessEqual({"qt4", "wx", "qt", "null"}, plugins)
 
     def test_toolkit_object(self):


### PR DESCRIPTION
Use `importlib_metadata` (`importlib.metadata` starting python 3.8) instead of `pkg_resources`, specifically when searching through the entry points, not when looking for resources.

fixes #789 