### PR TITLE
Use importlib_resources instead of pkg_resources for resource files

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -92,7 +92,7 @@ supported_combinations = {
 TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
 
 dependencies = {
-    "importlib_resources",
+    "importlib_resources>=1.1.0",
     "traits" + TRAITS_VERSION_REQUIRES,
     "traitsui",
     "numpy",

--- a/etstool.py
+++ b/etstool.py
@@ -92,6 +92,7 @@ supported_combinations = {
 TRAITS_VERSION_REQUIRES = os.environ.get("TRAITS_REQUIRES", "")
 
 dependencies = {
+    "importlib_resources",
     "traits" + TRAITS_VERSION_REQUIRES,
     "traitsui",
     "numpy",

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     __version__ = "not-built"
 
 
-__requires__ = ["traits>=6"]
+__requires__ = ["traits>=6", "importlib_resources"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -18,7 +18,7 @@ except ImportError:
     __version__ = "not-built"
 
 
-__requires__ = ["traits>=6", "importlib_resources"]
+__requires__ = ["traits>=6", "importlib_resources>=1.1.0"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],

--- a/pyface/resource/resource_manager.py
+++ b/pyface/resource/resource_manager.py
@@ -113,15 +113,12 @@ class ResourceManager(HasTraits):
             # If we come across a reference to a module, use pkg_resources
             # to try and find the image inside of an .egg, .zip, etc.
             if isinstance(dirname, types.ModuleType):
-                from pkg_resources import resource_string
-
+                from importlib_resources import files
                 for path in subdirs:
                     for extension in extensions:
                         searchpath = "%s/%s%s" % (path, basename, extension)
                         try:
-                            data = resource_string(
-                                dirname.__name__, searchpath
-                            )
+                            data = files(dirname.__name__).joinpath(searchpath).read_bytes()
                             return ImageReference(
                                 self.resource_factory, data=data
                             )

--- a/pyface/resource/resource_manager.py
+++ b/pyface/resource/resource_manager.py
@@ -17,6 +17,8 @@ import collections.abc, glob, inspect, os, sys, types
 from os.path import join
 from zipfile import is_zipfile, ZipFile
 
+from importlib_resources import files
+
 from traits.api import HasTraits, Instance, List
 from traits.util.resource import get_path
 
@@ -113,12 +115,15 @@ class ResourceManager(HasTraits):
             # If we come across a reference to a module, use pkg_resources
             # to try and find the image inside of an .egg, .zip, etc.
             if isinstance(dirname, types.ModuleType):
-                from importlib_resources import files
                 for path in subdirs:
                     for extension in extensions:
                         searchpath = "%s/%s%s" % (path, basename, extension)
                         try:
-                            data = files(dirname.__name__).joinpath(searchpath).read_bytes()
+                            data = (
+                                files(dirname.__name__)
+                                .joinpath(searchpath)
+                                .read_bytes()
+                            )
                             return ImageReference(
                                 self.resource_factory, data=data
                             )

--- a/pyface/resource/resource_manager.py
+++ b/pyface/resource/resource_manager.py
@@ -112,8 +112,8 @@ class ResourceManager(HasTraits):
 
         for dirname in resource_path:
 
-            # If we come across a reference to a module, use pkg_resources
-            # to try and find the image inside of an .egg, .zip, etc.
+            # If we come across a reference to a module, try and find the
+            # image inside of an .egg, .zip, etc.
             if isinstance(dirname, types.ModuleType):
                 for path in subdirs:
                     for extension in extensions:

--- a/pyface/tests/test_image_resource.py
+++ b/pyface/tests/test_image_resource.py
@@ -30,8 +30,7 @@ is_pyqt4_windows = (
 
 
 SEARCH_PATH = os.fspath(files("pyface") / "images")
-IMAGE_DIR = files("pyface.tests") / "images"
-IMAGE_PATH = os.fspath(IMAGE_DIR / "core.png")
+IMAGE_PATH = os.fspath(files("pyface.tests") / "images" / "core.png")
 
 
 class TestImageResource(unittest.TestCase):

--- a/pyface/tests/test_image_resource.py
+++ b/pyface/tests/test_image_resource.py
@@ -30,9 +30,9 @@ is_pyqt4_windows = (
 )
 
 
-SEARCH_PATH = str(files("pyface") / "images")
+SEARCH_PATH = os.fspath(files("pyface") / "images")
 IMAGE_DIR = files("pyface.tests") / "images"
-IMAGE_PATH = str(IMAGE_DIR / "core.png")
+IMAGE_PATH = os.fspath(IMAGE_DIR / "core.png")
 
 
 class TestImageResource(unittest.TestCase):

--- a/pyface/tests/test_image_resource.py
+++ b/pyface/tests/test_image_resource.py
@@ -11,7 +11,6 @@
 
 import os
 import platform
-import pkg_resources
 import unittest
 
 from importlib_resources import files

--- a/pyface/tests/test_image_resource.py
+++ b/pyface/tests/test_image_resource.py
@@ -14,6 +14,8 @@ import platform
 import pkg_resources
 import unittest
 
+from importlib_resources import files
+
 import pyface
 import pyface.tests
 from ..image_resource import ImageResource
@@ -28,9 +30,9 @@ is_pyqt4_windows = (
 )
 
 
-SEARCH_PATH = pkg_resources.resource_filename("pyface", "images")
-IMAGE_DIR = pkg_resources.resource_filename(__name__, "images")
-IMAGE_PATH = os.path.join(IMAGE_DIR, "core.png")
+SEARCH_PATH = str(files("pyface") / "images")
+IMAGE_DIR = files("pyface.tests") / "images"
+IMAGE_PATH = str(IMAGE_DIR / "core.png")
 
 
 class TestImageResource(unittest.TestCase):


### PR DESCRIPTION
This is a sister PR to #790 

This PR replaces the use of `pkg_resources` to access files from packages with the use of `importlib_resources`.

Note : I dont expect this to work on master because the `importlib_resources` version available on edm is older than the latest
version available via PyPI (3.3.0).