### PR TITLE
Add installation instruction on README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ To install with PyQt5 dependencies::
 
     $ pip install pyface[pyqt5]
 
-To install with wxPython dependencies (experimental)::
+To install with wxPython4 dependencies (experimental)::
 
     $ pip install pyface[wx]
 

--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,28 @@ The following GUI backends are supported:
 - PySide2
 - wxPython 4 (experimental)
 
+Installation
+------------
+
+GUI backends are marked as optional dependencies of Pyface. Some features
+or infrastructures may also require additional dependencies.
+
+To install with PySide2 dependencies::
+
+    $ pip install pyface[pyside2]
+
+To install with PyQt5 dependencies::
+
+    $ pip install pyface[pyqt5]
+
+To install with wxPython dependencies (experimental)::
+
+    $ pip install pyface[wx]
+
+To install with additional test dependencies::
+
+    $ pip install pyface[test]
+
 Documentation
 -------------
 


### PR DESCRIPTION
This PR updates the README for Pyface (also visible on PyPI page) to provide installation instructions for optional dependencies.