### PR TITLE
Extend assertion failure message for debugging sporadic test failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
+  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then defaults read NSGlobalDomain NSAppSleepDisabled; fi
   - edm install -y wheel click coverage
 install:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,6 @@ before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
   - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then defaults read NSGlobalDomain NSAppSleepDisabled; fi
   - edm install -y wheel click coverage
 install:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done

--- a/pyface/timer/tests/test_timer.py
+++ b/pyface/timer/tests/test_timer.py
@@ -422,7 +422,15 @@ class TestTimer(TestCase, GuiTestAssistant):
 
         self.assertFalse(timer.IsRunning())
 
-        self.assertEqual(handler.count, 4)
+        # If it should fail, fail with the time intervals between each call
+        # for debugging purposes.
+        time_intervals = [
+            y - x for x, y in zip(handler.times[:-1], handler.times[1:])
+        ]
+        self.assertEqual(
+            handler.count, 4,
+            "Time intervals between calls: {}".format(time_intervals)
+        )
 
         expected_times = [start_time + 0.2 * i + 0.2 for i in range(4)]
 


### PR DESCRIPTION
I have been able to reproduce the issue #556 on OSX after making the GUI event loop work a lot. This looks to be related to this Qt issue: ~https://bugreports.qt.io/browse/QTBUG-63832~ https://bugreports.qt.io/browse/QTBUG-74233

This PR updates the assertion failure message with the time intervals between calls so that we can confirm the behaviour on CI as well.