### PR TITLE
Fix sporadic Timer test failure on OSX + Qt

### DIFF
--- a/pyface/timer/tests/test_timer.py
+++ b/pyface/timer/tests/test_timer.py
@@ -422,9 +422,14 @@ class TestTimer(TestCase, GuiTestAssistant):
 
         self.assertFalse(timer.IsRunning())
 
-        self.assertEqual(handler.count, 4)
-
-        expected_times = [start_time + 0.2 * i + 0.2 for i in range(4)]
+        # The callback may be called more than 4 times depending
+        # on the order when condition timer in event_loop_unit_condition
+        # is called relative to the Timer here. Timer accuracy also depends
+        # on whether the event loop is interrupted by the system.
+        # The objective is that the timer should not be called too frequently.
+        expected_times = [
+            start_time + 0.2 * i + 0.2 for i in range(handler.count)
+        ]
 
         self.assertTrue(
             all(


### PR DESCRIPTION
Closes #556

The explanation for the issue (though I cannot reproduce to confirm) is that the timer being tested may interact with the condition timer from the `GuiTestAssistant.event_loop_helper.event_loop_until_condition` such that the callback can be called more than 4 times. 

This PR updated the test so that it no longer requires the handler to have been called exactly 4 times.

More motivation:

The number of callbacks was not the core of the test objective: The behaviour we need to be testing is that the callback is called at or after (almost always after, allowing for some precision errors) the expected times when the timer is supposed to time out. Note also that timer is not accurate because the timer event cannot fire if the system is busy doing something else. 