### PR TITLE
Log debug message if import PythonShell and PythonEditor fail in api.py

### DIFF
--- a/pyface/api.py
+++ b/pyface/api.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
+import logging as _logging
 
 from .about_dialog import AboutDialog
 from .application import Application
@@ -33,11 +34,15 @@ from .util._optional_dependencies import optional_import as _optional_import
 
 # Excuse pygments dependency (for Qt), otherwise re-raise
 with _optional_import(
-        "pygments", msg="PythonEditor not available due to missing pygments."):
+        "pygments",
+        msg="PythonEditor not available due to missing pygments.",
+        logger=_logging.getLogger(__name__)):
     from .python_editor import PythonEditor
 
 with _optional_import(
-        "pygments", msg="PythonShell not available due to missing pygments."):
+        "pygments",
+        msg="PythonShell not available due to missing pygments.",
+        logger=_logging.getLogger(__name__)):
     from .python_shell import PythonShell
 
 from .sorter import Sorter

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -32,10 +32,12 @@ from .progress_dialog import ProgressDialog
 from .util._optional_dependencies import optional_import as _optional_import
 
 # Excuse pygments dependency (for Qt), otherwise re-raise
-with _optional_import("pygments", msg="PythonEditor not available"):
+with _optional_import(
+        "pygments", msg="PythonEditor not available due to missing pygments."):
     from .python_editor import PythonEditor
 
-with _optional_import("pygments", msg="PythonShell not available"):
+with _optional_import(
+        "pygments", msg="PythonShell not available due to missing pygments."):
     from .python_shell import PythonShell
 
 from .sorter import Sorter

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -28,13 +28,16 @@ from .image_resource import ImageResource
 from .key_pressed_event import KeyPressedEvent
 from .message_dialog import error, information, warning, MessageDialog
 from .progress_dialog import ProgressDialog
-try:
+
+from .util._optional_dependencies import optional_import as _optional_import
+
+# Excuse pygments dependency (for Qt), otherwise re-raise
+with _optional_import("pygments", msg="PythonEditor not available"):
     from .python_editor import PythonEditor
+
+with _optional_import("pygments", msg="PythonShell not available"):
     from .python_shell import PythonShell
-except ImportError as _exception:
-    # Excuse pygments dependency (for Qt), otherwise re-raise
-    if _exception.name != "pygments":
-        raise
+
 from .sorter import Sorter
 from .single_choice_dialog import choose_one, SingleChoiceDialog
 from .splash_screen import SplashScreen

--- a/pyface/util/_optional_dependencies.py
+++ b/pyface/util/_optional_dependencies.py
@@ -1,0 +1,40 @@
+
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" Utilities for handling optional import dependencies."""
+
+import contextlib
+import logging
+
+
+_PYFACE_LOGGER = logging.getLogger("pyface")
+
+
+@contextlib.contextmanager
+def optional_import(dependency_name, msg):
+    """ Context manager for capturing ImportError for a particular optional
+    dependency. If such an error occurs, it will be silenced and a debug
+    message will be logged.
+
+    Parameters
+    ----------
+    dependency_name : str
+        Name of the module that may fail to be imported.
+        If matched, the ImportError will be silenced
+    msg : str
+        Log message to be emitted.
+    """
+    try:
+        yield
+    except ImportError as exception:
+        if exception.name == dependency_name:
+            _PYFACE_LOGGER.debug(msg, exc_info=True)
+        else:
+            raise

--- a/pyface/util/_optional_dependencies.py
+++ b/pyface/util/_optional_dependencies.py
@@ -11,14 +11,10 @@
 """ Utilities for handling optional import dependencies."""
 
 import contextlib
-import logging
-
-
-_PYFACE_LOGGER = logging.getLogger("pyface")
 
 
 @contextlib.contextmanager
-def optional_import(dependency_name, msg):
+def optional_import(dependency_name, msg, logger):
     """ Context manager for capturing ImportError for a particular optional
     dependency. If such an error occurs, it will be silenced and a debug
     message will be logged.
@@ -30,11 +26,13 @@ def optional_import(dependency_name, msg):
         If matched, the ImportError will be silenced
     msg : str
         Log message to be emitted.
+    logger : Logger
+        Logger to use for logging messages.
     """
     try:
         yield
     except ImportError as exception:
         if exception.name == dependency_name:
-            _PYFACE_LOGGER.debug(msg, exc_info=True)
+            logger.debug(msg, exc_info=True)
         else:
             raise

--- a/pyface/util/tests/test__optional_dependencies.py
+++ b/pyface/util/tests/test__optional_dependencies.py
@@ -1,0 +1,38 @@
+# (C) Copyright 2005-2020 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+""" Tests for the _optional_dependencies module """
+
+import unittest
+
+from pyface.util._optional_dependencies import optional_import
+
+#: Name of the logger used for logging debug messages from optional_import
+TARGET_LOGGER_NAME = "pyface"
+
+
+class TestOptionalImport(unittest.TestCase):
+    """ Test optional import context manager """
+
+    def test_optional_import(self):
+        # Test excusing dependency on 'some_random.path'
+
+        with self.assertLogs(TARGET_LOGGER_NAME, level="DEBUG") as log_context:
+            with optional_import("random_missing_lib", "fail to import"):
+                # assume this library is not importable.
+                import random_missing_lib   # noqa: F401
+
+        log, = log_context.output
+        self.assertIn("fail to import", log)
+
+    def test_optional_import_reraise(self):
+        # Test if the import error was about something else, reraise
+        with self.assertRaises(ImportError):
+            with optional_import("some_random_lib", ""):
+                import some_random_missing_lib   # noqa: F401

--- a/pyface/util/tests/test__optional_dependencies.py
+++ b/pyface/util/tests/test__optional_dependencies.py
@@ -9,12 +9,10 @@
 # Thanks for using Enthought open source!
 """ Tests for the _optional_dependencies module """
 
+import logging
 import unittest
 
 from pyface.util._optional_dependencies import optional_import
-
-#: Name of the logger used for logging debug messages from optional_import
-TARGET_LOGGER_NAME = "pyface"
 
 
 class TestOptionalImport(unittest.TestCase):
@@ -22,9 +20,10 @@ class TestOptionalImport(unittest.TestCase):
 
     def test_optional_import(self):
         # Test excusing dependency and the logging behaviour
-
-        with self.assertLogs(TARGET_LOGGER_NAME, level="DEBUG") as log_context:
-            with optional_import("random_missing_lib", "fail to import"):
+        logger = logging.getLogger(self.id())
+        with self.assertLogs(logger, level="DEBUG") as log_context:
+            with optional_import(
+                    "random_missing_lib", "fail to import", logger):
                 # assume this library is not importable.
                 import random_missing_lib   # noqa: F401
 
@@ -33,6 +32,7 @@ class TestOptionalImport(unittest.TestCase):
 
     def test_optional_import_reraise(self):
         # Test if the import error was about something else, reraise
+        logger = logging.getLogger(self.id())
         with self.assertRaises(ImportError):
-            with optional_import("some_random_lib", ""):
+            with optional_import("some_random_lib", "", logger):
                 import some_random_missing_lib   # noqa: F401

--- a/pyface/util/tests/test__optional_dependencies.py
+++ b/pyface/util/tests/test__optional_dependencies.py
@@ -21,7 +21,7 @@ class TestOptionalImport(unittest.TestCase):
     """ Test optional import context manager """
 
     def test_optional_import(self):
-        # Test excusing dependency on 'some_random.path'
+        # Test excusing dependency and the logging behaviour
 
         with self.assertLogs(TARGET_LOGGER_NAME, level="DEBUG") as log_context:
             with optional_import("random_missing_lib", "fail to import"):


### PR DESCRIPTION
Follow up from https://github.com/enthought/pyface/pull/796
In particular, this: https://github.com/enthought/pyface/pull/796#issuecomment-725538154

If PythonEditor and PythonShell cannot be imported because pygments is not available, it might help if we log a debug message so that downstream projects have more information when the import fails.

The alternative would be to emit a warning, but for developers who don't care about these two classes, this could be too noisy.