### PR TITLE
Add wx_id parameter to __init__ for Tree to avoid errors

### DIFF
--- a/pyface/ui/wx/tree/tree.py
+++ b/pyface/ui/wx/tree/tree.py
@@ -182,7 +182,7 @@ class Tree(Widget):
 
         # Create the toolkit-specific control.
         self.control = tree = _Tree(
-            self, parent, style=self._get_style()
+            self, parent, wxid=wx.ID_ANY, style=self._get_style()
         )
 
         # Wire up the wx tree events.


### PR DESCRIPTION
I noticed this while trying to run the following example:
https://github.com/enthought/apptools/blob/master/examples/naming/explorer.py

And doing so I saw the following traceback:
```
$ python explorer.py 
01:52:11 PM: Debug: Adding duplicate image handler for 'Windows bitmap file'
01:52:11 PM: Debug: Adding duplicate animation handler for '1' type
01:52:11 PM: Debug: Adding duplicate animation handler for '2' type
01:52:11 PM: Debug: Adding duplicate image handler for 'Windows bitmap file'
01:52:11 PM: Debug: Adding duplicate animation handler for '1' type
01:52:11 PM: Debug: Adding duplicate animation handler for '2' type
01:52:11 PM: Debug: Adding duplicate image handler for 'Windows bitmap file'
01:52:11 PM: Debug: Adding duplicate animation handler for '1' type
01:52:11 PM: Debug: Adding duplicate animation handler for '2' type
Traceback (most recent call last):
  File "explorer.py", line 70, in <module>
    window.open()
  File "/Users/aayres/.edm/envs/apptools-test-3.6/lib/python3.6/site-packages/pyface/i_window.py", line 203, in open
    self._create()
  File "/Users/aayres/.edm/envs/apptools-test-3.6/lib/python3.6/site-packages/pyface/ui/wx/application_window.py", line 125, in _create
    contents = self._create_contents(self.control)
  File "/Users/aayres/.edm/envs/apptools-test-3.6/lib/python3.6/site-packages/pyface/split_application_window.py", line 39, in _create_contents
    return self._create_splitter(parent)
  File "/Users/aayres/.edm/envs/apptools-test-3.6/lib/python3.6/site-packages/pyface/ui/wx/split_widget.py", line 58, in _create_splitter
    lhs = self._create_lhs(splitter)
  File "/Users/aayres/Desktop/apptools/apptools/naming/ui/explorer.py", line 63, in _create_lhs
    return self._create_tree(parent, self.root)
  File "/Users/aayres/Desktop/apptools/apptools/naming/ui/explorer.py", line 77, in _create_tree
    self._tree = tree = NamingTree(parent, root=root)
  File "/Users/aayres/.edm/envs/apptools-test-3.6/lib/python3.6/site-packages/pyface/ui/wx/tree/tree.py", line 185, in __init__
    self, parent, style=self._get_style()
TypeError: __init__() missing 1 required positional argument: 'wxid'
Error in atexit._run_exitfuncs:
wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /Users/robind/projects/bb2/dist-osx-py36/build/ext/wxWidgets/src/common/wincmn.cpp(475) in ~wxWindowBase(): any pushed event handlers must have been removed
```

The way `_Tree` is currently written, it expects to be passed a `wx_id`.  According to the wx docs for `wx.TreeCtrl`:https://wxpython.org/Phoenix/docs/html/wx.TreeCtrl.html#wx.TreeCtrl.__init__ this normally just defaults to `wx.ID_ANY`.  