### PR TITLE
Dont include ALL txt files from root directory

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,8 @@
-include *.txt
+include image_LICENSE.txt
+include image_LICENSE_Eclipse.txt
+include image_LICENSE_Nuvola.txt
+include image_LICENSE_OOo.txt
+include LICENSE.txt
 include README.rst
 include MANIFEST.in
 recursive-include pyface *.py *.png *.jpg *.gif *.svg *.zip *.txt


### PR DESCRIPTION
This PR changes the manifest file to only include the image license and other relevant top level files, not all `txt` extension files.

On master, the following additional files are included in the sdist, which aren't included in this PR.

- `appveyor-clean-cache.txt`
- `CHANGES.txt`
- `ci-src-requirements.txt`
- `dev_requirements.txt`
- `doc-src-requirements.txt`