### PR TITLE
Remove macOS builds from Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,6 @@ matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2 wx"
     - env: RUNTIME=3.6 TOOLKITS="pyqt5 wx" TRAITS_REQUIRES="^=6.0"
-    - os: osx
-      # Obtain newer libxml2 for QtWebKit
-      osx_image: xcode11.5
-      env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2 wx"
   fast_finish: true
 
 cache:
@@ -41,7 +37,6 @@ cache:
 before_install:
   - mkdir -p "${HOME}/.cache/download"
   - if [[ ${TRAVIS_OS_NAME} == 'linux' ]]; then ./install-edm-linux.sh; export PATH="${HOME}/edm/bin:${PATH}"; fi
-  - if [[ ${TRAVIS_OS_NAME} == 'osx' ]]; then ./install-edm-osx.sh; export PATH="${PATH}:/usr/local/bin"; fi
   - edm install -y wheel click coverage
 install:
   - for toolkit in ${TOOLKITS}; do edm run -- python etstool.py install --runtime=${RUNTIME} --toolkit=${toolkit} || exit; done


### PR DESCRIPTION
macOS minutes are expensive; remove macOS builds from the Travis CI configuration. Longer term, we'll plan to migrate to GitHub Actions.