### PR TITLE
Fix loading resource images from a module that is not a package

### DIFF
--- a/pyface/resource/resource_manager.py
+++ b/pyface/resource/resource_manager.py
@@ -291,7 +291,7 @@ def _get_package_data(module, rel_path):
             return fp.read()
 
     return (
-        files(module.__name__).joinpath(rel_path).read_bytes()
+        files(module).joinpath(rel_path).read_bytes()
     )
 
 

--- a/pyface/resource/resource_manager.py
+++ b/pyface/resource/resource_manager.py
@@ -143,7 +143,7 @@ class ResourceManager(HasTraits):
                     data = _find_resource_data(
                         dirname, subdirs, image_filenames
                     )
-                except IOError:
+                except OSError:
                     continue
                 else:
                     return ImageReference(

--- a/pyface/tests/test_resource_manager.py
+++ b/pyface/tests/test_resource_manager.py
@@ -53,8 +53,8 @@ class TestPyfaceResourceFactory(unittest.TestCase):
         self.assertEqual(IMAGE_PATH, img_ref.filename)
 
     def test_locate_image_with_module(self):
-        # images/close.png is included in pyface package data.
-        # ResourceManager can find it via package resources
+        # ResourceManager should be able to find the images/close.png which
+        # is included in pyface package data.
         resource_manager = ResourceManager()
         image_ref = resource_manager.locate_image("close.png", [pyface])
         self.assertGreater(len(image_ref.data), 0)

--- a/pyface/tests/test_resource_manager.py
+++ b/pyface/tests/test_resource_manager.py
@@ -68,11 +68,12 @@ class TestPyfaceResourceFactory(unittest.TestCase):
         self.assertIsNone(image_ref)
 
     def test_locate_image_with_name_being_dunder_main(self):
-        # When a module is __main__, we will fall back to use __file__
+        # When a module is not a package, we will fall back to use __file__
 
         # given a module from which there is an image in the same folder
         with tempfile.TemporaryDirectory() as tmp_dir:
             shutil.copyfile(IMAGE_PATH, os.path.join(tmp_dir, "random.png"))
+            # create an empty file for creating a module.
             py_filepath = os.path.join(tmp_dir, "tmp.py")
             with open(py_filepath, "w", encoding="utf-8"):
                 pass

--- a/pyface/tests/test_resource_manager.py
+++ b/pyface/tests/test_resource_manager.py
@@ -10,9 +10,13 @@
 
 
 from collections.abc import Sequence
+import importlib.util
 import os
+import shutil
+import tempfile
 import unittest
 
+import pyface     # a package with images as package resources
 from ..resource_manager import PyfaceResourceFactory
 from ..resource_manager import ResourceManager
 
@@ -47,3 +51,41 @@ class TestPyfaceResourceFactory(unittest.TestCase):
         resource_manager = ResourceManager()
         img_ref = resource_manager.locate_image("core.png", sequence)
         self.assertEqual(IMAGE_PATH, img_ref.filename)
+
+    def test_locate_image_with_module(self):
+        # images/close.png is included in pyface package data.
+        # ResourceManager can find it via package resources
+        resource_manager = ResourceManager()
+        image_ref = resource_manager.locate_image("close.png", [pyface])
+        self.assertGreater(len(image_ref.data), 0)
+
+    def test_locate_image_with_module_missing_file(self):
+        # The required image is not found, locate_image should return None.
+        resource_manager = ResourceManager()
+        image_ref = resource_manager.locate_image(
+            "does_not_exist.png", [pyface]
+        )
+        self.assertIsNone(image_ref)
+
+    def test_locate_image_with_name_being_dunder_main(self):
+        # When a module is __main__, we will fall back to use __file__
+
+        # given a module from which there is an image in the same folder
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            shutil.copyfile(IMAGE_PATH, os.path.join(tmp_dir, "random.png"))
+            py_filepath = os.path.join(tmp_dir, "tmp.py")
+            with open(py_filepath, "w", encoding="utf-8"):
+                pass
+            spec = importlib.util.spec_from_file_location(
+                "__main__", py_filepath
+            )
+            module = importlib.util.module_from_spec(spec)
+
+            resource_manager = ResourceManager(
+                resource_factory=PyfaceResourceFactory()
+            )
+            # when
+            image_ref = resource_manager.load_image("random.png", [module])
+
+            # then
+            self.assertIsNotNone(image_ref)


### PR DESCRIPTION
Fix #830 (supersede #831)

`importlib_resources.files` requires its input argument to be a Package, where Package is defined [as follows](https://docs.python.org/3/library/importlib.html#importlib.resources.Package):
> The Package type is defined as Union[str, ModuleType]. This means that where the function describes accepting a Package, you can pass in either a string or a module. Module objects must have a resolvable __spec__.submodule_search_locations that is not None.

When Pyface's `ImageResource` is defined in a Python script (e.g. run from the command line), the module  `__name__` is `"__main__"`, which is passed onto `importlib_resources.files` for locating image files. `__main__` fails the requirement on its being a package, hence the error described in the issue.

The test mentioned in https://github.com/enthought/pyface/pull/831#issuecomment-740095459 failed at the second assertion with pyface 7.0.0 source using `pkg_resources`. This is because `pkg_resources` uses `sys.modules` to look up the module with the given `"__main__"` name.  When the test is run with `python -m unittest ` (or similar) from the command line, `sys.modules["__main__"]` is defined to be the unittest main module, rather than the expected module from which the ImageResource was defined. This explains why the failure is observed in the test but not when one runs a Python script from the command line. The test therefore reveals a limitation of `pkg_resources`. Since the ResourceManager also has a reference to the Python module, there is no need to go the whole roundtrip to find the module again from `sys.modules` using `__name__`. 

Previously when `pkg_resources` was used, [the module `__file__` is used for getting the search path for resources](https://github.com/pypa/setuptools/blob/b6bbe236ed0689f50b5148f1172510b975687e62/pkg_resources/__init__.py#L1377). To preserve previous behaviour and to fix the issue, if the module is not a package, following the definition mentioned above, we will use the `__file__` information.  If the module is a package, then we continue to use `importlib_resources.files`.