### PR TITLE
Improve api documentation in pyface.tasks

### DIFF
--- a/pyface/tasks/advanced_editor_area_pane.py
+++ b/pyface/tasks/advanced_editor_area_pane.py
@@ -8,7 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``AdvancedEditorAreaPane``. """
+""" Toolkit-specific implementation of the ``AdvancedEditorAreaPane``.
+
+- :attr:`~.AdvancedEditorAreaPane`
+"""
 
 from pyface.toolkit import toolkit_object
 

--- a/pyface/tasks/advanced_editor_area_pane.py
+++ b/pyface/tasks/advanced_editor_area_pane.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``AdvancedEditorAreaPane``.
-
+"""
 - :attr:`~.AdvancedEditorAreaPane`
 """
 

--- a/pyface/tasks/advanced_editor_area_pane.py
+++ b/pyface/tasks/advanced_editor_area_pane.py
@@ -7,7 +7,9 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-# Import the toolkit specific version.
+
+""" Toolkit-specific implementation of the ``AdvancedEditorAreaPane``. """
+
 from pyface.toolkit import toolkit_object
 
 AdvancedEditorAreaPane = toolkit_object(

--- a/pyface/tasks/api.py
+++ b/pyface/tasks/api.py
@@ -8,6 +8,54 @@
 #
 # Thanks for using Enthought open source!
 
+"""
+
+API for the ``pyface.tasks`` submodule.
+
+Tasks-specific Interfaces
+-------------------------
+- :class:`~.IDockPane`
+- :class:`~.IEditor`
+- :class:`~.IEditorAreaPane`
+- :class:`~.ITaskPane`
+
+Tasks, Tasks Application and related classes
+--------------------------------------------
+
+- :class:`~.AdvancedEditorAreaPane`
+- :class:`~.DockPane`
+- :class:`~.Editor`
+- :class:`~.EditorAreaPane`
+- :class:`~.SplitEditorAreaPane`
+- :class:`~.Task`
+- :class:`~.TasksApplication`
+- :class:`~.TaskFactory`
+- :class:`~.TaskPane`
+- :class:`~.TaskWindow`
+
+Tasks layout
+------------
+- :class:`~.TaskLayout`
+- :class:`~.TaskWindowLayout`
+- :class:`~.PaneItem`
+- :class:`~.Tabbed`
+- :class:`~.Splitter`
+- :class:`~.HSplitter`
+- :class:`~.VSplitter`
+
+Traits-specific Tasks classes
+-----------------------------
+- :class:`~.TraitsDockPane`
+- :class:`~.TraitsEditor`
+- :class:`~.TraitsTaskPane`
+
+Enaml-specific Tasks functionality
+----------------------------------
+- :class:`~.EnamlDockPane`
+- :class:`~.EnamlEditor`
+- :class:`~.EnamlTaskPane`
+
+"""
 
 from .advanced_editor_area_pane import AdvancedEditorAreaPane
 from .split_editor_area_pane import SplitEditorAreaPane

--- a/pyface/tasks/dock_pane.py
+++ b/pyface/tasks/dock_pane.py
@@ -7,7 +7,9 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-# Import the toolkit specific version.
+
+""" Toolkit-specific implementation of the ``DockPane``. """
+
 from pyface.toolkit import toolkit_object
 
 DockPane = toolkit_object("tasks.dock_pane:DockPane")

--- a/pyface/tasks/dock_pane.py
+++ b/pyface/tasks/dock_pane.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``DockPane``.
-
+"""
 - :attr:`~.DockPane`
 """
 

--- a/pyface/tasks/dock_pane.py
+++ b/pyface/tasks/dock_pane.py
@@ -8,7 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``DockPane``. """
+""" Toolkit-specific implementation of the ``DockPane``.
+
+- :attr:`~.DockPane`
+"""
 
 from pyface.toolkit import toolkit_object
 

--- a/pyface/tasks/editor.py
+++ b/pyface/tasks/editor.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``Editor``.
-
+"""
 - :attr:`~.Editor`
 """
 

--- a/pyface/tasks/editor.py
+++ b/pyface/tasks/editor.py
@@ -7,7 +7,9 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-# Import the toolkit specific version.
+
+""" Toolkit-specific implementation of the ``Editor``. """
+
 from pyface.toolkit import toolkit_object
 
 Editor = toolkit_object("tasks.editor:Editor")

--- a/pyface/tasks/editor.py
+++ b/pyface/tasks/editor.py
@@ -8,7 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``Editor``. """
+""" Toolkit-specific implementation of the ``Editor``.
+
+- :attr:`~.Editor`
+"""
 
 from pyface.toolkit import toolkit_object
 

--- a/pyface/tasks/editor_area_pane.py
+++ b/pyface/tasks/editor_area_pane.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``EditorAreaPane``.
-
+"""
 - :attr:`~.EditorAreaPane`
 """
 

--- a/pyface/tasks/editor_area_pane.py
+++ b/pyface/tasks/editor_area_pane.py
@@ -8,7 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``EditorAreaPane``. """
+""" Toolkit-specific implementation of the ``EditorAreaPane``.
+
+- :attr:`~.EditorAreaPane`
+"""
 
 from pyface.toolkit import toolkit_object
 

--- a/pyface/tasks/editor_area_pane.py
+++ b/pyface/tasks/editor_area_pane.py
@@ -7,7 +7,9 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-# Import the toolkit specific version.
+
+""" Toolkit-specific implementation of the ``EditorAreaPane``. """
+
 from pyface.toolkit import toolkit_object
 
 EditorAreaPane = toolkit_object("tasks.editor_area_pane:EditorAreaPane")

--- a/pyface/tasks/i_dock_pane.py
+++ b/pyface/tasks/i_dock_pane.py
@@ -23,8 +23,8 @@ class IDockPane(ITaskPane):
 
     #: If enabled, the pane will have a button to close it, and a visibility
     #: toggle button will be added to the View menu. Otherwise, the pane's
-    #: visibility will only be adjustable programmatically, though the 'visible'
-    #: attribute.
+    #: visibility will only be adjustable programmatically, though the
+    #: 'visible' attribute.
     closable = Bool(True)
 
     #: The dock area in which the pane is currently present.

--- a/pyface/tasks/i_dock_pane.py
+++ b/pyface/tasks/i_dock_pane.py
@@ -21,28 +21,28 @@ class IDockPane(ITaskPane):
     general, be moved, resized, and hidden by the user.
     """
 
-    # If enabled, the pane will have a button to close it, and a visibility
-    # toggle button will be added to the View menu. Otherwise, the pane's
-    # visibility will only be adjustable programmatically, though the 'visible'
-    # attribute.
+    #: If enabled, the pane will have a button to close it, and a visibility
+    #: toggle button will be added to the View menu. Otherwise, the pane's
+    #: visibility will only be adjustable programmatically, though the 'visible'
+    #: attribute.
     closable = Bool(True)
 
-    # The dock area in which the pane is currently present.
+    #: The dock area in which the pane is currently present.
     dock_area = Enum("left", "right", "top", "bottom")
 
-    # Whether the pane can be detached from the main window.
+    #: Whether the pane can be detached from the main window.
     floatable = Bool(True)
 
-    # Whether the pane is currently detached from the main window.
+    #: Whether the pane is currently detached from the main window.
     floating = Bool(False)
 
-    # Whether the pane can be moved from one dock area to another.
+    #: Whether the pane can be moved from one dock area to another.
     movable = Bool(True)
 
-    # The size of the dock pane. Note that this value is read-only.
+    #: The size of the dock pane. Note that this value is read-only.
     size = Tuple()
 
-    # Whether the pane is currently visible.
+    #: Whether the pane is currently visible.
     visible = Bool(False)
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/i_editor_area_pane.py
+++ b/pyface/tasks/i_editor_area_pane.py
@@ -49,9 +49,10 @@ class IEditorAreaPane(ITaskPane):
     editors = List(IEditor)
 
     #: A list of extensions for file types to accept via drag and drop.
-    #: Note: This functionality is provided because it is very common, but drag
-    #: and drop support is in general highly toolkit-specific. If more
-    #: sophisticated support is required, subclass an editor area implementation.
+    #: Note: This functionality is provided because it is very common, but
+    #: drag and drop support is in general highly toolkit-specific. If more
+    #: sophisticated support is required, subclass an editor area
+    #: implementation.
     file_drop_extensions = List(Str)
 
     #: A file with a supported extension was dropped into the editor area.

--- a/pyface/tasks/i_editor_area_pane.py
+++ b/pyface/tasks/i_editor_area_pane.py
@@ -42,22 +42,22 @@ class IEditorAreaPane(ITaskPane):
 
     # 'IEditorAreaPane' interface -----------------------------------------#
 
-    # The currently active editor.
+    #: The currently active editor.
     active_editor = Instance(IEditor)
 
-    # The list of all the visible editors in the pane.
+    #: The list of all the visible editors in the pane.
     editors = List(IEditor)
 
-    # A list of extensions for file types to accept via drag and drop.
-    # Note: This functionality is provided because it is very common, but drag
-    # and drop support is in general highly toolkit-specific. If more
-    # sophisticated support is required, subclass an editor area implementation.
+    #: A list of extensions for file types to accept via drag and drop.
+    #: Note: This functionality is provided because it is very common, but drag
+    #: and drop support is in general highly toolkit-specific. If more
+    #: sophisticated support is required, subclass an editor area implementation.
     file_drop_extensions = List(Str)
 
-    # A file with a supported extension was dropped into the editor area.
+    #: A file with a supported extension was dropped into the editor area.
     file_dropped = Event(File)
 
-    # Whether to hide the tab bar when there is only a single editor.
+    #: Whether to hide the tab bar when there is only a single editor.
     hide_tab_bar = Bool(False)
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/split_editor_area_pane.py
+++ b/pyface/tasks/split_editor_area_pane.py
@@ -10,6 +10,9 @@
 
 """ Toolkit-specific implementation of the ``SplitEditorAreaPane`` and
 ``EditorAreaWidget``.
+
+- :attr:`~.SplitEditorAreaPane`
+- :attr:`~.EditorAreaWidget`
 """
 
 from pyface.toolkit import toolkit_object

--- a/pyface/tasks/split_editor_area_pane.py
+++ b/pyface/tasks/split_editor_area_pane.py
@@ -8,9 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``SplitEditorAreaPane`` and
-``EditorAreaWidget``.
-
+"""
 - :attr:`~.SplitEditorAreaPane`
 - :attr:`~.EditorAreaWidget`
 """

--- a/pyface/tasks/split_editor_area_pane.py
+++ b/pyface/tasks/split_editor_area_pane.py
@@ -7,7 +7,11 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-# Import the toolkit specific version.
+
+""" Toolkit-specific implementation of the ``SplitEditorAreaPane`` and
+``EditorAreaWidget``.
+"""
+
 from pyface.toolkit import toolkit_object
 
 SplitEditorAreaPane = toolkit_object(

--- a/pyface/tasks/task.py
+++ b/pyface/tasks/task.py
@@ -36,7 +36,8 @@ class Task(HasTraits):
     default_layout = Instance(TaskLayout, ())
 
     #: A list of extra IDockPane factories for the task. These dock panes are
-    #: used in conjunction with the dock panes returned by create_dock_panes().
+    #: used in conjunction with the dock panes returned by
+    #: create_dock_panes().
     extra_dock_pane_factories = List(Callable)
 
     #: The window to which the task is attached. Set by the framework.

--- a/pyface/tasks/task.py
+++ b/pyface/tasks/task.py
@@ -25,36 +25,36 @@ class Task(HasTraits):
     its view (a TaskWindow) and an application-specific model.
     """
 
-    # The task's identifier.
+    #: The task's identifier.
     id = Str()
 
-    # The task's user-visible name.
+    #: The task's user-visible name.
     name = Str()
 
-    # The default layout to use for the task. If not overridden, only the
-    # central pane is displayed.
+    #: The default layout to use for the task. If not overridden, only the
+    #: central pane is displayed.
     default_layout = Instance(TaskLayout, ())
 
-    # A list of extra IDockPane factories for the task. These dock panes are
-    # used in conjunction with the dock panes returned by create_dock_panes().
+    #: A list of extra IDockPane factories for the task. These dock panes are
+    #: used in conjunction with the dock panes returned by create_dock_panes().
     extra_dock_pane_factories = List(Callable)
 
-    # The window to which the task is attached. Set by the framework.
+    #: The window to which the task is attached. Set by the framework.
     window = Instance("pyface.tasks.task_window.TaskWindow")
 
     # Actions -------------------------------------------------------------#
 
-    # The menu bar for the task.
+    #: The menu bar for the task.
     menu_bar = Instance(MenuBarSchema)
 
-    # The (optional) status bar for the task.
+    #: The (optional) status bar for the task.
     status_bar = Instance(StatusBarManager)
 
-    # The list of tool bars for the tasks.
+    #: The list of tool bars for the tasks.
     tool_bars = List(ToolBarSchema)
 
-    # A list of extra actions, groups, and menus that are inserted into menu
-    # bars and tool bars constructed from the above schemas.
+    #: A list of extra actions, groups, and menus that are inserted into menu
+    #: bars and tool bars constructed from the above schemas.
     extra_actions = List(SchemaAddition)
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/task_layout.py
+++ b/pyface/tasks/task_layout.py
@@ -110,8 +110,8 @@ class PaneItem(LayoutItem):
     #: that TaskPane.
     id = Either(Str, Int, default="", pretty_skip=True)
 
-    #: The width of the pane in pixels. If not specified, the pane will be sized
-    #: according to its size hint.
+    #: The width of the pane in pixels. If not specified, the pane will be
+    #: sized according to its size hint.
     width = Int(-1)
 
     #: The height of the pane in pixels. If not specified, the pane will be
@@ -183,8 +183,8 @@ class DockLayout(LayoutItem):
     bottom = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
 
     #: Assignments of dock areas to the window's corners. By default, the top
-    #: and bottom dock areas extend into both of the top and both of the bottom
-    #: corners, respectively.
+    #: and bottom dock areas extend into both of the top and both of the
+    #: bottom corners, respectively.
     top_left_corner = Enum("top", "left")
     top_right_corner = Enum("top", "right")
     bottom_left_corner = Enum("bottom", "left")

--- a/pyface/tasks/task_layout.py
+++ b/pyface/tasks/task_layout.py
@@ -106,16 +106,16 @@ class PaneItem(LayoutItem):
     """ A pane in a Task layout.
     """
 
-    # The ID of the item. If the item refers to a TaskPane, this is the ID of
-    # that TaskPane.
+    #: The ID of the item. If the item refers to a TaskPane, this is the ID of
+    #: that TaskPane.
     id = Either(Str, Int, default="", pretty_skip=True)
 
-    # The width of the pane in pixels. If not specified, the pane will be sized
-    # according to its size hint.
+    #: The width of the pane in pixels. If not specified, the pane will be sized
+    #: according to its size hint.
     width = Int(-1)
 
-    # The height of the pane in pixels. If not specified, the pane will be
-    # sized according to its size hint.
+    #: The height of the pane in pixels. If not specified, the pane will be
+    #: sized according to its size hint.
     height = Int(-1)
 
     def __init__(self, id="", **traits):
@@ -130,12 +130,12 @@ class Tabbed(LayoutContainer):
     """ A tab area in a Task layout.
     """
 
-    # A tabbed layout can only contain PaneItems as sub-items. Splitters and
-    # other Tabbed layouts are not allowed.
+    #: A tabbed layout can only contain PaneItems as sub-items. Splitters and
+    #: other Tabbed layouts are not allowed.
     items = List(PaneItem, pretty_skip=True)
 
-    # The ID of the TaskPane which is active in layout. If not specified, the
-    # first pane is active.
+    #: The ID of the TaskPane which is active in layout. If not specified, the
+    #: first pane is active.
     active_tab = Either(Str, Int, default="")
 
 
@@ -143,11 +143,11 @@ class Splitter(LayoutContainer):
     """ A split area in a Task layout.
     """
 
-    # The orientation of the splitter.
+    #: The orientation of the splitter.
     orientation = Enum("horizontal", "vertical")
 
-    # The sub-items of the splitter, which are PaneItems, Tabbed layouts, and
-    # other Splitters.
+    #: The sub-items of the splitter, which are PaneItems, Tabbed layouts, and
+    #: other Splitters.
     items = List(
         Either(
             Instance(PaneItem),
@@ -176,15 +176,15 @@ class DockLayout(LayoutItem):
     """ The layout for a main window's dock area.
     """
 
-    # The layouts for the task's dock panes.
+    #: The layouts for the task's dock panes.
     left = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
     right = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
     top = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
     bottom = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
 
-    # Assignments of dock areas to the window's corners. By default, the top
-    # and bottom dock areas extend into both of the top and both of the bottom
-    # corners, respectively.
+    #: Assignments of dock areas to the window's corners. By default, the top
+    #: and bottom dock areas extend into both of the top and both of the bottom
+    #: corners, respectively.
     top_left_corner = Enum("top", "left")
     top_right_corner = Enum("top", "right")
     bottom_left_corner = Enum("bottom", "left")
@@ -195,5 +195,5 @@ class TaskLayout(DockLayout):
     """ The layout for a Task.
     """
 
-    # The ID of the task for which this is a layout.
+    #: The ID of the task for which this is a layout.
     id = Str()

--- a/pyface/tasks/task_pane.py
+++ b/pyface/tasks/task_pane.py
@@ -8,7 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``TaskPane``. """
+""" Toolkit-specific implementation of the ``TaskPane``.
+
+- :attr:`~.TaskPane`
+"""
 
 from pyface.toolkit import toolkit_object
 

--- a/pyface/tasks/task_pane.py
+++ b/pyface/tasks/task_pane.py
@@ -7,7 +7,9 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-# Import the toolkit specific version.
+
+""" Toolkit-specific implementation of the ``TaskPane``. """
+
 from pyface.toolkit import toolkit_object
 
 TaskPane = toolkit_object("tasks.task_pane:TaskPane")

--- a/pyface/tasks/task_pane.py
+++ b/pyface/tasks/task_pane.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``TaskPane``.
-
+"""
 - :attr:`~.TaskPane`
 """
 

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -60,8 +60,8 @@ class TaskWindow(ApplicationWindow):
     #: The active task for this window.
     active_task = Instance(Task)
 
-    #: The list of all tasks currently attached to this window. All panes of the
-    #: inactive tasks are hidden.
+    #: The list of all tasks currently attached to this window. All panes of
+    #: the inactive tasks are hidden.
     tasks = List(Task)
 
     #: The central pane of the active task, which is always visible.

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -49,32 +49,32 @@ class TaskWindow(ApplicationWindow):
 
     # IWindow interface ----------------------------------------------------
 
-    # Unless a title is specifically assigned, delegate to the active task.
+    #: Unless a title is specifically assigned, delegate to the active task.
     title = Property(Str, depends_on=["active_task.name", "_title"])
 
     # TaskWindow interface ------------------------------------------------
 
-    # The pane (central or dock) in the active task that currently has focus.
+    #: The pane (central or dock) in the active task that currently has focus.
     active_pane = Instance(ITaskPane)
 
-    # The active task for this window.
+    #: The active task for this window.
     active_task = Instance(Task)
 
-    # The list of all tasks currently attached to this window. All panes of the
-    # inactive tasks are hidden.
+    #: The list of all tasks currently attached to this window. All panes of the
+    #: inactive tasks are hidden.
     tasks = List(Task)
 
-    # The central pane of the active task, which is always visible.
+    #: The central pane of the active task, which is always visible.
     central_pane = Instance(ITaskPane)
 
-    # The list of all dock panes in the active task, which may or may not be
-    # visible.
+    #: The list of all dock panes in the active task, which may or may not be
+    #: visible.
     dock_panes = List(IDockPane)
 
-    # The factory for the window's TaskActionManagerBuilder, which is
-    # instantiated to translate menu and tool bar schemas into Pyface action
-    # managers. This attribute can overridden to introduce custom logic into
-    # the translation process, although this is not usually necessary.
+    #: The factory for the window's TaskActionManagerBuilder, which is
+    #: instantiated to translate menu and tool bar schemas into Pyface action
+    #: managers. This attribute can overridden to introduce custom logic into
+    #: the translation process, although this is not usually necessary.
     action_manager_builder_factory = Callable(TaskActionManagerBuilder)
 
     # Protected traits -----------------------------------------------------

--- a/pyface/tasks/task_window_backend.py
+++ b/pyface/tasks/task_window_backend.py
@@ -8,7 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``TaskWindowBackend``. """
+""" Toolkit-specific implementation of the ``TaskWindowBackend``.
+
+- :attr:`~.TaskWindowBackend`
+"""
 
 from pyface.toolkit import toolkit_object
 

--- a/pyface/tasks/task_window_backend.py
+++ b/pyface/tasks/task_window_backend.py
@@ -8,8 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-""" Toolkit-specific implementation of the ``TaskWindowBackend``.
-
+"""
 - :attr:`~.TaskWindowBackend`
 """
 

--- a/pyface/tasks/task_window_backend.py
+++ b/pyface/tasks/task_window_backend.py
@@ -7,7 +7,9 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-# Import the toolkit specific version.
+
+""" Toolkit-specific implementation of the ``TaskWindowBackend``. """
+
 from pyface.toolkit import toolkit_object
 
 TaskWindowBackend = toolkit_object(

--- a/pyface/tasks/task_window_layout.py
+++ b/pyface/tasks/task_window_layout.py
@@ -18,11 +18,12 @@ class TaskWindowLayout(LayoutContainer):
     """ The layout of a TaskWindow.
     """
 
-    #: The ID of the active task. If unspecified, the first task will be active.
+    #: The ID of the active task. If unspecified, the first task will be
+    #: active.
     active_task = Str()
 
     #: The tasks contained in the window. If an ID is specified, the task will
-    #: use its default layout. Otherwise, it will use the specified TaskLayout.
+    #: use its default layout. Otherwise, it will use the specified TaskLayout
     items = List(Either(Str, Instance(TaskLayout)), pretty_skip=True)
 
     #: The position of the window.

--- a/pyface/tasks/task_window_layout.py
+++ b/pyface/tasks/task_window_layout.py
@@ -18,19 +18,20 @@ class TaskWindowLayout(LayoutContainer):
     """ The layout of a TaskWindow.
     """
 
-    # The ID of the active task. If unspecified, the first task will be active.
+    #: The ID of the active task. If unspecified, the first task will be active.
     active_task = Str()
 
-    # The tasks contained in the window. If an ID is specified, the task will
-    # use its default layout. Otherwise, it will use the specified TaskLayout.
+    #: The tasks contained in the window. If an ID is specified, the task will
+    #: use its default layout. Otherwise, it will use the specified TaskLayout.
     items = List(Either(Str, Instance(TaskLayout)), pretty_skip=True)
 
-    # The position of the window.
+    #: The position of the window.
     position = Tuple(-1, -1)
 
-    # The size of the window.
+    #: The size of the window.
     size = Tuple(800, 600)
 
+    #: Whether or not the application is maximized.
     size_state = Enum("normal", "maximized")
 
     def get_active_task(self):

--- a/pyface/tasks/traits_dock_pane.py
+++ b/pyface/tasks/traits_dock_pane.py
@@ -20,10 +20,10 @@ class TraitsDockPane(DockPane):
 
     # TraitsDockPane interface ---------------------------------------------
 
-    # The model object to view. If not specified, the pane is used instead.
+    #: The model object to view. If not specified, the pane is used instead.
     model = Instance(HasTraits)
 
-    # The UI object associated with the Traits view, if it has been constructed.
+    #: The UI object associated with the Traits view, if it has been constructed.
     ui = Instance("traitsui.ui.UI")
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/traits_dock_pane.py
+++ b/pyface/tasks/traits_dock_pane.py
@@ -23,7 +23,8 @@ class TraitsDockPane(DockPane):
     #: The model object to view. If not specified, the pane is used instead.
     model = Instance(HasTraits)
 
-    #: The UI object associated with the Traits view, if it has been constructed.
+    #: The UI object associated with the Traits view, if it has been
+    #: constructed.
     ui = Instance("traitsui.ui.UI")
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/traits_editor.py
+++ b/pyface/tasks/traits_editor.py
@@ -23,7 +23,8 @@ class TraitsEditor(Editor):
     #: The model object to view. If not specified, the editor is used instead.
     model = Instance(HasTraits)
 
-    #: The UI object associated with the Traits view, if it has been constructed.
+    #: The UI object associated with the Traits view, if it has been
+    #: constructed.
     ui = Instance("traitsui.ui.UI")
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/traits_editor.py
+++ b/pyface/tasks/traits_editor.py
@@ -20,10 +20,10 @@ class TraitsEditor(Editor):
 
     # TraitsEditor interface -----------------------------------------------
 
-    # The model object to view. If not specified, the editor is used instead.
+    #: The model object to view. If not specified, the editor is used instead.
     model = Instance(HasTraits)
 
-    # The UI object associated with the Traits view, if it has been constructed.
+    #: The UI object associated with the Traits view, if it has been constructed.
     ui = Instance("traitsui.ui.UI")
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/traits_task_pane.py
+++ b/pyface/tasks/traits_task_pane.py
@@ -20,10 +20,10 @@ class TraitsTaskPane(TaskPane):
 
     # TraitsTaskPane interface ---------------------------------------------
 
-    # The model object to view. If not specified, the pane is used instead.
+    #: The model object to view. If not specified, the pane is used instead.
     model = Instance(HasTraits)
 
-    # The UI object associated with the Traits view, if it has been constructed.
+    #: The UI object associated with the Traits view, if it has been constructed.
     ui = Instance("traitsui.ui.UI")
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/traits_task_pane.py
+++ b/pyface/tasks/traits_task_pane.py
@@ -23,7 +23,8 @@ class TraitsTaskPane(TaskPane):
     #: The model object to view. If not specified, the pane is used instead.
     model = Instance(HasTraits)
 
-    #: The UI object associated with the Traits view, if it has been constructed.
+    #: The UI object associated with the Traits view, if it has been
+    #: constructed.
     ui = Instance("traitsui.ui.UI")
 
     # ------------------------------------------------------------------------


### PR DESCRIPTION
This PR improves documentation in the `pyface.tasks` submodule in the following ways

- adds a module docstring to `pyface.tasks.api`
- adds a module docstring to the modules that import toolkit-specific classes/implementations
- updates trait comments so that they get picked up by sphinx for api docs.