### PR TITLE
Address a few sphinx warnings

### DIFF
--- a/pyface/tasks/tasks_application.py
+++ b/pyface/tasks/tasks_application.py
@@ -44,7 +44,7 @@ class TaskFactory(HasStrictTraits):
 
     #: A callable with the following signature:
     #:
-    #:     callable(**traits) -> Task
+    #:     callable(\**traits) -> Task
     #:
     #: Often this attribute will simply be a Task subclass.
     factory = Callable

--- a/pyface/timer/do_later.py
+++ b/pyface/timer/do_later.py
@@ -55,7 +55,10 @@ def do_after(interval, callable, *args, **kwargs):
         The time interval in milliseconds to wait before calling.
     callable : callable
         The callable to call.
-    *args, \**kwargs : tuple, dict
+    \*args
+        Positional arguments to be passed through to the callable.
+    \*\*kwargs
+        Keyword arguments to be passed through to the callable.
         Arguments to be passed through to the callable.
     """
     return CallbackTimer.single_shot(

--- a/pyface/timer/do_later.py
+++ b/pyface/timer/do_later.py
@@ -38,7 +38,7 @@ def do_later(callable, *args, **kwargs):
     ----------
     callable : callable
         The callable to call in 50ms time.
-    *args, **kwargs : tuple, dict
+    *args, \**kwargs : tuple, dict
         Arguments to be passed through to the callable.
     """
     return CallbackTimer.single_shot(
@@ -55,7 +55,7 @@ def do_after(interval, callable, *args, **kwargs):
         The time interval in milliseconds to wait before calling.
     callable : callable
         The callable to call.
-    *args, **kwargs : tuple, dict
+    *args, \**kwargs : tuple, dict
         Arguments to be passed through to the callable.
     """
     return CallbackTimer.single_shot(


### PR DESCRIPTION
Not sure if this is the right fix but this is a fix. This PR addresses the following sphinx warnings : 

```
pyface\tasks\tasks_application.py:docstring of pyface.tasks.tasks_application.TaskFactory.factory:3: WARNING: Inline strong start-string without end-string.
pyface\timer\do_later.py:docstring of pyface.timer.do_later.do_later:5: WARNING: Inline strong start-string without end-string.
pyface\timer\do_later.py:docstring of pyface.timer.do_later.do_later:6: WARNING: Inline strong start-string without end-string.
pyface\timer\do_later.py:docstring of pyface.timer.do_later.do_after:7: WARNING: Inline strong start-string without end-string.
pyface\timer\do_later.py:docstring of pyface.timer.do_later.do_after:8: WARNING: Inline strong start-string without end-string.
```

Interpreting the "Inline strong start-string" as `"**"`, the fix I employed was to simply escape the characters i.e. `"\**"`