### PR TITLE
Improve api docs for pyface.undo and pyface.undo.action

### DIFF
--- a/pyface/undo/action/api.py
+++ b/pyface/undo/action/api.py
@@ -22,6 +22,19 @@
 # Description: <Enthought undo package component>
 # ------------------------------------------------------------------------------
 
+"""
+
+API for ``pyface.undo.action``.
+
+CommandAction and useful subclasses
+-----------------------------------
+
+- :class:`~.CommandAction`
+- :class:`~.RedoAction`
+- :class:`~.UndoAction`
+
+"""
+
 from .command_action import CommandAction
 from .redo_action import RedoAction
 from .undo_action import UndoAction

--- a/pyface/undo/api.py
+++ b/pyface/undo/api.py
@@ -12,6 +12,22 @@
 # Description: <Enthought undo package component>
 # ------------------------------------------------------------------------------
 
+"""
+
+API for ``pyface.undo``.
+
+Interfaces and Implementations
+------------------------------
+
+- :class:`~.ICommand`
+- :class:`~.AbstractCommand`
+- :class:`~.ICommandStack`
+- :class:`~.CommandStack`
+- :class:`~.IUndoManager`
+- :class:`~.UndoManager`
+
+"""
+
 from .abstract_command import AbstractCommand
 from .command_stack import CommandStack
 from .i_command import ICommand


### PR DESCRIPTION
This PR improves the api documentation for `pyface.undo` and `pyface.undo.action` by adding a module docstring to `pyface.undo.api` and `pyface.undo.action.api` which document the classes exposed by the respective API modules.