### PR TITLE
Declare python_requires to support Python >= 3.6

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -50,7 +50,7 @@ using::
 
     python etstool.py test-all
 
-Currently supported runtime values are ``2.7`` and ``3.5``, and currently
+Currently supported runtime values include ``3.6``, and currently
 supported toolkits are ``null``, ``pyqt``, ``pyside`` and ``wx``.  Not all
 combinations of toolkits and runtimes will work, but the tasks will fail with
 a clear error if that is the case.
@@ -83,7 +83,6 @@ from contextlib import contextmanager
 import click
 
 supported_combinations = {
-    "3.5": {"pyqt", "pyqt5"},
     "3.6": {"pyqt", "pyqt5", "pyside2", "wx"},
 }
 

--- a/setup.py
+++ b/setup.py
@@ -317,7 +317,7 @@ if __name__ == "__main__":
               Operating System :: POSIX
               Operating System :: Unix
               Programming Language :: Python
-              Programming Language :: Python :: 3.5
+              Programming Language :: Python :: 3
               Programming Language :: Python :: 3.6
               Programming Language :: Python :: 3.7
               Programming Language :: Python :: 3.8
@@ -359,5 +359,6 @@ if __name__ == "__main__":
             ]
         },
         platforms=["Windows", "Linux", "Mac OS-X", "Unix", "Solaris"],
+        python_requires=">=3.6",
         zip_safe=False,
     )


### PR DESCRIPTION
Closes #845

This PR updates `setup.py` such that package installer will avoid the next release if the Python version is less than 3.6.

Pyface no longer supports Python 2, and CI for Python 3.5 has been removed so it would be difficult to continue its support, Python 3.5 has also reached its end-of-life.

Similar to https://github.com/enthought/traitsui/pull/1436