### PR TITLE
Use viewcode sphinx extension

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,6 +23,8 @@ import sys
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    # Link to code in sphinx generated API docs
+    "sphinx.ext.viewcode",
     'traits.util.trait_documenter'
 ]
 


### PR DESCRIPTION
Using this extension means that API docs now link to source code. See example below which now includes the source button.

![sphinx-viewcode](https://user-images.githubusercontent.com/1926457/102229428-b62f8d00-3ee3-11eb-882d-c82144899980.png)
