### PR TITLE
Fix importing QtWebEngine after toolkit selection

### DIFF
--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -22,7 +22,7 @@ __requires__ = ["importlib-metadata", "importlib-resources>=1.1.0", "traits>=6"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],
-    "pyqt5": ["pyqt5", "pygments"],
+    "pyqt5": ["pyqt5", "PyQtWebEngine", "pygments"],
     "pyside": ["pyside>=1.2", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
     "test": ["packaging"],

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -22,7 +22,7 @@ __requires__ = ["importlib-metadata", "importlib-resources>=1.1.0", "traits>=6"]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],
-    "pyqt5": ["pyqt5", "PyQtWebEngine", "pygments"],
+    "pyqt5": ["pyqt5", "pygments"],
     "pyside": ["pyside>=1.2", "pygments"],
     "pyside2": ["pyside2", "shiboken2", "pygments"],
     "test": ["packaging"],

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -38,8 +38,8 @@ if _app is None:
         # pyface.qt.QtWebKit tries QtWebEngineWidgets first, but
         # if QtWebEngineWidgets is present, it must be imported prior to
         # creating a QCoreApplication instance, otherwise importing
-        # QtWebEngineWidgets later would fail. Import it here first before
-        # creating the instance.
+        # QtWebEngineWidgets later would fail (see enthought/pyface#581).
+        # Import it here first before creating the instance.
         from pyface.qt import QtWebKit
     except ImportError:
         # This error will be raised in the context where

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -34,6 +34,17 @@ if qt_api == "pyqt":
 _app = QtGui.QApplication.instance()
 
 if _app is None:
+    try:
+        # pyface.qt.QtWebKit tries QtWebEngineWidgets first, but
+        # if QtWebEngineWidgets is present, it must be imported prior to
+        # creating a QCoreApplication instance, otherwise importing
+        # QtWebEngineWidgets later would fail. Import it here first before
+        # creating the instance.
+        from pyface.qt import QtWebKit
+    except ImportError:
+        # This error will be raised in the context where
+        # QtWebKit/QtWebEngine widgets are required.
+        pass
     _app = QtGui.QApplication(sys.argv)
 
 


### PR DESCRIPTION
Fix #581

First of all, we need a separate distribution for QtWebEngine with PyQt5. This PR expands the `extras_require` so that `pip install pyface[pyqt5]` brings in `PyQtWebEngine`.

After installing `PyQtWebEngine`, importing `QtWebEngineWidgets` after instantiating a QCoreApplication results in an ImportError.  This PR fixes this by trying to import QtWebEngineWidgets before instantiating the QApplication.

All of this has to do with import side effect so it is hard to test. If the test mentioned in #581 is run on its own, it passes on master:
```
$ python -m unittest pyface.ui.qt4.tests.test_qt_imports.TestPyfaceQtImports
.
----------------------------------------------------------------------
Ran 1 test in 0.213s

OK
```
But if it is run after some other tests that have instantiated the QApplication, it fails (on master), as in #581:
```
$ python -m unittest pyface.ui.qt4.tests.test_gui pyface.ui.qt4.tests.test_qt_imports.TestPyfaceQtImports
======================================================================
ERROR: test_imports (pyface.ui.qt4.tests.test_qt_imports.TestPyfaceQtImports)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/pyface/pyface/qt/QtWebKit.py", line 20, in <module>
    from PyQt5.QtWebEngineWidgets import (
ImportError: QtWebEngineWidgets must be imported before a QCoreApplication instance is created

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kchoi/Work/ETS/pyface/pyface/ui/qt4/tests/test_qt_imports.py", line 24, in test_imports
    import pyface.qt.QtWebKit
  File "/Users/kchoi/Work/ETS/pyface/pyface/qt/QtWebKit.py", line 28, in <module>
    from PyQt5.QtWebKit import *
ModuleNotFoundError: No module named 'PyQt5.QtWebKit'

----------------------------------------------------------------------
Ran 2 tests in 0.062s

FAILED (errors=1)
```
With this PR, the second test command also passes.