### PR TITLE
Expose keyboard focus on Widgets

### DIFF
--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -54,6 +54,19 @@ class IWidget(Interface):
             The enabled state to set the widget to.
         """
 
+    def focus(self):
+        """ Set the keyboard focus to this widget.
+        """
+
+    def has_focus(self):
+        """ Does the widget currently have keyboard focus?
+
+        Returns
+        -------
+        focus_state : bool
+            Whether or not the widget has keyboard focus.
+        """
+
     def create(self):
         """ Creates the toolkit specific control.
 

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -34,11 +34,12 @@ class ConcreteWidget(Widget):
             control.Show(self.visible)
         elif toolkit_object.toolkit in {"qt4", "qt"}:
             from pyface.qt import QtGui
+            from pyface.qt.QtCore import Qt
 
             control = QtGui.QWidget(parent)
             control.setEnabled(self.enabled)
             control.setVisible(self.visible)
-            control.setFocusPolicy(QtGui.StrongFocus)
+            control.setFocusPolicy(Qt.StrongFocus)
         else:
             control = None
         return control

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -315,3 +315,12 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
                 self.widget.enabled = False
 
         self.assertFalse(self.widget.control.isEnabled())
+
+    def test_focus(self):
+        with self.event_loop():
+            self.widget.create()
+
+        with self.event_loop():
+            self.widget.focus()
+
+        self.assertTrue(self.widget.control.has_focus())

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -323,4 +323,4 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
         with self.event_loop():
             self.widget.focus()
 
-        self.assertTrue(self.widget.control.has_focus())
+        self.assertTrue(self.widget.has_focus())

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -38,6 +38,7 @@ class ConcreteWidget(Widget):
             control = QtGui.QWidget(parent)
             control.setEnabled(self.enabled)
             control.setVisible(self.visible)
+            control.setFocusPolicy(QtGui.StrongFocus)
         else:
             control = None
         return control

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 
+import sys
 import unittest
 
 from traits.api import Instance
@@ -22,6 +23,7 @@ GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
 no_gui_test_assistant = GuiTestAssistant.__name__ == "Unimplemented"
 
 is_qt = (toolkit_object.toolkit in {"qt4", "qt"})
+is_linux = (sys.platform == "linux")
 
 
 class ConcreteWidget(Widget):
@@ -318,6 +320,10 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
 
         self.assertFalse(self.widget.control.isEnabled())
 
+    @unittest.skipIf(
+        is_linux,
+        "Linux keyboard focus is False unless window is active",
+    )
     def test_focus(self):
         with self.event_loop():
             self.widget.create()

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -328,6 +328,8 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
         with self.event_loop():
             self.widget.create()
 
+        self.assertFalse(self.widget.has_focus())
+
         with self.event_loop():
             self.widget.focus()
 

--- a/pyface/ui/qt4/widget.py
+++ b/pyface/ui/qt4/widget.py
@@ -76,7 +76,7 @@ class Widget(MWidget, HasTraits):
         """ Set the keyboard focus to this widget.
         """
         if self.control is not None:
-            self.setFocus()
+            self.control.setFocus()
 
     def has_focus(self):
         """ Does the widget currently have keyboard focus?
@@ -86,7 +86,10 @@ class Widget(MWidget, HasTraits):
         focus_state : bool
             Whether or not the widget has keyboard focus.
         """
-        return self.hasFocus()
+        return (
+            self.control is not None
+            and self.control.hasFocus()
+        )
 
     def destroy(self):
         self._remove_event_listeners()

--- a/pyface/ui/qt4/widget.py
+++ b/pyface/ui/qt4/widget.py
@@ -72,6 +72,22 @@ class Widget(MWidget, HasTraits):
         if self.control is not None:
             self.control.setEnabled(enabled)
 
+    def focus(self):
+        """ Set the keyboard focus to this widget.
+        """
+        if self.control is not None:
+            self.setFocus()
+
+    def has_focus(self):
+        """ Does the widget currently have keyboard focus?
+
+        Returns
+        -------
+        focus_state : bool
+            Whether or not the widget has keyboard focus.
+        """
+        return self.hasFocus()
+
     def destroy(self):
         self._remove_event_listeners()
         if self.control is not None:

--- a/pyface/ui/wx/widget.py
+++ b/pyface/ui/wx/widget.py
@@ -71,7 +71,7 @@ class Widget(MWidget, HasTraits):
         """ Set the keyboard focus to this widget.
         """
         if self.control is not None:
-            self.SetFocus()
+            self.control.SetFocus()
 
     def has_focus(self):
         """ Does the widget currently have keyboard focus?
@@ -81,7 +81,10 @@ class Widget(MWidget, HasTraits):
         focus_state : bool
             Whether or not the widget has keyboard focus.
         """
-        return self.HasFocus()
+        return (
+            self.control is not None
+            and self.control.HasFocus()
+        )
 
     def destroy(self):
         if self.control is not None:

--- a/pyface/ui/wx/widget.py
+++ b/pyface/ui/wx/widget.py
@@ -67,6 +67,22 @@ class Widget(MWidget, HasTraits):
         if self.control is not None:
             self.control.Enable(enabled)
 
+    def focus(self):
+        """ Set the keyboard focus to this widget.
+        """
+        if self.control is not None:
+            self.SetFocus()
+
+    def has_focus(self):
+        """ Does the widget currently have keyboard focus?
+
+        Returns
+        -------
+        focus_state : bool
+            Whether or not the widget has keyboard focus.
+        """
+        return self.HasFocus()
+
     def destroy(self):
         if self.control is not None:
             self.control.Destroy()


### PR DESCRIPTION
This PR adds two methods to the base Widget class to set the keyboard focus and to check whether the widget currently has keyboard focus.

This is needed to make it easier to create toolkit-independent TraitsUI Editors that use Pyface widgets.

The tests are skipped on Linux, because there keyboard focus is global, and so a widget doesn't get focus unless the window also has focus/is active, which is hard to guarantee, and is disruptive to development as it prevents the tests from running in the background.

I will open an issue to track the testing of focus on linux.