### PR TITLE
Convert on_trait_change decorators to observe decorators

### DIFF
--- a/examples/application/python_editor/python_editor_task.py
+++ b/examples/application/python_editor/python_editor_task.py
@@ -54,7 +54,7 @@ from traits.api import (
     Property,
     Str,
     cached_property,
-    on_trait_change,
+    observe,
 )
 
 from python_browser_pane import PythonBrowserPane
@@ -333,15 +333,15 @@ class PythonEditorTask(Task):
 
     # Trait change handlers --------------------------------------------------
 
-    @on_trait_change("window:closing")
+    @observe("window:closing")
     def _prompt_on_close(self, event):
         """ Prompt the user to save when exiting.
         """
         close = self._prompt_for_save()
-        event.veto = not close
+        event.new.veto = not close
 
-    @on_trait_change("active_editor.name")
-    def _change_title(self):
+    @observe("active_editor.name")
+    def _change_title(self, event):
         """ Update the window title when the active editor changes.
         """
         if self.window.active_task == self:
@@ -350,8 +350,8 @@ class PythonEditorTask(Task):
             else:
                 self.window.title = self.name
 
-    @on_trait_change("active_editor.[line,column,selection_length]")
-    def _update_status(self):
+    @observe("active_editor.[line,column,selection_length]")
+    def _update_status(self, event):
         if self.active_editor is not None:
             editor = self.active_editor
             if editor.selection_length:

--- a/examples/tasks/advanced/example_task.py
+++ b/examples/tasks/advanced/example_task.py
@@ -21,7 +21,7 @@ from pyface.api import (
     OK,
     CANCEL,
 )
-from traits.api import on_trait_change, Property, Instance
+from traits.api import observe, Property, Instance
 
 
 from example_panes import PythonScriptBrowserPane
@@ -185,12 +185,12 @@ class ExampleTask(Task):
 
     # Trait change handlers ------------------------------------------------
 
-    @on_trait_change("window:closing")
+    @observe("window:closing")
     def _prompt_on_close(self, event):
         """ Prompt the user to save when exiting.
         """
         close = self._prompt_for_save()
-        event.veto = not close
+        event.new.veto = not close
 
     # Trait property getter/setters ----------------------------------------
 

--- a/examples/tasks/basic/example_task.py
+++ b/examples/tasks/basic/example_task.py
@@ -14,7 +14,7 @@ from pyface.api import (
     OK,
     CANCEL,
 )
-from traits.api import on_trait_change
+from traits.api import observe
 
 
 from example_panes import PythonEditorPane, PythonScriptBrowserPane
@@ -148,9 +148,9 @@ class ExampleTask(Task):
                     return self._prompt_for_save()
         return True
 
-    @on_trait_change("window:closing")
+    @observe("window:closing")
     def _prompt_on_close(self, event):
         """ Prompt the user to save when exiting.
         """
         if not self._prompt_for_save():
-            event.veto = True
+            event.new.veto = True

--- a/examples/tasks/basic/example_task.py
+++ b/examples/tasks/basic/example_task.py
@@ -152,5 +152,6 @@ class ExampleTask(Task):
     def _prompt_on_close(self, event):
         """ Prompt the user to save when exiting.
         """
+        window = event.new
         if not self._prompt_for_save():
-            event.new.veto = True
+            window.veto = True

--- a/pyface/action/action_item.py
+++ b/pyface/action/action_item.py
@@ -11,7 +11,7 @@
 """ An action manager item that represents an actual action. """
 
 
-from traits.api import Any, Instance, List, Property, Str, on_trait_change
+from traits.api import Any, Instance, List, Property, Str, observe
 
 
 from pyface.action.action import Action
@@ -72,11 +72,11 @@ class ActionItem(ActionManagerItem):
     def _visible_changed(self, trait_name, old, new):
         self.action.visible = new
 
-    @on_trait_change("_wrappers.control")
-    def _on_destroy(self, object, name, old, new):
+    @observe("_wrappers:items:control")
+    def _on_destroy(self, event):
         """ Handle the destruction of the wrapper. """
-        if name == "control" and new is None:
-            self._wrappers.remove(object)
+        if event.new is None:
+            self._wrappers.remove(event.object)
 
     # ------------------------------------------------------------------------
     # 'ActionItem' interface.

--- a/pyface/data_view/data_models/row_table_data_model.py
+++ b/pyface/data_view/data_models/row_table_data_model.py
@@ -14,7 +14,7 @@ case of non-hierarchical, row-oriented data.
 """
 from collections.abc import Sequence
 
-from traits.api import ComparisonMode, Instance, List, observe
+from traits.api import Instance, List, observe
 from traits.observation.api import trait
 
 from pyface.data_view.abstract_data_model import (
@@ -35,20 +35,13 @@ class RowTableDataModel(AbstractDataModel):
     """
 
     #: A sequence of objects to display as rows.
-    data = Instance(
-        Sequence,
-        comparison_mode=ComparisonMode.identity,
-        allow_none=False,
-    )
+    data = Instance(Sequence, allow_none=False)
 
     #: An object which describes how to map data for the row headers.
     row_header_data = Instance(AbstractDataAccessor, allow_none=False)
 
     #: An object which describes how to map data for each column.
-    column_data = List(
-        Instance(AbstractDataAccessor, allow_none=False),
-        comparison_mode=ComparisonMode.identity,
-    )
+    column_data = List(Instance(AbstractDataAccessor, allow_none=False))
 
     #: The index manager that helps convert toolkit indices to data view
     #: indices.

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 import logging
 
 from traits.api import (
-    Bool, ComparisonMode, Enum, HasStrictTraits, Instance, List, Property,
+    Bool, Enum, HasStrictTraits, Instance, List, Property,
     TraitError, Tuple, cached_property,
 )
 
@@ -53,10 +53,7 @@ class IDataViewWidget(IWidget):
     selection = List(Tuple)
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(
-        Instance(AbstractDataExporter),
-        comparison_mode=ComparisonMode.identity,
-    )
+    exporters = List(Instance(AbstractDataExporter))
 
 
 class MDataViewWidget(HasStrictTraits):
@@ -81,10 +78,7 @@ class MDataViewWidget(HasStrictTraits):
     selection = Property(depends_on='_selection[]')
 
     #: Exporters available for the DataViewWidget.
-    exporters = List(
-        Instance(AbstractDataExporter),
-        comparison_mode=ComparisonMode.identity,
-    )
+    exporters = List(Instance(AbstractDataExporter))
 
     # Private traits --------------------------------------------------------
 
@@ -93,7 +87,7 @@ class MDataViewWidget(HasStrictTraits):
 
     #: The selected indices in the view.  This should never be mutated, any
     #: changes should be by replacement of the entire list.
-    _selection = List(Tuple, comparison_mode=ComparisonMode.identity)
+    _selection = List(Tuple)
 
     # ------------------------------------------------------------------------
     # MDataViewWidget Interface

--- a/pyface/gui_application.py
+++ b/pyface/gui_application.py
@@ -25,7 +25,6 @@ import logging
 from traits.api import (
     Bool,
     Callable,
-    ComparisonMode,
     Instance,
     List,
     ReadOnly,
@@ -86,7 +85,7 @@ class GUIApplication(Application):
     active_window = Instance(IWindow)
 
     #: List of all open windows in the application
-    windows = List(Instance(IWindow), comparison_mode=ComparisonMode.identity)
+    windows = List(Instance(IWindow))
 
     #: The Pyface GUI instance for the application
     gui = ReadOnly

--- a/pyface/gui_application.py
+++ b/pyface/gui_application.py
@@ -284,8 +284,9 @@ class GUIApplication(Application):
     def _on_activate_window(self, event):
         """ Listener that tracks currently active window.
         """
-        if event.object in self.windows:
-            self.active_window = event.object
+        window = event.object
+        if window in self.windows:
+            self.active_window = window
 
     @observe("windows:items:deactivated")
     def _on_deactivate_window(self, event):
@@ -297,5 +298,6 @@ class GUIApplication(Application):
     def _on_window_closed(self, event):
         """ Listener that ensures window handles are released when closed.
         """
-        if event.object in self.windows:
-            self.windows.remove(event.object)
+        window = event.object
+        if window in self.windows:
+            self.windows.remove(window)

--- a/pyface/gui_application.py
+++ b/pyface/gui_application.py
@@ -25,13 +25,14 @@ import logging
 from traits.api import (
     Bool,
     Callable,
+    ComparisonMode,
     Instance,
     List,
     ReadOnly,
     Tuple,
     Undefined,
     Vetoable,
-    on_trait_change,
+    observe,
 )
 
 from .application import Application
@@ -85,7 +86,7 @@ class GUIApplication(Application):
     active_window = Instance(IWindow)
 
     #: List of all open windows in the application
-    windows = List(Instance(IWindow))
+    windows = List(Instance(IWindow), comparison_mode=ComparisonMode.identity)
 
     #: The Pyface GUI instance for the application
     gui = ReadOnly
@@ -280,22 +281,22 @@ class GUIApplication(Application):
 
     # Trait listeners --------------------------------------------------------
 
-    @on_trait_change("windows:activated")
-    def _on_activate_window(self, window, trait, old, new):
+    @observe("windows:items:activated")
+    def _on_activate_window(self, event):
         """ Listener that tracks currently active window.
         """
-        if window in self.windows:
-            self.active_window = window
+        if event.object in self.windows:
+            self.active_window = event.object
 
-    @on_trait_change("windows:deactivated")
-    def _on_deactivate_window(self, window, trait, old, new):
+    @observe("windows:items:deactivated")
+    def _on_deactivate_window(self, event):
         """ Listener that tracks currently active window.
         """
         self.active_window = None
 
-    @on_trait_change("windows:closed")
-    def _on_window_closed(self, window, trait, old, new):
+    @observe("windows:items:closed")
+    def _on_window_closed(self, event):
         """ Listener that ensures window handles are released when closed.
         """
-        if window in self.windows:
-            self.windows.remove(window)
+        if event.object in self.windows:
+            self.windows.remove(event.object)

--- a/pyface/tasks/action/dock_pane_toggle_group.py
+++ b/pyface/tasks/action/dock_pane_toggle_group.py
@@ -15,7 +15,7 @@ from traits.api import (
     cached_property,
     Instance,
     List,
-    on_trait_change,
+    observe,
     Property,
     Str,
 )
@@ -66,13 +66,13 @@ class DockPaneToggleAction(Action):
     def _get_tooltip(self):
         return "Toggles the visibility of the %s pane." % self.name
 
-    @on_trait_change("dock_pane.visible")
-    def _update_checked(self):
+    @observe("dock_pane.visible")
+    def _update_checked(self, event):
         if self.dock_pane:
             self.checked = self.dock_pane.visible
 
-    @on_trait_change("dock_pane.closable")
-    def _update_visible(self):
+    @observe("dock_pane.closable")
+    def _update_visible(self, event):
         if self.dock_pane:
             self.visible = self.dock_pane.closable
 
@@ -119,8 +119,8 @@ class DockPaneToggleGroup(Group):
 
     # Private interface ----------------------------------------------------
 
-    @on_trait_change("dock_panes[]")
-    def _dock_panes_updated(self):
+    @observe("dock_panes.items")
+    def _dock_panes_updated(self, event):
         """Recreate the group items when dock panes have been added/removed.
         """
 

--- a/pyface/tasks/action/task_toggle_group.py
+++ b/pyface/tasks/action/task_toggle_group.py
@@ -10,7 +10,7 @@
 
 
 from pyface.action.api import Action, ActionItem, Group
-from traits.api import Any, List, Instance, Property, Str, on_trait_change
+from traits.api import Any, List, Instance, Property, Str, observe
 
 
 from pyface.tasks.task import Task
@@ -65,8 +65,8 @@ class TaskToggleAction(Action):
     def _get_tooltip(self):
         return "Switch to the %s task." % self.name
 
-    @on_trait_change("task.window.active_task")
-    def _update_checked(self):
+    @observe("task.window.active_task")
+    def _update_checked(self, event):
         if self.task:
             window = self.task.window
             self.checked = (

--- a/pyface/tasks/action/task_window_toggle_group.py
+++ b/pyface/tasks/action/task_window_toggle_group.py
@@ -10,7 +10,7 @@
 
 
 from pyface.action.api import Action, ActionItem, Group
-from traits.api import Any, Instance, List, Property, Str, on_trait_change
+from traits.api import Any, Instance, List, Property, Str, observe
 
 
 class TaskWindowToggleAction(Action):
@@ -47,12 +47,12 @@ class TaskWindowToggleAction(Action):
             return self.window.title
         return ""
 
-    @on_trait_change("window:activated")
-    def _window_activated(self):
+    @observe("window:activated")
+    def _window_activated(self, event):
         self.checked = True
 
-    @on_trait_change("window:deactivated")
-    def _window_deactivated(self):
+    @observe("window:deactivated")
+    def _window_deactivated(self, event):
         self.checked = False
 
 

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -431,7 +431,7 @@ class TaskWindow(ApplicationWindow):
             self.status_bar_manager = state.status_bar_manager
             self.tool_bar_managers = state.tool_bar_managers
 
-    @observe("central_pane.has_focus, dock_panes:items:has_focus")
+    @observe("central_pane:has_focus, dock_panes:items:has_focus")
     def _focus_updated(self, event):
         if event.new:
             self.active_pane = event.object

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -23,7 +23,7 @@ from traits.api import (
     Property,
     Str,
     Vetoable,
-    on_trait_change,
+    observe,
 )
 
 
@@ -431,13 +431,13 @@ class TaskWindow(ApplicationWindow):
             self.status_bar_manager = state.status_bar_manager
             self.tool_bar_managers = state.tool_bar_managers
 
-    @on_trait_change("central_pane.has_focus, dock_panes.has_focus")
-    def _focus_updated(self, obj, name, old, new):
-        if name == "has_focus" and new:
-            self.active_pane = obj
+    @observe("central_pane.has_focus, dock_panes:items:has_focus")
+    def _focus_updated(self, event):
+        if event.new:
+            self.active_pane = event.object
 
-    @on_trait_change("_states[]")
-    def _states_updated(self):
+    @observe("_states.items")
+    def _states_updated(self, event):
         self.tasks = [state.task for state in self._states]
 
 

--- a/pyface/tasks/tasks_application.py
+++ b/pyface/tasks/tasks_application.py
@@ -23,7 +23,7 @@ from traits.api import (
     Property,
     Str,
     cached_property,
-    on_trait_change,
+    observe,
 )
 
 from pyface.gui_application import GUIApplication
@@ -172,15 +172,14 @@ class TasksApplication(GUIApplication):
 
     # Destruction utilities ---------------------------------------------------
 
-    @on_trait_change("windows:closed")
-    def _on_window_closed(self, window, trait, old, new):
+    @observe("windows:items:closed")
+    def _on_window_closed(self, event):
         """ Listener that ensures window handles are released when closed.
         """
+        window = event.object
         if getattr(window, "active_task", None) in self.tasks:
             self.tasks.remove(window.active_task)
-        super(TasksApplication, self)._on_window_closed(
-            window, trait, old, new
-        )
+        super(TasksApplication, self)._on_window_closed(event)
 
     # Trait initializers and property getters ---------------------------------
 

--- a/pyface/tests/test_gui_application.py
+++ b/pyface/tests/test_gui_application.py
@@ -14,7 +14,7 @@ from shutil import rmtree
 from tempfile import mkdtemp
 import unittest
 
-from traits.api import Bool, on_trait_change
+from traits.api import Bool, observe
 
 from ..application_window import ApplicationWindow
 from ..gui_application import GUIApplication
@@ -104,10 +104,10 @@ class TestingApp(GUIApplication):
         if self.exit_prepared_error:
             raise Exception("Exit preparation failed")
 
-    @on_trait_change("windows:opening")
+    @observe("windows:items:opening")
     def _on_activate_window(self, event):
         if self.veto_open_window:
-            event.veto = self.veto_open_window
+            event.new.veto = self.veto_open_window
 
 
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")

--- a/pyface/tests/test_gui_application.py
+++ b/pyface/tests/test_gui_application.py
@@ -107,7 +107,8 @@ class TestingApp(GUIApplication):
     @observe("windows:items:opening")
     def _on_activate_window(self, event):
         if self.veto_open_window:
-            event.new.veto = self.veto_open_window
+            window = event.new
+            window.veto = self.veto_open_window
 
 
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -24,7 +24,7 @@ from pyface.qt import QtGui
 
 from pyface.action.api import MenuBarManager, StatusBarManager
 from pyface.action.api import ToolBarManager
-from traits.api import Instance, List, on_trait_change, provides, Str
+from traits.api import Instance, List, observe, provides, Str
 
 
 from pyface.i_application_window import IApplicationWindow, MApplicationWindow
@@ -177,8 +177,8 @@ class ApplicationWindow(MApplicationWindow, Window):
                 old.destroy_status_bar()
             self._create_status_bar(self.control)
 
-    @on_trait_change("tool_bar_manager, tool_bar_managers")
-    def _update_tool_bar_managers(self):
+    @observe("tool_bar_manager, tool_bar_managers.items")
+    def _update_tool_bar_managers(self, event):
         if self.control is not None:
             # Remove the old toolbars.
             for child in self.control.children():

--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -208,11 +208,13 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
 
     @observe("editors:items:[dirty, name]")
     def _update_label(self, event):
-        event.object.control.parent().update_title()
+        editor = event.object
+        editor.control.parent().update_title()
 
     @observe("editors:items:tooltip")
     def _update_tooltip(self, event):
-        event.object.control.parent().update_tooltip()
+        editor = event.object
+        editor.control.parent().update_tooltip()
 
 
 # ----------------------------------------------------------------------------

--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -15,8 +15,7 @@ from pyface.qt import QtCore, QtGui
 
 
 from traits.api import (
-    Any, Callable, DelegatesTo, Instance, List, on_trait_change, provides,
-    Tuple
+    Any, Callable, DelegatesTo, Instance, List, observe, provides, Tuple
 )
 
 
@@ -207,13 +206,13 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
 
     # Trait change handlers ------------------------------------------------
 
-    @on_trait_change("editors:[dirty, name]")
-    def _update_label(self, editor, name, new):
-        editor.control.parent().update_title()
+    @observe("editors:items:[dirty, name]")
+    def _update_label(self, event):
+        event.object.control.parent().update_title()
 
-    @on_trait_change("editors:tooltip")
-    def _update_tooltip(self, editor, name, new):
-        editor.control.parent().update_tooltip()
+    @observe("editors:items:tooltip")
+    def _update_tooltip(self, event):
+        event.object.control.parent().update_tooltip()
 
 
 # ----------------------------------------------------------------------------

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 
 
 from pyface.tasks.i_dock_pane import IDockPane, MDockPane
-from traits.api import Bool, on_trait_change, Property, provides, Tuple
+from traits.api import Bool, observe, Property, provides, Tuple
 
 
 from pyface.qt import QtCore, QtGui
@@ -61,10 +61,10 @@ class DockPane(TaskPane, MDockPane):
         control.setObjectName(self.task.id + ":" + self.id)
 
         # Configure the dock widget according to the DockPane settings.
-        self._set_dock_features()
-        self._set_dock_title()
-        self._set_floating()
-        self._set_visible()
+        self._set_dock_features(None)
+        self._set_dock_title(None)
+        self._set_floating(None)
+        self._set_visible(None)
 
         # Connect signal handlers for updating DockPane traits.
         control.dockLocationChanged.connect(self._receive_dock_area)
@@ -138,8 +138,8 @@ class DockPane(TaskPane, MDockPane):
 
     # Trait change handlers ------------------------------------------------
 
-    @on_trait_change("dock_area")
-    def _set_dock_area(self):
+    @observe("dock_area")
+    def _set_dock_area(self, event):
         if self.control is not None and not self._receiving:
             # Only attempt to adjust the area if the task is active.
             main_window = self.task.window.control
@@ -150,8 +150,8 @@ class DockPane(TaskPane, MDockPane):
                     AREA_MAP[self.dock_area], self.control
                 )
 
-    @on_trait_change("closable,floatable,movable")
-    def _set_dock_features(self):
+    @observe("closable,floatable,movable")
+    def _set_dock_features(self, event):
         if self.control is not None:
             features = QtGui.QDockWidget.NoDockWidgetFeatures
             if self.closable:
@@ -162,18 +162,18 @@ class DockPane(TaskPane, MDockPane):
                 features |= QtGui.QDockWidget.DockWidgetMovable
             self.control.setFeatures(features)
 
-    @on_trait_change("name")
-    def _set_dock_title(self):
+    @observe("name")
+    def _set_dock_title(self, event):
         if self.control is not None:
             self.control.setWindowTitle(self.name)
 
-    @on_trait_change("floating")
-    def _set_floating(self):
+    @observe("floating")
+    def _set_floating(self, event):
         if self.control is not None and not self._receiving:
             self.control.setFloating(self.floating)
 
-    @on_trait_change("visible")
-    def _set_visible(self):
+    @observe("visible")
+    def _set_visible(self, event):
         if self.control is not None and not self._receiving:
             self.control.setVisible(self.visible)
 

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -139,7 +139,7 @@ class DockPane(TaskPane, MDockPane):
     # Trait change handlers ------------------------------------------------
 
     @observe("dock_area")
-    def _set_dock_area(self, _=None):
+    def _set_dock_area(self, event):
         if self.control is not None and not self._receiving:
             # Only attempt to adjust the area if the task is active.
             main_window = self.task.window.control
@@ -151,7 +151,7 @@ class DockPane(TaskPane, MDockPane):
                 )
 
     @observe("closable,floatable,movable")
-    def _set_dock_features(self, _=None):
+    def _set_dock_features(self, event):
         if self.control is not None:
             features = QtGui.QDockWidget.NoDockWidgetFeatures
             if self.closable:
@@ -163,17 +163,17 @@ class DockPane(TaskPane, MDockPane):
             self.control.setFeatures(features)
 
     @observe("name")
-    def _set_dock_title(self, _=None):
+    def _set_dock_title(self, event):
         if self.control is not None:
             self.control.setWindowTitle(self.name)
 
     @observe("floating")
-    def _set_floating(self, _=None):
+    def _set_floating(self, event):
         if self.control is not None and not self._receiving:
             self.control.setFloating(self.floating)
 
     @observe("visible")
-    def _set_visible(self, _=None):
+    def _set_visible(self, event):
         if self.control is not None and not self._receiving:
             self.control.setVisible(self.visible)
 

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -61,10 +61,10 @@ class DockPane(TaskPane, MDockPane):
         control.setObjectName(self.task.id + ":" + self.id)
 
         # Configure the dock widget according to the DockPane settings.
-        self._set_dock_features(None)
-        self._set_dock_title(None)
-        self._set_floating(None)
-        self._set_visible(None)
+        self._set_dock_features()
+        self._set_dock_title()
+        self._set_floating()
+        self._set_visible()
 
         # Connect signal handlers for updating DockPane traits.
         control.dockLocationChanged.connect(self._receive_dock_area)
@@ -139,7 +139,7 @@ class DockPane(TaskPane, MDockPane):
     # Trait change handlers ------------------------------------------------
 
     @observe("dock_area")
-    def _set_dock_area(self, event):
+    def _set_dock_area(self, _=None):
         if self.control is not None and not self._receiving:
             # Only attempt to adjust the area if the task is active.
             main_window = self.task.window.control
@@ -151,7 +151,7 @@ class DockPane(TaskPane, MDockPane):
                 )
 
     @observe("closable,floatable,movable")
-    def _set_dock_features(self, event):
+    def _set_dock_features(self, _=None):
         if self.control is not None:
             features = QtGui.QDockWidget.NoDockWidgetFeatures
             if self.closable:
@@ -163,17 +163,17 @@ class DockPane(TaskPane, MDockPane):
             self.control.setFeatures(features)
 
     @observe("name")
-    def _set_dock_title(self, event):
+    def _set_dock_title(self, _=None):
         if self.control is not None:
             self.control.setWindowTitle(self.name)
 
     @observe("floating")
-    def _set_floating(self, event):
+    def _set_floating(self, _=None):
         if self.control is not None and not self._receiving:
             self.control.setFloating(self.floating)
 
     @observe("visible")
-    def _set_visible(self, event):
+    def _set_visible(self, _=None):
         if self.control is not None and not self._receiving:
             self.control.setVisible(self.visible)
 

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -61,10 +61,10 @@ class DockPane(TaskPane, MDockPane):
         control.setObjectName(self.task.id + ":" + self.id)
 
         # Configure the dock widget according to the DockPane settings.
-        self._set_dock_features()
-        self._set_dock_title()
-        self._set_floating()
-        self._set_visible()
+        self._set_dock_features(event=None)
+        self._set_dock_title(event=None)
+        self._set_floating(event=None)
+        self._set_visible(event=None)
 
         # Connect signal handlers for updating DockPane traits.
         control.dockLocationChanged.connect(self._receive_dock_area)

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -129,7 +129,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         index = self.control.addTab(editor.control, self._get_label(editor))
         self.control.setTabToolTip(index, editor.tooltip)
         self.editors.append(editor)
-        self._update_tab_bar()
+        self._update_tab_bar(event=None)
 
         # The 'currentChanged' signal, used below, is not emitted when the first
         # editor is added.
@@ -143,7 +143,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         self.control.removeTab(self.control.indexOf(editor.control))
         editor.destroy()
         editor.editor_area = None
-        self._update_tab_bar()
+        self._update_tab_bar(event=None)
         if not self.editors:
             self.active_editor = None
 

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -207,7 +207,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             self.active_editor = self._get_editor_with_control(control)
 
     @observe("hide_tab_bar")
-    def _update_tab_bar(self, _=None):
+    def _update_tab_bar(self, event):
         if self.control is not None:
             visible = self.control.count() > 1 if self.hide_tab_bar else True
             self.control.tabBar().setVisible(visible)

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -12,7 +12,7 @@ import sys
 
 
 from pyface.tasks.i_editor_area_pane import IEditorAreaPane, MEditorAreaPane
-from traits.api import Any, Callable, List, on_trait_change, provides, Tuple
+from traits.api import Any, Callable, List, observe, provides, Tuple
 
 
 from pyface.qt import QtCore, QtGui
@@ -129,7 +129,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         index = self.control.addTab(editor.control, self._get_label(editor))
         self.control.setTabToolTip(index, editor.tooltip)
         self.editors.append(editor)
-        self._update_tab_bar()
+        self._update_tab_bar(None)
 
         # The 'currentChanged' signal, used below, is not emitted when the first
         # editor is added.
@@ -143,7 +143,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         self.control.removeTab(self.control.indexOf(editor.control))
         editor.destroy()
         editor.editor_area = None
-        self._update_tab_bar()
+        self._update_tab_bar(None)
         if not self.editors:
             self.active_editor = None
 
@@ -179,15 +179,15 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
 
     # Trait change handlers ------------------------------------------------
 
-    @on_trait_change("editors:[dirty, name]")
-    def _update_label(self, editor, name, new):
-        index = self.control.indexOf(editor.control)
-        self.control.setTabText(index, self._get_label(editor))
+    @observe("editors:items:[dirty, name]")
+    def _update_label(self, event):
+        index = self.control.indexOf(event.object.control)
+        self.control.setTabText(index, self._get_label(event.object))
 
-    @on_trait_change("editors:tooltip")
-    def _update_tooltip(self, editor, name, new):
-        index = self.control.indexOf(editor.control)
-        self.control.setTabToolTip(index, editor.tooltip)
+    @observe("editors:items:tooltip")
+    def _update_tooltip(self, event):
+        index = self.control.indexOf(event.object.control)
+        self.control.setTabToolTip(index, event.object.tooltip)
 
     # Signal handlers -----------------------------------------------------#
 
@@ -204,8 +204,8 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             control = self.control.widget(index)
             self.active_editor = self._get_editor_with_control(control)
 
-    @on_trait_change("hide_tab_bar")
-    def _update_tab_bar(self):
+    @observe("hide_tab_bar")
+    def _update_tab_bar(self, event):
         if self.control is not None:
             visible = self.control.count() > 1 if self.hide_tab_bar else True
             self.control.tabBar().setVisible(visible)

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -187,8 +187,9 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
 
     @observe("editors:items:tooltip")
     def _update_tooltip(self, event):
-        index = self.control.indexOf(event.object.control)
-        self.control.setTabToolTip(index, event.object.tooltip)
+        editor = event.object
+        index = self.control.indexOf(editor.control)
+        self.control.setTabToolTip(index, editor.tooltip)
 
     # Signal handlers -----------------------------------------------------#
 

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -129,7 +129,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         index = self.control.addTab(editor.control, self._get_label(editor))
         self.control.setTabToolTip(index, editor.tooltip)
         self.editors.append(editor)
-        self._update_tab_bar(None)
+        self._update_tab_bar()
 
         # The 'currentChanged' signal, used below, is not emitted when the first
         # editor is added.
@@ -143,7 +143,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         self.control.removeTab(self.control.indexOf(editor.control))
         editor.destroy()
         editor.editor_area = None
-        self._update_tab_bar(None)
+        self._update_tab_bar()
         if not self.editors:
             self.active_editor = None
 
@@ -205,7 +205,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             self.active_editor = self._get_editor_with_control(control)
 
     @observe("hide_tab_bar")
-    def _update_tab_bar(self, event):
+    def _update_tab_bar(self, _=None):
         if self.control is not None:
             visible = self.control.count() > 1 if self.hide_tab_bar else True
             self.control.tabBar().setVisible(visible)

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -20,7 +20,7 @@ from traits.api import (
     Dict,
     Instance,
     List,
-    on_trait_change,
+    observe,
     Property,
     provides,
     Str,
@@ -379,15 +379,15 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
 
     # Trait change handlers ------------------------------------------------
 
-    @on_trait_change("editors:[dirty, name]")
-    def _update_label(self, editor, name, new):
-        index = self.active_tabwidget.indexOf(editor.control)
-        self.active_tabwidget.setTabText(index, self._get_label(editor))
+    @observe("editors:items:[dirty, name]")
+    def _update_label(self, event):
+        index = self.active_tabwidget.indexOf(event.object.control)
+        self.active_tabwidget.setTabText(index, self._get_label(event.object))
 
-    @on_trait_change("editors:tooltip")
-    def _update_tooltip(self, editor, name, new):
-        index = self.active_tabwidget.indexOf(editor.control)
-        self.active_tabwidget.setTabToolTip(index, self._get_label(editor))
+    @observe("editors:items:tooltip")
+    def _update_tooltip(self, event):
+        index = self.active_tabwidget.indexOf(event.object.control)
+        self.active_tabwidget.setTabToolTip(index, self._get_label(event.object))
 
     # Signal handlers -----------------------------------------------------#
 

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -381,13 +381,15 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
 
     @observe("editors:items:[dirty, name]")
     def _update_label(self, event):
-        index = self.active_tabwidget.indexOf(event.object.control)
-        self.active_tabwidget.setTabText(index, self._get_label(event.object))
+        editor = event.object
+        index = self.active_tabwidget.indexOf(editor.control)
+        self.active_tabwidget.setTabText(index, self._get_label(editor))
 
     @observe("editors:items:tooltip")
     def _update_tooltip(self, event):
-        index = self.active_tabwidget.indexOf(event.object.control)
-        self.active_tabwidget.setTabToolTip(index, self._get_label(event.object))
+        editor = event.object
+        index = self.active_tabwidget.indexOf(editor.control)
+        self.active_tabwidget.setTabToolTip(index, self._get_label(editor))
 
     # Signal handlers -----------------------------------------------------#
 

--- a/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
@@ -26,11 +26,15 @@ class TestWorkbenchWindowLayout(unittest.TestCase):
 
         layout = WorkbenchWindowLayout(_qt4_editor_area=mock_split_tab_widget)
 
+        class DummyEvent:
+            def __init__(self, new):
+                self.new = new
+
         # This should not throw
-        layout._qt4_active_editor_changed(None, None)
+        layout._qt4_active_editor_changed(DummyEvent(new=None))
         self.assertEqual(mock_split_tab_widget.setTabTextColor.called, False)
 
         mock_active_editor = mock.Mock()
-        layout._qt4_active_editor_changed(None, mock_active_editor)
+        layout._qt4_active_editor_changed(mock_active_editor)
 
         self.assertEqual(mock_split_tab_widget.setTabTextColor.called, True)

--- a/pyface/ui/qt4/workbench/workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/workbench_window_layout.py
@@ -20,7 +20,7 @@ import logging
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Instance, on_trait_change
+from traits.api import Instance, observe
 
 
 from pyface.message_dialog import error
@@ -342,12 +342,12 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
                 editor.control, QtCore.Qt.red
             )
 
-    @on_trait_change("window:active_editor")
-    def _qt4_active_editor_changed(self, old, new):
+    @observe("window:active_editor")
+    def _qt4_active_editor_changed(self, event):
         """ Handle change of active editor """
         # Reset tab title to foreground color
-        if new is not None:
-            self._qt4_editor_area.setTabTextColor(new.control)
+        if event.new is not None:
+            self._qt4_editor_area.setTabTextColor(event.new.control)
 
     def _qt4_view_focus_changed(self, old, new):
         """ Handle the change of focus for a view. """

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -22,7 +22,7 @@ from pyface.wx.aui import aui, PyfaceAuiManager
 
 from pyface.action.api import MenuBarManager, StatusBarManager
 from pyface.action.api import ToolBarManager
-from traits.api import Instance, List, on_trait_change, provides, Str
+from traits.api import Instance, List, observe, provides, Str
 from pyface.i_application_window import IApplicationWindow
 from pyface.i_application_window import MApplicationWindow
 from pyface.image_resource import ImageResource
@@ -229,8 +229,8 @@ class ApplicationWindow(MApplicationWindow, Window):
                 old.remove_status_bar(self.control)
             self._create_status_bar(self.control)
 
-    @on_trait_change("tool_bar_manager, tool_bar_managers")
-    def _update_tool_bar_managers(self):
+    @observe("tool_bar_manager, tool_bar_managers.items")
+    def _update_tool_bar_managers(self, event):
         if self.control is not None:
             self._create_tool_bar(self.control)
 

--- a/pyface/ui/wx/tasks/dock_pane.py
+++ b/pyface/ui/wx/tasks/dock_pane.py
@@ -15,7 +15,7 @@ import logging
 from pyface.tasks.i_dock_pane import IDockPane, MDockPane
 from traits.api import (
     Bool,
-    on_trait_change,
+    observe,
     Property,
     provides,
     Tuple,
@@ -198,7 +198,7 @@ class DockPane(TaskPane, MDockPane):
             "info: dock_area=%s dir=%s" % (self.dock_area, info.dock_direction)
         )
 
-    @on_trait_change("dock_area")
+    @observe("dock_area")
     def _set_dock_area(self):
         logger.debug("trait change: dock_area")
         if self.control is not None:
@@ -213,8 +213,8 @@ class DockPane(TaskPane, MDockPane):
         info.CaptionVisible(self.caption_visible)
         info.Layer(self.dock_layer)
 
-    @on_trait_change("closable,floatable,movable,caption_visible,dock_layer")
-    def _set_dock_features(self):
+    @observe("closable,floatable,movable,caption_visible,dock_layer")
+    def _set_dock_features(self, event):
         if self.control is not None:
             info = self.get_pane_info()
             self.update_dock_features(info)
@@ -223,8 +223,8 @@ class DockPane(TaskPane, MDockPane):
     def update_dock_title(self, info):
         info.Caption(self.name)
 
-    @on_trait_change("name")
-    def _set_dock_title(self):
+    @observe("name")
+    def _set_dock_title(self, event):
         if self.control is not None:
             info = self.get_pane_info()
             self.update_dock_title(info)
@@ -238,8 +238,8 @@ class DockPane(TaskPane, MDockPane):
         else:
             info.Dock()
 
-    @on_trait_change("floating")
-    def _set_floating(self):
+    @observe("floating")
+    def _set_floating(self, event):
         if self.control is not None:
             info = self.get_pane_info()
             self.update_floating(info)
@@ -251,8 +251,8 @@ class DockPane(TaskPane, MDockPane):
         else:
             info.Hide()
 
-    @on_trait_change("visible")
-    def _set_visible(self):
+    @observe("visible")
+    def _set_visible(self, event):
         logger.debug(
             "_set_visible %s on pane=%s, control=%s"
             % (self.visible, self.pane_name, self.control)

--- a/pyface/ui/wx/tasks/editor_area_pane.py
+++ b/pyface/ui/wx/tasks/editor_area_pane.py
@@ -13,7 +13,7 @@ import logging
 
 
 from pyface.tasks.i_editor_area_pane import IEditorAreaPane, MEditorAreaPane
-from traits.api import on_trait_change, provides
+from traits.api import observe, provides
 
 
 import wx
@@ -93,7 +93,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         except AttributeError:
             pass
         self.editors.append(editor)
-        self._update_tab_bar()
+        self._update_tab_bar(None)
 
         # The EVT_AUINOTEBOOK_PAGE_CHANGED event is not sent when the first
         # editor is added.
@@ -109,7 +109,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         self.control.RemovePage(index)
         editor.destroy()
         editor.editor_area = None
-        self._update_tab_bar()
+        self._update_tab_bar(None)
         if not self.editors:
             self.active_editor = None
 
@@ -137,14 +137,14 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
 
     # Trait change handlers ------------------------------------------------
 
-    @on_trait_change("editors:[dirty, name]")
-    def _update_label(self, editor, name, new):
-        index = self.control.GetPageIndex(editor.control)
-        self.control.SetPageText(index, self._get_label(editor))
+    @observe("editors:items:[dirty, name]")
+    def _update_label(self, event):
+        index = self.control.GetPageIndex(event.object.control)
+        self.control.SetPageText(index, self._get_label(event.object))
 
-    @on_trait_change("editors:tooltip")
-    def _update_tooltip(self, editor, name, new):
-        self.control.SetPageToolTip(editor.control, editor.tooltip)
+    @observe("editors:items:tooltip")
+    def _update_tooltip(self, event):
+        self.control.SetPageToolTip(event.objecet.control, event.object.tooltip)
 
     # Signal handlers -----------------------------------------------------#
 
@@ -172,8 +172,8 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             control = self.control.GetPage(index)
             self.active_editor = self._get_editor_with_control(control)
 
-    @on_trait_change("hide_tab_bar")
-    def _update_tab_bar(self):
+    @observe("hide_tab_bar")
+    def _update_tab_bar(self, event):
         if self.control is not None:
             visible = (
                 self.control.GetPageCount() > 1 if self.hide_tab_bar else True

--- a/pyface/ui/wx/tasks/editor_area_pane.py
+++ b/pyface/ui/wx/tasks/editor_area_pane.py
@@ -139,12 +139,14 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
 
     @observe("editors:items:[dirty, name]")
     def _update_label(self, event):
-        index = self.control.GetPageIndex(event.object.control)
-        self.control.SetPageText(index, self._get_label(event.object))
+        editor = event.object
+        index = self.control.GetPageIndex(editor.control)
+        self.control.SetPageText(index, self._get_label(editor))
 
     @observe("editors:items:tooltip")
     def _update_tooltip(self, event):
-        self.control.SetPageToolTip(event.objecet.control, event.object.tooltip)
+        editor = event.object
+        self.control.SetPageToolTip(editor.control, editor.tooltip)
 
     # Signal handlers -----------------------------------------------------#
 

--- a/pyface/ui/wx/tasks/editor_area_pane.py
+++ b/pyface/ui/wx/tasks/editor_area_pane.py
@@ -175,7 +175,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             self.active_editor = self._get_editor_with_control(control)
 
     @observe("hide_tab_bar")
-    def _update_tab_bar(self, _=None):
+    def _update_tab_bar(self, event):
         if self.control is not None:
             visible = (
                 self.control.GetPageCount() > 1 if self.hide_tab_bar else True

--- a/pyface/ui/wx/tasks/editor_area_pane.py
+++ b/pyface/ui/wx/tasks/editor_area_pane.py
@@ -93,7 +93,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         except AttributeError:
             pass
         self.editors.append(editor)
-        self._update_tab_bar(None)
+        self._update_tab_bar()
 
         # The EVT_AUINOTEBOOK_PAGE_CHANGED event is not sent when the first
         # editor is added.
@@ -109,7 +109,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         self.control.RemovePage(index)
         editor.destroy()
         editor.editor_area = None
-        self._update_tab_bar(None)
+        self._update_tab_bar()
         if not self.editors:
             self.active_editor = None
 
@@ -173,7 +173,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             self.active_editor = self._get_editor_with_control(control)
 
     @observe("hide_tab_bar")
-    def _update_tab_bar(self, event):
+    def _update_tab_bar(self, _=None):
         if self.control is not None:
             visible = (
                 self.control.GetPageCount() > 1 if self.hide_tab_bar else True

--- a/pyface/ui/wx/tasks/editor_area_pane.py
+++ b/pyface/ui/wx/tasks/editor_area_pane.py
@@ -93,7 +93,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         except AttributeError:
             pass
         self.editors.append(editor)
-        self._update_tab_bar()
+        self._update_tab_bar(event=None)
 
         # The EVT_AUINOTEBOOK_PAGE_CHANGED event is not sent when the first
         # editor is added.
@@ -109,7 +109,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         self.control.RemovePage(index)
         editor.destroy()
         editor.editor_area = None
-        self._update_tab_bar()
+        self._update_tab_bar(event=None)
         if not self.editors:
             self.active_editor = None
 

--- a/pyface/workbench/action/perspective_menu_manager.py
+++ b/pyface/workbench/action/perspective_menu_manager.py
@@ -11,7 +11,7 @@
 
 
 from pyface.action.api import Group, MenuManager
-from traits.api import Instance, List, on_trait_change
+from traits.api import Instance, List, observe
 
 
 from .delete_user_perspective_action import DeleteUserPerspectiveAction
@@ -68,9 +68,8 @@ class PerspectiveMenuManager(MenuManager):
     # 'PerspectiveMenuManager' interface.
     # ------------------------------------------------------------------------
 
-    @on_trait_change("window.perspectives")
-    @on_trait_change("window.perspectives_items")
-    def rebuild(self):
+    @observe("window.perspectives.items")
+    def rebuild(self, event):
         """ Rebuild the menu.
 
         This is called when user perspectives have been added or removed.

--- a/pyface/workbench/action/set_active_perspective_action.py
+++ b/pyface/workbench/action/set_active_perspective_action.py
@@ -11,7 +11,7 @@
 
 
 from pyface.workbench.api import IPerspective
-from traits.api import Delegate, Instance, on_trait_change
+from traits.api import Delegate, Instance, observe
 
 
 from .workbench_action import WorkbenchAction
@@ -59,8 +59,8 @@ class SetActivePerspectiveAction(WorkbenchAction):
     # Private interface.
     # ------------------------------------------------------------------------
 
-    @on_trait_change("perspective,window.active_perspective")
-    def _refresh_checked(self):
+    @observe("perspective,window.active_perspective")
+    def _refresh_checked(self, event):
         """ Refresh the checked state of the action. """
 
         self.checked = (

--- a/pyface/workbench/action/user_perspective_action.py
+++ b/pyface/workbench/action/user_perspective_action.py
@@ -10,7 +10,7 @@
 """ The base class for user perspective actions. """
 
 
-from traits.api import on_trait_change
+from traits.api import observe
 
 
 from .workbench_action import WorkbenchAction
@@ -48,8 +48,8 @@ class UserPerspectiveAction(WorkbenchAction):
 
         return (id[:19] == "__user_perspective_") and (id[-2:] == "__")
 
-    @on_trait_change("window.active_perspective")
-    def _refresh_enabled(self):
+    @observe("window.active_perspective")
+    def _refresh_enabled(self, event):
         """ Refresh the enabled state of the action. """
 
         self.enabled = (

--- a/pyface/workbench/action/view_menu_manager.py
+++ b/pyface/workbench/action/view_menu_manager.py
@@ -15,7 +15,7 @@ import logging
 
 from pyface.action.api import Group, MenuManager
 from traits.api import Any, Bool, Instance, List, Str
-from traits.api import on_trait_change
+from traits.api import observe
 
 
 from .perspective_menu_manager import PerspectiveMenuManager
@@ -88,10 +88,7 @@ class ViewMenuManager(MenuManager):
     # 'ViewMenuManager' interface.
     # ------------------------------------------------------------------------
 
-    @on_trait_change(
-        "window.active_perspective,window.active_part,"
-        "window.views,window.views_items"
-    )
+    @observe("window.active_perspective,window.active_part,window.views.items")
     def refresh(self):
         """ Refreshes the checked state of the actions in the menu. """
 

--- a/pyface/workbench/action/view_menu_manager.py
+++ b/pyface/workbench/action/view_menu_manager.py
@@ -89,7 +89,7 @@ class ViewMenuManager(MenuManager):
     # ------------------------------------------------------------------------
 
     @observe("window.active_perspective,window.active_part,window.views.items")
-    def refresh(self):
+    def refresh(self, event):
         """ Refreshes the checked state of the actions in the menu. """
 
         logger.debug("refreshing view menu")

--- a/pyface/workbench/debug/debug_view.py
+++ b/pyface/workbench/debug/debug_view.py
@@ -11,7 +11,7 @@
 
 
 from pyface.workbench.api import View, WorkbenchWindow
-from traits.api import HasTraits, Instance, Str, on_trait_change
+from traits.api import HasTraits, Instance, Str, observe
 from traitsui.api import View as TraitsView
 
 
@@ -30,9 +30,7 @@ class DebugViewModel(HasTraits):
     # 'Model' interface.
     # ------------------------------------------------------------------------
 
-    @on_trait_change(
-        "window.active_editor", "window.active_part", "window.active_view"
-    )
+    @observe("window.active_editor,window.active_part,window.active_view")
     def refresh(self):
         """ Refresh the model. """
 

--- a/pyface/workbench/debug/debug_view.py
+++ b/pyface/workbench/debug/debug_view.py
@@ -31,7 +31,7 @@ class DebugViewModel(HasTraits):
     # ------------------------------------------------------------------------
 
     @observe("window.active_editor,window.active_part,window.active_view")
-    def refresh(self):
+    def refresh(self, event):
         """ Refresh the model. """
 
         self.active_editor = self._get_id(self.window.active_editor)

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -16,7 +16,7 @@ import logging
 from pyface.api import ApplicationWindow, GUI
 from traits.api import Callable, Constant, Delegate, Event, Instance
 from traits.api import List, Str, Tuple, Str, Vetoable, Undefined
-from traits.api import on_trait_change, provides
+from traits.api import observe, provides
 
 
 from .i_editor import IEditor
@@ -849,16 +849,15 @@ class WorkbenchWindow(ApplicationWindow):
 
     # Dynamic ----
 
-    @on_trait_change("layout.editor_closed")
-    def _on_editor_closed(self, editor):
+    @observe("layout:editor_closed")
+    def _on_editor_closed(self, event):
         """ Dynamic trait change handler. """
 
-        if editor is None or editor is Undefined:
+        if event.new is None or event.new is Undefined:
             return
-
-        index = self.editors.index(editor)
+        index = self.editors.index(event.new)
         del self.editors[index]
-        if editor is self.active_editor:
+        if event.new is self.active_editor:
             if len(self.editors) > 0:
                 index = min(index, len(self.editors) - 1)
                 # If the user closed the editor manually then this method is
@@ -873,31 +872,30 @@ class WorkbenchWindow(ApplicationWindow):
 
         return
 
-    @on_trait_change("editors.has_focus")
-    def _on_editor_has_focus_changed(self, obj, trait_name, old, new):
+    @observe("editors:items:has_focus")
+    def _on_editor_has_focus_changed(self, event):
         """ Dynamic trait change handler. """
 
-        if trait_name == "has_focus" and new:
-            self.active_editor = obj
+        if event.new:
+            self.active_editor = event.object
 
         return
 
-    @on_trait_change("views.has_focus")
-    def _has_focus_changed_for_view(self, obj, trait_name, old, new):
+    @observe("views:items:has_focus")
+    def _has_focus_changed_for_view(self, event):
         """ Dynamic trait change handler. """
 
-        if trait_name == "has_focus" and new:
-            self.active_view = obj
+        if event.new:
+            self.active_view = event.object
 
         return
 
-    @on_trait_change("views.visible")
-    def _visible_changed_for_view(self, obj, trait_name, old, new):
+    @observe("views:items:visible")
+    def _visible_changed_for_view(self, event):
         """ Dynamic trait change handler. """
 
-        if trait_name == "visible":
-            if not new:
-                if obj is self.active_view:
-                    self.active_view = None
+        if not event.new:
+            if event.object is self.active_view:
+                self.active_view = None
 
         return


### PR DESCRIPTION
part of #732 
also part of #637 

This PR incrementally (effectively 1 file per commit) replaces all uses of the `@on_trait_change` decorator with the equivalent form of `@observe`.

Additionally, it removes any explicit use of setting `comparison_mode` as that is no longer needed with traits 6.2

Since traits 6.2 eggs are not on edm yet, I suspect CI will fail(? or at least give the comparison mode warnings), but very soon that will no longer occur. Looks like we also still have CI running with traits6.0 so it does fail
Looks like travis is also having failures that seem to stem from changes made to `i_data_view_widget`.  Those changes were mostly to do with comparison_mode and I did not see them locally, so I'm suspecting they will be resolved with traits 6.2 (🤞 )