### PR TITLE
Stop running CI on traits 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2 wx"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt5 wx" TRAITS_REQUIRES="^=6.0"
+    - env: RUNTIME=3.6 TOOLKITS="pyqt5 wx" TRAITS_REQUIRES="^=6.1"
   fast_finish: true
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ env:
 matrix:
   include:
     - env: RUNTIME=3.6 TOOLKITS="pyqt pyqt5 pyside2 wx"
-    - env: RUNTIME=3.6 TOOLKITS="pyqt5 wx" TRAITS_REQUIRES="^=6.1"
   fast_finish: true
 
 cache:

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -69,12 +69,6 @@ def load_tests(loader, standard_tests, pattern):
     if additional_exclude is not None:
         exclusion_patterns.append(additional_exclude)
 
-    # Only data_view requires Traits 6.1.
-    # We will skip tests in data_view package in Traits 6.0 environment
-    # Remove this when Traits 6.0 is dropped for the entire code base.
-    if not is_traits_version_ge("6.1"):
-        exclusion_patterns.append(r"\.data_view\.")
-
     filtered_package_tests = TestSuite()
     for test_suite in package_tests:
         for exclusion_pattern in exclusion_patterns:

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
 __requires__ = [
     "importlib-metadata",
     "importlib-resources>=1.1.0",
-    "traits>=6.1"
+    "traits>=6.2"
 ]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -18,7 +18,11 @@ except ImportError:
     __version__ = "not-built"
 
 
-__requires__ = ["importlib-metadata", "importlib-resources>=1.1.0", "traits>=6"]
+__requires__ = [
+    "importlib-metadata",
+    "importlib-resources>=1.1.0",
+    "traits>=6.1"
+]
 __extras_require__ = {
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],


### PR DESCRIPTION
fixes #781 

This PR updates the travis.yml file to require traits 6.1+ not 6.0+.  It also removes a traits version check that prevented data_view test from being run for traits !=6.1.  Not we will want these tests to run on 6.2+ as well.