### PR TITLE
Import from traits apis

### DIFF
--- a/pyface/action/tests/test_action_item.py
+++ b/pyface/action/tests/test_action_item.py
@@ -11,7 +11,7 @@
 
 import unittest
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.image_cache import ImageCache
 from pyface.toolkit import toolkit_object

--- a/pyface/action/tests/test_action_manager.py
+++ b/pyface/action/tests/test_action_manager.py
@@ -11,7 +11,7 @@
 
 import unittest
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from ..action import Action
 from ..action_item import ActionItem

--- a/pyface/action/tests/test_group.py
+++ b/pyface/action/tests/test_group.py
@@ -11,7 +11,7 @@
 
 import unittest
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from ..action import Action
 from ..action_item import ActionItem

--- a/pyface/action/tests/test_gui_application_action.py
+++ b/pyface/action/tests/test_gui_application_action.py
@@ -11,7 +11,7 @@
 
 import unittest
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.gui_application import GUIApplication
 from ..gui_application_action import GUIApplicationAction

--- a/pyface/action/tests/test_listening_action.py
+++ b/pyface/action/tests/test_listening_action.py
@@ -12,7 +12,7 @@
 import unittest
 
 from traits.api import Any, Bool, HasTraits
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from ..listening_action import ListeningAction
 from ..action_event import ActionEvent

--- a/pyface/action/tests/test_traitsui_widget_action.py
+++ b/pyface/action/tests/test_traitsui_widget_action.py
@@ -12,7 +12,7 @@
 import unittest
 
 from traits.api import Enum, HasTraits
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.gui import GUI
 from pyface.toolkit import toolkit

--- a/pyface/application.py
+++ b/pyface/application.py
@@ -296,25 +296,25 @@ class Application(HasStrictTraits):
 
     def _id_default(self):
         """ Use the application's directory as the id """
-        from traits.etsconfig.etsconfig import ETSConfig
+        from traits.etsconfig.api import ETSConfig
 
         return ETSConfig._get_application_dirname()
 
     def _home_default(self):
         """ Default home comes from ETSConfig. """
-        from traits.etsconfig.etsconfig import ETSConfig
+        from traits.etsconfig.api import ETSConfig
 
         return os.path.join(ETSConfig.application_data, self.id)
 
     def _user_data_default(self):
         """ Default user_data comes from ETSConfig. """
-        from traits.etsconfig.etsconfig import ETSConfig
+        from traits.etsconfig.api import ETSConfig
 
         return ETSConfig.user_data
 
     def _company_default(self):
         """ Default company comes from ETSConfig. """
-        from traits.etsconfig.etsconfig import ETSConfig
+        from traits.etsconfig.api import ETSConfig
 
         return ETSConfig.company
 

--- a/pyface/data_view/data_models/tests/test_array_data_model.py
+++ b/pyface/data_view/data_models/tests/test_array_data_model.py
@@ -10,7 +10,7 @@
 
 from unittest import TestCase
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
 
 from pyface.data_view.data_view_errors import DataViewSetError

--- a/pyface/data_view/tests/test_abstract_value_type.py
+++ b/pyface/data_view/tests/test_abstract_value_type.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 from unittest.mock import Mock
 
 from traits.api import Str
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.color import Color
 from pyface.data_view.data_view_errors import DataViewSetError

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -13,7 +13,7 @@ import unittest
 
 from traits.api import TraitError
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.gui import GUI
 from pyface.toolkit import toolkit

--- a/pyface/data_view/value_types/tests/test_constant_value.py
+++ b/pyface/data_view/value_types/tests/test_constant_value.py
@@ -11,7 +11,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.color import Color
 from pyface.data_view.value_types.constant_value import ConstantValue

--- a/pyface/data_view/value_types/tests/test_editable_value.py
+++ b/pyface/data_view/value_types/tests/test_editable_value.py
@@ -11,7 +11,7 @@
 from unittest import TestCase
 from unittest.mock import Mock
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.data_view.data_view_errors import DataViewSetError
 from pyface.data_view.value_types.editable_value import EditableValue

--- a/pyface/fields/tests/field_mixin.py
+++ b/pyface/fields/tests/field_mixin.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.action.api import Action, MenuManager
 from pyface.gui import GUI

--- a/pyface/tasks/tests/test_task_window.py
+++ b/pyface/tasks/tests/test_task_window.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 import unittest
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 from pyface.tasks.api import Task
 from ..task_window import TaskWindow
 

--- a/pyface/tests/test_application.py
+++ b/pyface/tests/test_application.py
@@ -15,7 +15,7 @@ from tempfile import mkdtemp
 from unittest import TestCase
 
 from traits.api import Bool
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from ..application import ApplicationExit, Application
 

--- a/pyface/tests/test_beep.py
+++ b/pyface/tests/test_beep.py
@@ -11,7 +11,7 @@
 
 import unittest
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from ..beep import beep
 

--- a/pyface/tests/test_ui_traits.py
+++ b/pyface/tests/test_ui_traits.py
@@ -14,7 +14,7 @@ import unittest
 
 from traits.api import DefaultValue, HasTraits, TraitError
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from ..color import Color
 from ..i_image_resource import IImageResource

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -12,7 +12,7 @@
 import unittest
 
 from traits.api import Instance
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from ..application_window import ApplicationWindow
 from ..toolkit import toolkit_object

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -17,7 +17,7 @@ import unittest.mock as mock
 
 from pyface.qt.QtGui import QApplication
 from pyface.ui.qt4.gui import GUI
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 from traits.testing.unittest_tools import (
     _TraitsChangeCollector as TraitsChangeCollector,
 )

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -14,7 +14,7 @@ import os
 import unittest
 from unittest import mock
 
-from traits.testing.unittest_tools import UnittestTools
+from traits.testing.api import UnittestTools
 
 from pyface.workbench.perspective import Perspective
 from pyface.workbench.api import Workbench


### PR DESCRIPTION
With the release of traits 6.2 a section was added to the documentation explicitly requesting users to import from the `.api` modules in traits. See PR https://github.com/enthought/traits/pull/1387

Motivated by this I decided to run through pyface looking for any non api imports from traits.  This PR updates a couple (namely it always imports `UnittestTools` from the `traits.testing.api` and `ETSConfig` from `traitst.etsconfig.api`.

However, I ran into many more examples of traits imports of things not exposed in traits apis.  It is known that this is done but I figured it couldn't hurt to compile a list.  It may be fine to leave them as is, some of these we may want to expose in some traits api, some of them we may not want to be pulling from traits (traits isn't meant to be a storage place for miscellaneous utilities).  This list probably warrants being in a separate or multiple separate issues which I can gladly open eventually.  For now these are the imports I found:

From `traits.trait_base` there are imports of:
 * `xgetattr`
 * `xsetattr`
 * `get_resource_path`
 * `user_name_for`
 * `traits_home`

Additionally we import optional dependencies from `traits.testing.optional_dependencies`

From `traits.trait_list_object` we import `TraitsList` but this is a different `TraitList` from the one exposed in `traits.api`

 from `traits.version` we import `version`

from `traits.util.resource` we import `get_path`

form `traitst.trait_notifiers` we import `set_ui_handler` and `ui_handler`

from `traitss.util.clean_strings` we import `python_name`

and from `traits.util.camel_case` we import `camel_case_to_words`

 