### PR TITLE
Skip test if wx is not around

### DIFF
--- a/pyface/ui/wx/data_view/tests/test_data_wrapper.py
+++ b/pyface/ui/wx/data_view/tests/test_data_wrapper.py
@@ -8,14 +8,18 @@
 #
 # Thanks for using Enthought open source!
 
-from unittest import TestCase
+import unittest
 
-import wx
+try:
+    import wx
+    from pyface.ui.wx.data_view.data_wrapper import DataWrapper
+except ImportError:
+    wx_available = False
+else:
+    wx_available = True
 
-from pyface.ui.wx.data_view.data_wrapper import DataWrapper
-
-
-class TestDataWrapper(TestCase):
+@unittest.skipUnless(wx_available, "Test requires wx")
+class TestDataWrapper(unittest.TestCase):
 
     def test_get_mimedata(self):
         toolkit_data = wx.DataObjectComposite()

--- a/pyface/ui/wx/data_view/tests/test_data_wrapper.py
+++ b/pyface/ui/wx/data_view/tests/test_data_wrapper.py
@@ -18,6 +18,7 @@ else:
     from pyface.ui.wx.data_view.data_wrapper import DataWrapper
     wx_available = True
 
+
 @unittest.skipUnless(wx_available, "Test requires wx")
 class TestDataWrapper(unittest.TestCase):
 

--- a/pyface/ui/wx/data_view/tests/test_data_wrapper.py
+++ b/pyface/ui/wx/data_view/tests/test_data_wrapper.py
@@ -12,10 +12,10 @@ import unittest
 
 try:
     import wx
-    from pyface.ui.wx.data_view.data_wrapper import DataWrapper
 except ImportError:
     wx_available = False
 else:
+    from pyface.ui.wx.data_view.data_wrapper import DataWrapper
     wx_available = True
 
 @unittest.skipUnless(wx_available, "Test requires wx")


### PR DESCRIPTION
Previously running:
```
python etstool.py install 
edm shell -e pyface-test-3.6-pyqt
python -m unittest
```
I was seeing the following test failure:
```
======================================================================
ERROR: pyface.ui.wx.data_view.tests.test_data_wrapper (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: pyface.ui.wx.data_view.tests.test_data_wrapper
Traceback (most recent call last):
  File "/Users/aayres/.edm/envs/pyface-test-3.6-pyqt/lib/python3.6/unittest/loader.py", line 428, in _find_test_path
    module = self._get_module_from_name(name)
  File "/Users/aayres/.edm/envs/pyface-test-3.6-pyqt/lib/python3.6/unittest/loader.py", line 369, in _get_module_from_name
    __import__(name)
  File "/Users/aayres/Desktop/pyface/pyface/ui/wx/data_view/tests/test_data_wrapper.py", line 21, in <module>
    @unittest.skipUnless(wx_available, "Test requires wx")
NameError: name 'unittest' is not defined
```

This PR simply updates that test file to skip the test if `wx` is not available in the environment.

Looking into this also made me realize that there is no consistent way this type of thing is done across the codebase.  For example:
https://github.com/enthought/pyface/blob/8cc824ec59f68ae6ebe6a8dcfea006d62a66811f/pyface/ui/wx/grid/tests/test_simple_grid_model.py#L12-L20
https://github.com/enthought/pyface/blob/8cc824ec59f68ae6ebe6a8dcfea006d62a66811f/pyface/action/tests/test_traitsui_widget_action.py#L25
https://github.com/enthought/pyface/blob/8cc824ec59f68ae6ebe6a8dcfea006d62a66811f/pyface/tests/test_api.py#L17-L18
https://github.com/enthought/pyface/blob/8cc824ec59f68ae6ebe6a8dcfea006d62a66811f/pyface/tasks/tests/test_dock_pane_toggle_group.py#L26

sometimes trying the import, something working with `toolkit` from `pyface.toolkit` sometimes through `ETSConfig.toolkit`, etc.  It is pretty inconsequential (they all do what we want), but it would be good to pin down a consistent way to skip tests based on toolkit.  