### PR TITLE
Convert dynamic on_trait_change to observe part 2

### DIFF
--- a/docs/source/timer.rst
+++ b/docs/source/timer.rst
@@ -165,16 +165,21 @@ EventTimer
 Another common use case is that you want a Traits Event to be fired
 periodically or at some future time.  This permits many possible listeners
 to be called from the same timer, and have them be turned on and turned off
-dynamically, if desired.  The :py:class:`~pyface.timer.timer.EventTimer`
-provides this functionality via its
-:py:class:`~pyface.timer.timer.EventTimer.timeout` event trait.
+dynamically, if desired, via
+`Traits' observe <https://docs.enthought.com/traits/traits_user_manual/notification.html>`_
+(note that observe listeners are required to take a single event argument).
+The :py:class:`~pyface.timer.timer.EventTimer` provides this functionality via
+its :py:class:`~pyface.timer.timer.EventTimer.timeout` event trait.
 
 .. code-block:: python
 
     from pyface.timer.api import EventTimer
 
+    def print_time(event):
+        print("The time is {}".format(datetime.datetime.now()))
+
     timer = EventTimer(interval=0.5, expire=60)
-    timer.on_trait_change(print_time, 'timeout')
+    timer.observe(print_time, 'timeout')
 
     timer.start()
 

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -17,6 +17,7 @@ import logging
 
 from pyface.action.action import Action
 from traits.api import Any, Str
+from traits.observation.api import trait
 
 # Logging.
 logger = logging.getLogger(__name__)
@@ -58,11 +59,15 @@ class ListeningAction(Action):
         if self.object:
             if self.enabled_name:
                 self.object.observe(
-                    self._enabled_update, self.enabled_name, remove=True
+                    self._enabled_update,
+                    trait(self.enabled_name, optional=True),
+                    remove=True
                 )
             if self.visible_name:
                 self.object.observe(
-                    self._visible_update, self.visible_name, remove=True
+                    self._visible_update,
+                    trait(self.visible_name, optional=True),
+                    remove=True
                 )
 
     def perform(self, event=None):
@@ -123,11 +128,10 @@ class ListeningAction(Action):
         for kind in ("enabled", "visible"):
             method = getattr(self, "_%s_update" % kind)
             name = getattr(self, "%s_name" % kind)
-            if name:
-                if old:
-                    old.observe(method, name, remove=True)
-                if new:
-                    new.observe(method, name)
+            if old:
+                old.observe(method, trait(name, optional=True), remove=True)
+            if new:
+                new.observe(method, trait(name, optional=True))
             method(event=None)
 
     def _enabled_update(self, event):

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -110,7 +110,7 @@ class ListeningAction(Action):
                 obj.observe(self._enabled_update, old, remove=True)
             if new:
                 obj.observe(self._enabled_update, new)
-        self._enabled_update(event=None)
+        self._enabled_update()
 
     def _visible_name_changed(self, old, new):
         obj = self.object
@@ -119,7 +119,7 @@ class ListeningAction(Action):
                 obj.observe(self._visible_update, old, remove=True)
             if new:
                 obj.observe(self._visible_update, new)
-        self._visible_update(event=None)
+        self._visible_update()
 
     def _object_changed(self, old, new):
         for kind in ("enabled", "visible"):
@@ -129,9 +129,9 @@ class ListeningAction(Action):
                 old.observe(method, trait(name, optional=True), remove=True)
             if new:
                 new.observe(method, trait(name, optional=True))
-            method(event=None)
+            method()
 
-    def _enabled_update(self, event):
+    def _enabled_update(self, event=None):
         if self.enabled_name:
             if self.object:
                 self.enabled = bool(
@@ -142,7 +142,7 @@ class ListeningAction(Action):
         else:
             self.enabled = bool(self.object)
 
-    def _visible_update(self, event):
+    def _visible_update(self, event=None):
         if self.visible_name:
             if self.object:
                 self.visible = bool(

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -56,18 +56,16 @@ class ListeningAction(Action):
         """
 
         if self.object:
-            if self.enabled_name:
-                self.object.observe(
-                    self._enabled_update,
-                    trait(self.enabled_name, optional=True),
-                    remove=True
-                )
-            if self.visible_name:
-                self.object.observe(
-                    self._visible_update,
-                    trait(self.visible_name, optional=True),
-                    remove=True
-                )
+            self.object.observe(
+                self._enabled_update,
+                trait(self.enabled_name, optional=True),
+                remove=True
+            )
+            self.object.observe(
+                self._visible_update,
+                trait(self.visible_name, optional=True),
+                remove=True
+            )
 
     def perform(self, event=None):
         """ Call the appropriate function.

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -54,7 +54,6 @@ class ListeningAction(Action):
 
         Removes all the task listeners.
         """
-        print(self.enabled_name)
 
         if self.object:
             if self.enabled_name:

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -53,14 +53,17 @@ class ListeningAction(Action):
 
         Removes all the task listeners.
         """
+        print(self.enabled_name)
 
         if self.object:
-            self.object.on_trait_change(
-                self._enabled_update, self.enabled_name, remove=True
-            )
-            self.object.on_trait_change(
-                self._visible_update, self.visible_name, remove=True
-            )
+            if self.enabled_name:
+                self.object.observe(
+                    self._enabled_update, self.enabled_name, remove=True
+                )
+            if self.visible_name:
+                self.object.observe(
+                    self._visible_update, self.visible_name, remove=True
+                )
 
     def perform(self, event=None):
         """ Call the appropriate function.
@@ -102,19 +105,19 @@ class ListeningAction(Action):
         obj = self.object
         if obj is not None:
             if old:
-                obj.on_trait_change(self._enabled_update, old, remove=True)
+                obj.observe(self._enabled_update, old, remove=True)
             if new:
-                obj.on_trait_change(self._enabled_update, new)
-        self._enabled_update()
+                obj.observe(self._enabled_update, new)
+        self._enabled_update(event=None)
 
     def _visible_name_changed(self, old, new):
         obj = self.object
         if obj is not None:
             if old:
-                obj.on_trait_change(self._visible_update, old, remove=True)
+                obj.observe(self._visible_update, old, remove=True)
             if new:
-                obj.on_trait_change(self._visible_update, new)
-        self._visible_update()
+                obj.observe(self._visible_update, new)
+        self._visible_update(event=None)
 
     def _object_changed(self, old, new):
         for kind in ("enabled", "visible"):
@@ -122,12 +125,12 @@ class ListeningAction(Action):
             name = getattr(self, "%s_name" % kind)
             if name:
                 if old:
-                    old.on_trait_change(method, name, remove=True)
+                    old.observe(method, name, remove=True)
                 if new:
-                    new.on_trait_change(method, name)
-            method()
+                    new.observe(method, name)
+            method(event=None)
 
-    def _enabled_update(self):
+    def _enabled_update(self, event):
         if self.enabled_name:
             if self.object:
                 self.enabled = bool(
@@ -138,7 +141,7 @@ class ListeningAction(Action):
         else:
             self.enabled = bool(self.object)
 
-    def _visible_update(self):
+    def _visible_update(self, event):
         if self.visible_name:
             if self.object:
                 self.visible = bool(

--- a/pyface/fields/i_combo_field.py
+++ b/pyface/fields/i_combo_field.py
@@ -69,8 +69,8 @@ class MComboField(HasTraits):
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
         super(MComboField, self)._add_event_listeners()
-        self.on_trait_change(
-            self._values_updated, "values[],formatter", dispatch="ui"
+        self.observe(
+            self._values_updated, "values.items,formatter", dispatch="ui"
         )
         if self.control is not None:
             self._observe_control_value()
@@ -79,9 +79,9 @@ class MComboField(HasTraits):
         """ Remove toolkit-specific bindings for events """
         if self.control is not None:
             self._observe_control_value(remove=True)
-        self.on_trait_change(
+        self.observe(
             self._values_updated,
-            "values[],formatter",
+            "values.items,formatter",
             dispatch="ui",
             remove=True,
         )
@@ -99,6 +99,6 @@ class MComboField(HasTraits):
 
     # Trait change handlers --------------------------------------------------
 
-    def _values_updated(self):
+    def _values_updated(self, event):
         if self.control is not None:
             self._set_control_values(self.values)

--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -58,9 +58,9 @@ class MField(HasTraits):
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
         super(MField, self)._add_event_listeners()
-        self.on_trait_change(self._value_updated, "value", dispatch="ui")
-        self.on_trait_change(self._tooltip_updated, "tooltip", dispatch="ui")
-        self.on_trait_change(
+        self.observe(self._value_updated, "value", dispatch="ui")
+        self.observe(self._tooltip_updated, "tooltip", dispatch="ui")
+        self.observe(
             self._context_menu_updated, "context_menu", dispatch="ui"
         )
         if self.control is not None and self.context_menu is not None:
@@ -70,13 +70,13 @@ class MField(HasTraits):
         """ Remove toolkit-specific bindings for events """
         if self.control is not None and self.context_menu is not None:
             self._observe_control_context_menu(remove=True)
-        self.on_trait_change(
+        self.observe(
             self._value_updated, "value", dispatch="ui", remove=True
         )
-        self.on_trait_change(
+        self.observe(
             self._tooltip_updated, "tooltip", dispatch="ui", remove=True
         )
-        self.on_trait_change(
+        self.observe(
             self._context_menu_updated,
             "context_menu",
             dispatch="ui",
@@ -160,17 +160,20 @@ class MField(HasTraits):
 
     # Trait change handlers -------------------------------------------------
 
-    def _value_updated(self, value):
+    def _value_updated(self, event):
+        value = event.new
         if self.control is not None:
             self._set_control_value(value)
 
-    def _tooltip_updated(self, tooltip):
+    def _tooltip_updated(self, event):
+        tooltip = event.new
         if self.control is not None:
             self._set_control_tooltip(tooltip)
 
-    def _context_menu_updated(self, old, new):
+    def _context_menu_updated(self, event):
+        
         if self.control is not None:
-            if new is None:
+            if event.new is None:
                 self._observe_control_context_menu(remove=True)
-            if old is None:
+            if event.old is None:
                 self._observe_control_context_menu()

--- a/pyface/fields/i_spin_field.py
+++ b/pyface/fields/i_spin_field.py
@@ -73,7 +73,7 @@ class MSpinField(HasTraits):
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
         super(MSpinField, self)._add_event_listeners()
-        self.on_trait_change(self._bounds_updated, "bounds", dispatch="ui")
+        self.observe(self._bounds_updated, "bounds", dispatch="ui")
         if self.control is not None:
             self._observe_control_value()
 
@@ -81,7 +81,7 @@ class MSpinField(HasTraits):
         """ Remove toolkit-specific bindings for events """
         if self.control is not None:
             self._observe_control_value(remove=True)
-        self.on_trait_change(
+        self.observe(
             self._bounds_updated, "bounds", dispatch="ui", remove=True
         )
         super(MSpinField, self)._remove_event_listeners()
@@ -127,6 +127,6 @@ class MSpinField(HasTraits):
 
     # Trait change handlers --------------------------------------------------
 
-    def _bounds_updated(self):
+    def _bounds_updated(self, event):
         if self.control is not None:
             self._set_control_bounds(self.bounds)

--- a/pyface/fields/i_text_field.py
+++ b/pyface/fields/i_text_field.py
@@ -68,16 +68,10 @@ class MTextField(HasTraits):
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
         super(MTextField, self)._add_event_listeners()
-        self.on_trait_change(
-            self._update_text_updated, "update_text", dispatch="ui"
-        )
-        self.on_trait_change(
-            self._placeholder_updated, "placeholder", dispatch="ui"
-        )
-        self.on_trait_change(self._echo_updated, "echo", dispatch="ui")
-        self.on_trait_change(
-            self._read_only_updated, "read_only", dispatch="ui"
-        )
+        self.observe(self._update_text_updated, "update_text", dispatch="ui")
+        self.observe(self._placeholder_updated, "placeholder", dispatch="ui")
+        self.observe(self._echo_updated, "echo", dispatch="ui")
+        self.observe(self._read_only_updated, "read_only", dispatch="ui")
         if self.control is not None:
             if self.update_text == "editing_finished":
                 self._observe_control_editing_finished()
@@ -91,22 +85,22 @@ class MTextField(HasTraits):
                 self._observe_control_editing_finished(remove=True)
             else:
                 self._observe_control_value(remove=True)
-        self.on_trait_change(
+        self.observe(
             self._update_text_updated,
             "update_text",
             dispatch="ui",
             remove=True,
         )
-        self.on_trait_change(
+        self.observe(
             self._placeholder_updated,
             "placeholder",
             dispatch="ui",
             remove=True,
         )
-        self.on_trait_change(
+        self.observe(
             self._echo_updated, "echo", dispatch="ui", remove=True
         )
-        self.on_trait_change(
+        self.observe(
             self._read_only_updated, "read_only", dispatch="ui", remove=True
         )
         super(MTextField, self)._remove_event_listeners()
@@ -148,22 +142,22 @@ class MTextField(HasTraits):
 
     # Trait change handlers --------------------------------------------------
 
-    def _placeholder_updated(self):
+    def _placeholder_updated(self, event):
         if self.control is not None:
             self._set_control_placeholder(self.placeholder)
 
-    def _echo_updated(self):
+    def _echo_updated(self, event):
         if self.control is not None:
             self._set_control_echo(self.echo)
 
-    def _read_only_updated(self):
+    def _read_only_updated(self, event):
         if self.control is not None:
             self._set_control_read_only(self.read_only)
 
-    def _update_text_updated(self, new):
+    def _update_text_updated(self, event):
         """ Change how we listen to for updates to text value. """
         if self.control is not None:
-            if new == "editing_finished":
+            if event.new == "editing_finished":
                 self._observe_control_value(remove=True)
                 self._observe_control_editing_finished()
             else:

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -582,3 +582,8 @@ class _PaletteTool(HasTraits):
         action.perform(action_event)
 
         return
+
+    def dispose(self):
+        action = self.item.action
+        action.observe(self._on_action_enabled_changed, "enabled", remove=True)
+        action.observe(self._on_action_checked_changed, "checked", remove=True)

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -218,7 +218,6 @@ class _MenuItem(HasTraits):
 
     def _on_action_enabled_changed(self, event):
         """ Called when the enabled trait is changed on an action. """
-        print('HEYYYYYYYYYYYYYYYYY')
         action = event.object
         if self.control is not None:
             self.control.setEnabled(action.enabled)

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -119,15 +119,13 @@ class _MenuItem(HasTraits):
 
         # Listen for trait changes on the action (so that we can update its
         # enabled/disabled/checked state etc).
-        action.on_trait_change(self._on_action_enabled_changed, "enabled")
-        action.on_trait_change(self._on_action_visible_changed, "visible")
-        action.on_trait_change(self._on_action_checked_changed, "checked")
-        action.on_trait_change(self._on_action_name_changed, "name")
-        action.on_trait_change(
-            self._on_action_accelerator_changed, "accelerator"
-        )
-        action.on_trait_change(self._on_action_image_changed, "image")
-        action.on_trait_change(self._on_action_tooltip_changed, "tooltip")
+        action.observe(self._on_action_enabled_changed, "enabled")
+        action.observe(self._on_action_visible_changed, "visible")
+        action.observe(self._on_action_checked_changed, "checked")
+        action.observe(self._on_action_name_changed, "name")
+        action.observe(self._on_action_accelerator_changed, "accelerator")
+        action.observe(self._on_action_image_changed, "image")
+        action.observe(self._on_action_tooltip_changed, "tooltip")
 
         # Detect if the control is destroyed.
         self.control.destroyed.connect(self._qt4_on_destroyed)
@@ -138,27 +136,15 @@ class _MenuItem(HasTraits):
 
     def dispose(self):
         action = self.item.action
-        action.on_trait_change(
-            self._on_action_enabled_changed, "enabled", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_visible_changed, "visible", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_checked_changed, "checked", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_name_changed, "name", remove=True
-        )
-        action.on_trait_change(
+        action.observe(self._on_action_enabled_changed, "enabled", remove=True)
+        action.observe(self._on_action_visible_changed, "visible", remove=True)
+        action.observe(self._on_action_checked_changed, "checked", remove=True)
+        action.observe(self._on_action_name_changed, "name", remove=True)
+        action.observe(
             self._on_action_accelerator_changed, "accelerator", remove=True
         )
-        action.on_trait_change(
-            self._on_action_image_changed, "image", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_tooltip_changed, "tooltip", remove=True
-        )
+        action.observe(self._on_action_image_changed, "image", remove=True)
+        action.observe(self._on_action_tooltip_changed, "tooltip", remove=True)
 
     # ------------------------------------------------------------------------
     # Private interface.
@@ -230,38 +216,46 @@ class _MenuItem(HasTraits):
         if self.control is not None:
             self.control.setChecked(self.checked)
 
-    def _on_action_enabled_changed(self, action, trait_name, old, new):
+    def _on_action_enabled_changed(self, event):
         """ Called when the enabled trait is changed on an action. """
+        print('HEYYYYYYYYYYYYYYYYY')
+        action = event.object
         if self.control is not None:
             self.control.setEnabled(action.enabled)
 
-    def _on_action_visible_changed(self, action, trait_name, old, new):
+    def _on_action_visible_changed(self, event):
         """ Called when the visible trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setVisible(action.visible)
 
-    def _on_action_checked_changed(self, action, trait_name, old, new):
+    def _on_action_checked_changed(self, event):
         """ Called when the checked trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setChecked(action.checked)
 
-    def _on_action_name_changed(self, action, trait_name, old, new):
+    def _on_action_name_changed(self, event):
         """ Called when the name trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setText(action.name)
 
-    def _on_action_accelerator_changed(self, action, trait_name, old, new):
+    def _on_action_accelerator_changed(self, event):
         """ Called when the accelerator trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setShortcut(action.accelerator)
 
-    def _on_action_image_changed(self, action, trait_name, old, new):
+    def _on_action_image_changed(self, event):
         """ Called when the accelerator trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setIcon(action.image.create_icon())
 
-    def _on_action_tooltip_changed(self, action, trait_name, old, new):
+    def _on_action_tooltip_changed(self, event):
         """ Called when the accelerator trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setToolTip(action.tooltip)
 
@@ -346,15 +340,13 @@ class _Tool(HasTraits):
 
         # Listen for trait changes on the action (so that we can update its
         # enabled/disabled/checked state etc).
-        action.on_trait_change(self._on_action_enabled_changed, "enabled")
-        action.on_trait_change(self._on_action_visible_changed, "visible")
-        action.on_trait_change(self._on_action_checked_changed, "checked")
-        action.on_trait_change(self._on_action_name_changed, "name")
-        action.on_trait_change(
-            self._on_action_accelerator_changed, "accelerator"
-        )
-        action.on_trait_change(self._on_action_image_changed, "image")
-        action.on_trait_change(self._on_action_tooltip_changed, "tooltip")
+        action.observe(self._on_action_enabled_changed, "enabled")
+        action.observe(self._on_action_visible_changed, "visible")
+        action.observe(self._on_action_checked_changed, "checked")
+        action.observe(self._on_action_name_changed, "name")
+        action.observe(self._on_action_accelerator_changed, "accelerator")
+        action.observe(self._on_action_image_changed, "image")
+        action.observe(self._on_action_tooltip_changed, "tooltip")
 
         # Detect if the control is destroyed.
         self.control.destroyed.connect(self._qt4_on_destroyed)
@@ -365,27 +357,15 @@ class _Tool(HasTraits):
 
     def dispose(self):
         action = self.item.action
-        action.on_trait_change(
-            self._on_action_enabled_changed, "enabled", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_visible_changed, "visible", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_checked_changed, "checked", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_name_changed, "name", remove=True
-        )
-        action.on_trait_change(
+        action.observe(self._on_action_enabled_changed, "enabled", remove=True)
+        action.observe(self._on_action_visible_changed, "visible", remove=True)
+        action.observe(self._on_action_checked_changed, "checked", remove=True)
+        action.observe(self._on_action_name_changed, "name", remove=True)
+        action.observe(
             self._on_action_accelerator_changed, "accelerator", remove=True
         )
-        action.on_trait_change(
-            self._on_action_image_changed, "image", remove=True
-        )
-        action.on_trait_change(
-            self._on_action_tooltip_changed, "tooltip", remove=True
-        )
+        action.observe(self._on_action_image_changed, "image", remove=True)
+        action.observe(self._on_action_tooltip_changed, "tooltip", remove=True)
 
     # ------------------------------------------------------------------------
     # Private interface.
@@ -453,41 +433,48 @@ class _Tool(HasTraits):
         if self.control is not None:
             self.control.setChecked(self.checked)
 
-    def _on_action_enabled_changed(self, action, trait_name, old, new):
+    def _on_action_enabled_changed(self, event):
         """ Called when the enabled trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setEnabled(action.enabled)
 
-    def _on_action_visible_changed(self, action, trait_name, old, new):
+    def _on_action_visible_changed(self, event):
         """ Called when the visible trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setVisible(action.visible)
 
-    def _on_action_checked_changed(self, action, trait_name, old, new):
+    def _on_action_checked_changed(self, event):
         """ Called when the checked trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setChecked(action.checked)
 
-    def _on_action_name_changed(self, action, trait_name, old, new):
+    def _on_action_name_changed(self, event):
         """ Called when the name trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setText(action.name)
 
-    def _on_action_accelerator_changed(self, action, trait_name, old, new):
+    def _on_action_accelerator_changed(self, event):
         """ Called when the accelerator trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setShortcut(action.accelerator)
 
-    def _on_action_image_changed(self, action, trait_name, old, new):
+    def _on_action_image_changed(self, event):
         """ Called when the accelerator trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             size = self.tool_bar.iconSize()
             self.control.setIcon(
                 action.image.create_icon((size.width(), size.height()))
             )
 
-    def _on_action_tooltip_changed(self, action, trait_name, old, new):
+    def _on_action_tooltip_changed(self, event):
         """ Called when the accelerator trait is changed on an action. """
+        action = event.object
         if self.control is not None:
             self.control.setToolTip(action.tooltip)
 
@@ -547,8 +534,8 @@ class _PaletteTool(HasTraits):
 
         # Listen to the trait changes on the action (so that we can update its
         # enabled/disabled/checked state etc).
-        action.on_trait_change(self._on_action_enabled_changed, "enabled")
-        action.on_trait_change(self._on_action_checked_changed, "checked")
+        action.observe(self._on_action_enabled_changed, "enabled")
+        action.observe(self._on_action_checked_changed, "checked")
 
         return
 
@@ -558,25 +545,25 @@ class _PaletteTool(HasTraits):
 
     # Trait event handlers -------------------------------------------------
 
-    def _on_action_enabled_changed(self, action, trait_name, old, new):
+    def _on_action_enabled_changed(self, event):
         """ Called when the enabled trait is changed on an action. """
-
+        action = event.object
         self.tool_palette.enable_tool(self.tool_id, action.enabled)
 
-    def _on_action_checked_changed(self, action, trait_name, old, new):
+    def _on_action_checked_changed(self, event):
         """ Called when the checked trait is changed on an action. """
-
+        action = event.object
         if action.style == "radio":
             # If we're turning this one on, then we need to turn all the others
             # off.  But if we're turning this one off, don't worry about the
             # others.
-            if new:
+            if event.new:
                 for item in self.item.parent.items:
                     if item is not self.item:
                         item.action.checked = False
 
         # This will *not* emit a tool event.
-        self.tool_palette.toggle_tool(self.tool_id, new)
+        self.tool_palette.toggle_tool(self.tool_id, event.new)
 
         return
 

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -144,7 +144,7 @@ class _Menu(QtGui.QMenu):
         self._manager.observe(self._on_enabled_changed, "enabled")
         self._manager.observe(self._on_visible_changed, "visible")
         self._manager.observe(self._on_name_changed, "name")
-        self._manager.observe(self._on_image_changed, "image")
+        #self._manager.observe(self._on_image_changed, "image")
         self.setEnabled(self._manager.enabled)
         self.menuAction().setVisible(self._manager.visible)
 
@@ -155,7 +155,7 @@ class _Menu(QtGui.QMenu):
         self._manager.observe(self._on_enabled_changed, "enabled", remove=True)
         self._manager.observe(self._on_visible_changed, "visible", remove=True)
         self._manager.observe(self._on_name_changed, "name", remove=True)
-        self._manager.observe(self._on_image_changed, "image", remove=True)
+        #self._manager.observe(self._on_image_changed, "image", remove=True)
         # Removes event listeners from downstream menu items
         self.clear()
 

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -178,7 +178,7 @@ class _Menu(QtGui.QMenu):
 
         return self.isEmpty()
 
-    def refresh(self, _=None):
+    def refresh(self, event=None):
         """ Ensures that the menu reflects the state of the manager. """
 
         self.clear()

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -140,30 +140,22 @@ class _Menu(QtGui.QMenu):
         self.refresh()
 
         # Listen to the manager being updated.
-        self._manager.on_trait_change(self.refresh, "changed")
-        self._manager.on_trait_change(self._on_enabled_changed, "enabled")
-        self._manager.on_trait_change(self._on_visible_changed, "visible")
-        self._manager.on_trait_change(self._on_name_changed, "name")
-        self._manager.on_trait_change(self._on_image_changed, "image")
+        self._manager.observe(self.refresh, "changed")
+        self._manager.observe(self._on_enabled_changed, "enabled")
+        self._manager.observe(self._on_visible_changed, "visible")
+        self._manager.observe(self._on_name_changed, "name")
+        self._manager.observe(self._on_image_changed, "image")
         self.setEnabled(self._manager.enabled)
         self.menuAction().setVisible(self._manager.visible)
 
         return
 
     def dispose(self):
-        self._manager.on_trait_change(self.refresh, "changed", remove=True)
-        self._manager.on_trait_change(
-            self._on_enabled_changed, "enabled", remove=True
-        )
-        self._manager.on_trait_change(
-            self._on_visible_changed, "visible", remove=True
-        )
-        self._manager.on_trait_change(
-            self._on_name_changed, "name", remove=True
-        )
-        self._manager.on_trait_change(
-            self._on_image_changed, "image", remove=True
-        )
+        self._manager.observe(self.refresh, "changed", remove=True)
+        self._manager.observe(self._on_enabled_changed, "enabled", remove=True)
+        self._manager.observe(self._on_visible_changed, "visible", remove=True)
+        self._manager.observe(self._on_name_changed, "name", remove=True)
+        self._manager.observe(self._on_image_changed, "image", remove=True)
         # Removes event listeners from downstream menu items
         self.clear()
 
@@ -186,7 +178,7 @@ class _Menu(QtGui.QMenu):
 
         return self.isEmpty()
 
-    def refresh(self):
+    def refresh(self, _=None):
         """ Ensures that the menu reflects the state of the manager. """
 
         self.clear()
@@ -215,25 +207,25 @@ class _Menu(QtGui.QMenu):
     # Private interface.
     # ------------------------------------------------------------------------
 
-    def _on_enabled_changed(self, obj, trait_name, old, new):
+    def _on_enabled_changed(self, event):
         """ Dynamic trait change handler. """
 
-        self.setEnabled(new)
+        self.setEnabled(event.new)
 
-    def _on_visible_changed(self, obj, trait_name, old, new):
+    def _on_visible_changed(self, event):
         """ Dynamic trait change handler. """
 
-        self.menuAction().setVisible(new)
+        self.menuAction().setVisible(event.new)
 
-    def _on_name_changed(self, obj, trait_name, old, new):
+    def _on_name_changed(self, event):
         """ Dynamic trait change handler. """
 
-        self.menuAction().setText(new)
+        self.menuAction().setText(event.new)
 
-    def _on_image_changed(self, obj, trait_name, old, new):
+    def _on_image_changed(self, event):
         """ Dynamic trait change handler. """
 
-        self.menuAction().setIcon(new.create_icon())
+        self.menuAction().setIcon(event.new.create_icon())
 
     def _add_group(self, parent, group, previous_non_empty_group=None):
         """ Adds a group to a menu. """

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -144,7 +144,7 @@ class _Menu(QtGui.QMenu):
         self._manager.observe(self._on_enabled_changed, "enabled")
         self._manager.observe(self._on_visible_changed, "visible")
         self._manager.observe(self._on_name_changed, "name")
-        #self._manager.observe(self._on_image_changed, "image")
+        self._manager.observe(self._on_image_changed, "action:image")
         self.setEnabled(self._manager.enabled)
         self.menuAction().setVisible(self._manager.visible)
 
@@ -155,7 +155,7 @@ class _Menu(QtGui.QMenu):
         self._manager.observe(self._on_enabled_changed, "enabled", remove=True)
         self._manager.observe(self._on_visible_changed, "visible", remove=True)
         self._manager.observe(self._on_name_changed, "name", remove=True)
-        #self._manager.observe(self._on_image_changed, "image", remove=True)
+        self._manager.observe(self._on_image_changed, "action:image", remove=True)
         # Removes event listeners from downstream menu items
         self.clear()
 

--- a/pyface/ui/qt4/action/tool_bar_manager.py
+++ b/pyface/ui/qt4/action/tool_bar_manager.py
@@ -136,7 +136,7 @@ class ToolBarManager(ActionManager):
                 # Is a separator required?
                 if previous_non_empty_group is not None and group.separator:
                     separator = tool_bar.addSeparator()
-                    group.on_trait_change(
+                    group.observe(
                         self._separator_visibility_method(separator), "visible"
                     )
 
@@ -154,7 +154,7 @@ class ToolBarManager(ActionManager):
 
     def _separator_visibility_method(self, separator):
         """ Method to return closure to set visibility of group separators. """
-        return lambda visible: separator.setVisible(visible)
+        return lambda event: separator.setVisible(event.new)
 
 
 class _ToolBar(QtGui.QToolBar):
@@ -176,21 +176,21 @@ class _ToolBar(QtGui.QToolBar):
         # visibility.
         self.tool_bar_manager = tool_bar_manager
 
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_enabled_changed, "enabled"
         )
 
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_visible_changed, "visible"
         )
 
         return
 
     def dispose(self):
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_enabled_changed, "enabled", remove=True
         )
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_visible_changed, "visible", remove=True
         )
         # Removes event listeners from downstream tools and clears their
@@ -204,14 +204,14 @@ class _ToolBar(QtGui.QToolBar):
     # Trait change handlers.
     # ------------------------------------------------------------------------
 
-    def _on_tool_bar_manager_enabled_changed(self, obj, trait_name, old, new):
+    def _on_tool_bar_manager_enabled_changed(self, event):
         """ Dynamic trait change handler. """
 
-        self.setEnabled(new)
+        self.setEnabled(event.new)
 
-    def _on_tool_bar_manager_visible_changed(self, obj, trait_name, old, new):
+    def _on_tool_bar_manager_visible_changed(self, event):
         """ Dynamic trait change handler. """
 
-        self.setVisible(new)
+        self.setVisible(event.new)
 
         return

--- a/pyface/ui/wx/action/action_item.py
+++ b/pyface/ui/wx/action/action_item.py
@@ -138,6 +138,7 @@ class _MenuItem(HasTraits):
         action.observe(self._on_action_visible_changed, "visible", remove=True)
         action.observe(self._on_action_checked_changed, "checked", remove=True)
         action.observe(self._on_action_name_changed, "name", remove=True)
+        action.observe(self._on_action_image_changed, "image", remove=True)
 
     # ------------------------------------------------------------------------
     # Private interface.
@@ -395,6 +396,12 @@ class _Tool(HasTraits):
             self.controller = controller
             controller.add_to_toolbar(self)
 
+    def dispose(self):
+        action = self.item.action
+        action.observe(self._on_action_enabled_changed, "enabled", remove=True)
+        action.observe(self._on_action_visible_changed, "visible", remove=True)
+        action.observe(self._on_action_checked_changed, "checked", remove=True)
+
     # ------------------------------------------------------------------------
     # Private interface.
     # ------------------------------------------------------------------------
@@ -584,6 +591,11 @@ class _PaletteTool(HasTraits):
         action.observe(self._on_action_checked_changed, "checked")
 
         return
+
+    def dispose(self):
+        action = self.item.action
+        action.observe(self._on_action_enabled_changed, "enabled", remove=True)
+        action.observe(self._on_action_checked_changed, "checked", remove=True)
 
     # ------------------------------------------------------------------------
     # Private interface.

--- a/pyface/ui/wx/action/menu_manager.py
+++ b/pyface/ui/wx/action/menu_manager.py
@@ -103,7 +103,7 @@ class _Menu(wx.Menu):
         self.menu_items = []
 
         # Create the menu structure.
-        self.refresh()
+        self.refresh(event=None)
 
         # Listen to the manager being updated.
         self._manager.observe(self.refresh, "changed")
@@ -139,7 +139,7 @@ class _Menu(wx.Menu):
 
         return self.GetMenuItemCount() == 0
 
-    def refresh(self):
+    def refresh(self, event):
         """ Ensures that the menu reflects the state of the manager. """
 
         self.clear()
@@ -167,7 +167,7 @@ class _Menu(wx.Menu):
     # Private interface.
     # ------------------------------------------------------------------------
 
-    def _on_enabled_changed(self, obj, trait_name, old, new):
+    def _on_enabled_changed(self, event):
         """ Dynamic trait change handler. """
 
         # fixme: Nasty hack to allow enabling/disabling of menus.
@@ -176,7 +176,7 @@ class _Menu(wx.Menu):
         # we don't give them an '_id'...
 
         if hasattr(self, "_id"):
-            self._menu.Enable(self._id, new)
+            self._menu.Enable(self._id, event.new)
 
     def _add_group(self, parent, group, previous_non_empty_group=None):
         """ Adds a group to a menu. """

--- a/pyface/ui/wx/action/menu_manager.py
+++ b/pyface/ui/wx/action/menu_manager.py
@@ -103,7 +103,7 @@ class _Menu(wx.Menu):
         self.menu_items = []
 
         # Create the menu structure.
-        self.refresh(event=None)
+        self.refresh()
 
         # Listen to the manager being updated.
         self._manager.observe(self.refresh, "changed")

--- a/pyface/ui/wx/action/menu_manager.py
+++ b/pyface/ui/wx/action/menu_manager.py
@@ -106,10 +106,16 @@ class _Menu(wx.Menu):
         self.refresh()
 
         # Listen to the manager being updated.
-        self._manager.on_trait_change(self.refresh, "changed")
-        self._manager.on_trait_change(self._on_enabled_changed, "enabled")
+        self._manager.observe(self.refresh, "changed")
+        self._manager.observe(self._on_enabled_changed, "enabled")
 
         return
+
+    def dispose(self):
+        self._manager.observe(self.refresh, "changed", remove=True)
+        self._manager.observe(self._on_enabled_changed, "enabled", remove=True)
+        # Removes event listeners from downstream menu items
+        self.clear()
 
     # ------------------------------------------------------------------------
     # '_Menu' interface.

--- a/pyface/ui/wx/action/menu_manager.py
+++ b/pyface/ui/wx/action/menu_manager.py
@@ -139,7 +139,7 @@ class _Menu(wx.Menu):
 
         return self.GetMenuItemCount() == 0
 
-    def refresh(self, event):
+    def refresh(self, event=None):
         """ Ensures that the menu reflects the state of the manager. """
 
         self.clear()

--- a/pyface/ui/wx/action/tool_bar_manager.py
+++ b/pyface/ui/wx/action/tool_bar_manager.py
@@ -206,11 +206,11 @@ class _ToolBar(wx.ToolBar):
         # visibility.
         self.tool_bar_manager = tool_bar_manager
 
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_enabled_changed, "enabled"
         )
 
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_visible_changed, "visible"
         )
 
@@ -220,15 +220,15 @@ class _ToolBar(wx.ToolBar):
     # Trait change handlers.
     # ------------------------------------------------------------------------
 
-    def _on_tool_bar_manager_enabled_changed(self, obj, trait_name, old, new):
+    def _on_tool_bar_manager_enabled_changed(self, event):
         """ Dynamic trait change handler. """
 
-        obj.window._wx_enable_tool_bar(self, new)
+        obj.window._wx_enable_tool_bar(self, event.new)
 
-    def _on_tool_bar_manager_visible_changed(self, obj, trait_name, old, new):
+    def _on_tool_bar_manager_visible_changed(self, event):
         """ Dynamic trait change handler. """
 
-        obj.window._wx_show_tool_bar(self, new)
+        obj.window._wx_show_tool_bar(self, event.new)
 
 
 class _AuiToolBar(AUI.AuiToolBar):
@@ -247,11 +247,11 @@ class _AuiToolBar(AUI.AuiToolBar):
         # visibility.
         self.tool_bar_manager = tool_bar_manager
 
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_enabled_changed, "enabled"
         )
 
-        self.tool_bar_manager.on_trait_change(
+        self.tool_bar_manager.observe(
             self._on_tool_bar_manager_visible_changed, "visible"
         )
 
@@ -405,20 +405,20 @@ class _AuiToolBar(AUI.AuiToolBar):
     # Trait change handlers.
     # ------------------------------------------------------------------------
 
-    def _on_tool_bar_manager_enabled_changed(self, obj, trait_name, old, new):
+    def _on_tool_bar_manager_enabled_changed(self, event):
         """ Dynamic trait change handler. """
 
         try:
-            obj.controller.task.window._wx_enable_tool_bar(self, new)
+            obj.controller.task.window._wx_enable_tool_bar(self, event.new)
         except:
 
             pass
 
-    def _on_tool_bar_manager_visible_changed(self, obj, trait_name, old, new):
+    def _on_tool_bar_manager_visible_changed(self, event):
         """ Dynamic trait change handler. """
 
         try:
-            obj.controller.task.window._wx_show_tool_bar(self, new)
+            obj.controller.task.window._wx_show_tool_bar(self, event.new)
         except:
 
             pass

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -226,39 +226,39 @@ class Grid(Widget):
         grid.Bind(grid_movers.EVT_GRID_COL_MOVE, self._on_col_move)
         grid.Bind(grid_movers.EVT_GRID_ROW_MOVE, self._on_row_move)
 
-        smotc = self.model.on_trait_change
-        otc = self.on_trait_change
-        smotc(self._on_model_content_changed, "content_changed")
-        smotc(self._on_model_structure_changed, "structure_changed")
-        smotc(self._on_row_sort, "row_sorted")
-        smotc(self._on_column_sort, "column_sorted")
-        otc(self._on_new_model, "model")
+        smobs = self.model.observe
+        obs = self.observe
+        smobs(self._on_model_content_changed, "content_changed")
+        smobs(self._on_model_structure_changed, "structure_changed")
+        smobs(self._on_row_sort, "row_sorted")
+        smobs(self._on_column_sort, "column_sorted")
+        obs(self._on_new_model, "model")
 
         # hook up style trait handlers - note that we have to use
         # dynamic notification hook-ups because these handlers should
         # not be called until after the control object is initialized.
         # static trait notifiers get called when the object inits.
-        otc(self._on_enable_lines_changed, "enable_lines")
-        otc(self._on_grid_line_color_changed, "grid_line_color")
-        otc(self._on_default_label_font_changed, "default_label_font")
-        otc(self._on_default_label_bg_color_changed, "default_label_bg_color")
-        otc(
+        obs(self._on_enable_lines_changed, "enable_lines")
+        obs(self._on_grid_line_color_changed, "grid_line_color")
+        obs(self._on_default_label_font_changed, "default_label_font")
+        obs(self._on_default_label_bg_color_changed, "default_label_bg_color")
+        obs(
             self._on_default_label_text_color_changed,
             "default_label_text_color",
         )
-        otc(self._on_selection_bg_color_changed, "selection_bg_color")
-        otc(self._on_selection_text_color_changed, "selection_text_color")
-        otc(self._on_default_cell_font_changed, "default_cell_font")
-        otc(
+        obs(self._on_selection_bg_color_changed, "selection_bg_color")
+        obs(self._on_selection_text_color_changed, "selection_text_color")
+        obs(self._on_default_cell_font_changed, "default_cell_font")
+        obs(
             self._on_default_cell_text_color_changed, "default_cell_text_color"
         )
-        otc(self._on_default_cell_bg_color_changed, "default_cell_bg_color")
-        otc(self._on_read_only_changed, "read_only_changed")
-        otc(self._on_selection_mode_changed, "selection_mode")
-        otc(self._on_column_label_height_changed, "column_label_height")
-        otc(self._on_row_label_width_changed, "row_label_width")
-        otc(self._on_show_column_headers_changed, "show_column_headers")
-        otc(self._on_show_row_headers_changed, "show_row_headers")
+        obs(self._on_default_cell_bg_color_changed, "default_cell_bg_color")
+        obs(self._on_read_only_changed, "read_only_changed")
+        obs(self._on_selection_mode_changed, "selection_mode")
+        obs(self._on_column_label_height_changed, "column_label_height")
+        obs(self._on_row_label_width_changed, "row_label_width")
+        obs(self._on_show_column_headers_changed, "show_column_headers")
+        obs(self._on_show_row_headers_changed, "show_row_headers")
 
         # Initialize wx handlers:
         self._notify_select = True
@@ -347,63 +347,63 @@ class Grid(Widget):
             window.Unbind(wx.EVT_LEFT_DOWN)
             window.Unbind(wx.EVT_LEFT_UP)
 
-        otc = self.on_trait_change
-        otc(self._on_enable_lines_changed, "enable_lines", remove=True)
-        otc(self._on_grid_line_color_changed, "grid_line_color", remove=True)
-        otc(
+        obs = self.observe
+        obs(self._on_enable_lines_changed, "enable_lines", remove=True)
+        obs(self._on_grid_line_color_changed, "grid_line_color", remove=True)
+        obs(
             self._on_default_label_font_changed,
             "default_label_font",
             remove=True,
         )
-        otc(
+        obs(
             self._on_default_label_bg_color_changed,
             "default_label_bg_color",
             remove=True,
         )
-        otc(
+        obs(
             self._on_default_label_text_color_changed,
             "default_label_text_color",
             remove=True,
         )
-        otc(
+        obs(
             self._on_selection_bg_color_changed,
             "selection_bg_color",
             remove=True,
         )
-        otc(
+        obs(
             self._on_selection_text_color_changed,
             "selection_text_color",
             remove=True,
         )
-        otc(
+        obs(
             self._on_default_cell_font_changed,
             "default_cell_font",
             remove=True,
         )
-        otc(
+        obs(
             self._on_default_cell_text_color_changed,
             "default_cell_text_color",
             remove=True,
         )
-        otc(
+        obs(
             self._on_default_cell_bg_color_changed,
             "default_cell_bg_color",
             remove=True,
         )
-        otc(self._on_read_only_changed, "read_only_changed", remove=True)
-        otc(self._on_selection_mode_changed, "selection_mode", remove=True)
-        otc(
+        obs(self._on_read_only_changed, "read_only_changed", remove=True)
+        obs(self._on_selection_mode_changed, "selection_mode", remove=True)
+        obs(
             self._on_column_label_height_changed,
             "column_label_height",
             remove=True,
         )
-        otc(self._on_row_label_width_changed, "row_label_width", remove=True)
-        otc(
+        obs(self._on_row_label_width_changed, "row_label_width", remove=True)
+        obs(
             self._on_show_column_headers_changed,
             "show_column_headers",
             remove=True,
         )
-        otc(self._on_show_row_headers_changed, "show_row_headers", remove=True)
+        obs(self._on_show_row_headers_changed, "show_row_headers", remove=True)
 
         self._grid_table_base.dispose()
         self._grid = None
@@ -412,7 +412,7 @@ class Grid(Widget):
     # Trait event handlers.
     # ------------------------------------------------------------------------
 
-    def _on_new_model(self):
+    def _on_new_model(self, event):
         """ When we get a new model reinitialize grid match to that model. """
 
         self._grid_table_base.model = self.model
@@ -426,12 +426,12 @@ class Grid(Widget):
             # the rows looks like crap.
             self._grid.AutoSizeColumns(False)
 
-    def _on_model_content_changed(self):
+    def _on_model_content_changed(self, event):
         """ A notification method called when the data in the underlying
             model changes. """
         self._grid.ForceRefresh()
 
-    def _on_model_structure_changed(self, *arg, **kw):
+    def _on_model_structure_changed(self, event):
         """ A notification method called when the underlying model has
         changed. Responsible for making sure the view object updates
         correctly. """
@@ -510,16 +510,16 @@ class Grid(Widget):
         grid.AdjustScrollbars()
         self._refresh()
 
-    def _on_row_sort(self, evt):
+    def _on_row_sort(self, event):
         """ Handles a row_sorted event from the underlying model. """
 
         # First grab the new data out of the event:
-        if evt.index < 0:
+        if event.new.index < 0:
             self._current_sorted_row = None
         else:
-            self._current_sorted_row = evt.index
+            self._current_sorted_row = event.new.index
 
-        self._row_sort_reversed = evt.reversed
+        self._row_sort_reversed = event.new.reversed
 
         # Since the label may have changed we may need to autosize again:
         # fixme: when we change how we represent the sorted column
@@ -527,18 +527,18 @@ class Grid(Widget):
         self.__autosize()
 
         # Make sure everything updates to reflect the changes:
-        self._on_model_structure_changed()
+        self._on_model_structure_changed(event=None)
 
-    def _on_column_sort(self, evt):
+    def _on_column_sort(self, event):
         """ Handles a column_sorted event from the underlying model. """
 
         # first grab the new data out of the event
-        if evt.index < 0:
+        if event.new.index < 0:
             self._current_sorted_col = None
         else:
-            self._current_sorted_col = evt.index
+            self._current_sorted_col = event.new.index
 
-        self._col_sort_reversed = evt.reversed
+        self._col_sort_reversed = event.new.reversed
 
         # since the label may have changed we may need to autosize again
         # fixme: when we change how we represent the sorted column
@@ -546,17 +546,17 @@ class Grid(Widget):
         self.__autosize()
 
         # make sure everything updates to reflect the changes
-        self._on_model_structure_changed()
+        self._on_model_structure_changed(event=None)
 
-    def _on_enable_lines_changed(self):
+    def _on_enable_lines_changed(self, event):
         """ Handle a change to the enable_lines trait. """
         self._grid.EnableGridLines(self.enable_lines)
 
-    def _on_grid_line_color_changed(self):
+    def _on_grid_line_color_changed(self, event):
         """ Handle a change to the enable_lines trait. """
         self._grid.SetGridLineColour(self.grid_line_color)
 
-    def _on_default_label_font_changed(self):
+    def _on_default_label_font_changed(self, event):
         """ Handle a change to the default_label_font trait. """
 
         font = self.default_label_font
@@ -566,7 +566,7 @@ class Grid(Widget):
 
         self._grid.SetLabelFont(font)
 
-    def _on_default_label_text_color_changed(self):
+    def _on_default_label_text_color_changed(self, event):
         """ Handle a change to the default_cell_text_color trait. """
 
         if self.default_label_text_color is not None:
@@ -574,7 +574,7 @@ class Grid(Widget):
             self._grid.SetLabelTextColour(color)
             self._grid.ForceRefresh()
 
-    def _on_default_label_bg_color_changed(self):
+    def _on_default_label_bg_color_changed(self, event):
         """ Handle a change to the default_cell_text_color trait. """
 
         if self.default_label_bg_color is not None:
@@ -582,24 +582,24 @@ class Grid(Widget):
             self._grid.SetLabelBackgroundColour(color)
             self._grid.ForceRefresh()
 
-    def _on_selection_bg_color_changed(self):
+    def _on_selection_bg_color_changed(self, event):
         """ Handle a change to the selection_bg_color trait. """
         if self.selection_bg_color is not None:
             self._grid.SetSelectionBackground(self.selection_bg_color)
 
-    def _on_selection_text_color_changed(self):
+    def _on_selection_text_color_changed(self, event):
         """ Handle a change to the selection_text_color trait. """
         if self.selection_text_color is not None:
             self._grid.SetSelectionForeground(self.selection_text_color)
 
-    def _on_default_cell_font_changed(self):
+    def _on_default_cell_font_changed(self, event):
         """ Handle a change to the default_cell_font trait. """
 
         if self.default_cell_font is not None:
             self._grid.SetDefaultCellFont(self.default_cell_font)
             self._grid.ForceRefresh()
 
-    def _on_default_cell_text_color_changed(self):
+    def _on_default_cell_text_color_changed(self, event):
         """ Handle a change to the default_cell_text_color trait. """
 
         if self.default_cell_text_color is not None:
@@ -607,7 +607,7 @@ class Grid(Widget):
             self._grid.SetDefaultCellTextColour(color)
             self._grid.ForceRefresh()
 
-    def _on_default_cell_bg_color_changed(self):
+    def _on_default_cell_bg_color_changed(self, event):
         """ Handle a change to the default_cell_bg_color trait. """
 
         if self.default_cell_bg_color is not None:
@@ -615,7 +615,7 @@ class Grid(Widget):
             self._grid.SetDefaultCellBackgroundColour(color)
             self._grid.ForceRefresh()
 
-    def _on_read_only_changed(self):
+    def _on_read_only_changed(self, event):
         """ Handle a change to the read_only trait. """
 
         # should the whole grid be read-only?
@@ -624,7 +624,7 @@ class Grid(Widget):
         else:
             self._grid.EnableEditing(True)
 
-    def _on_selection_mode_changed(self):
+    def _on_selection_mode_changed(self, event):
         """ Handle a change to the selection_mode trait. """
 
         # should we allow individual cells to be selected or only rows
@@ -636,20 +636,20 @@ class Grid(Widget):
         elif self.selection_mode == "cols":
             self._grid.SetSelectionMode(wxGrid.SelectColumns)
 
-    def _on_column_label_height_changed(self):
+    def _on_column_label_height_changed(self, event):
         """ Handle a change to the column_label_height trait. """
 
         # handle setting for height of column labels
         if self.column_label_height is not None:
             self._grid.SetColLabelSize(self.column_label_height)
 
-    def _on_row_label_width_changed(self):
+    def _on_row_label_width_changed(self, event):
         """ Handle a change to the row_label_width trait. """
         # handle setting for width of row labels
         if self.row_label_width is not None:
             self._grid.SetRowLabelSize(self.row_label_width)
 
-    def _on_show_column_headers_changed(self):
+    def _on_show_column_headers_changed(self, event):
         """ Handle a change to the show_column_headers trait. """
 
         if not self.show_column_headers:
@@ -657,7 +657,7 @@ class Grid(Widget):
         else:
             self._grid.SetColLabelSize(self.column_label_height)
 
-    def _on_show_row_headers_changed(self):
+    def _on_show_row_headers_changed(self, event):
         """ Handle a change to the show_row_headers trait. """
 
         if not self.show_row_headers:
@@ -1254,10 +1254,10 @@ class Grid(Widget):
     def __initialize_fonts(self):
         """ Initialize the label fonts. """
 
-        self._on_default_label_font_changed()
-        self._on_default_cell_font_changed()
-        self._on_default_cell_text_color_changed()
-        self._on_grid_line_color_changed()
+        self._on_default_label_font_changed(event=None)
+        self._on_default_cell_font_changed(event=None)
+        self._on_default_cell_text_color_changed(event=None)
+        self._on_grid_line_color_changed(event=None)
 
         self._grid.SetColLabelAlignment(wx.ALIGN_CENTRE, wx.ALIGN_CENTRE)
         self._grid.SetRowLabelAlignment(wx.ALIGN_RIGHT, wx.ALIGN_CENTRE)
@@ -1310,18 +1310,18 @@ class Grid(Widget):
     def __initialize_style_settings(self, event=None):
 
         # make sure all the handlers for traits defining styles get called
-        self._on_enable_lines_changed()
-        self._on_read_only_changed()
-        self._on_selection_mode_changed()
-        self._on_column_label_height_changed()
-        self._on_row_label_width_changed()
-        self._on_show_column_headers_changed()
-        self._on_show_row_headers_changed()
-        self._on_default_cell_bg_color_changed()
-        self._on_default_label_bg_color_changed()
-        self._on_default_label_text_color_changed()
-        self._on_selection_bg_color_changed()
-        self._on_selection_text_color_changed()
+        self._on_enable_lines_changed(event=None)
+        self._on_read_only_changed(event=None)
+        self._on_selection_mode_changed(event=None)
+        self._on_column_label_height_changed(event=None)
+        self._on_row_label_width_changed(event=None)
+        self._on_show_column_headers_changed(event=None)
+        self._on_show_row_headers_changed(event=None)
+        self._on_default_cell_bg_color_changed(event=None)
+        self._on_default_label_bg_color_changed(event=None)
+        self._on_default_label_text_color_changed(event=None)
+        self._on_selection_bg_color_changed(event=None)
+        self._on_selection_text_color_changed(event=None)
 
     def __get_drag_value(self):
         """ Calculates the drag value based on the current selection. """

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -347,7 +347,16 @@ class Grid(Widget):
             window.Unbind(wx.EVT_LEFT_DOWN)
             window.Unbind(wx.EVT_LEFT_UP)
 
+        smobs = self.model.observe
         obs = self.observe
+        smobs(self._on_model_content_changed, "content_changed", remove=True)
+        smobs(
+            self._on_model_structure_changed, "structure_changed", remove=True
+        )
+        smobs(self._on_row_sort, "row_sorted", remove=True)
+        smobs(self._on_column_sort, "column_sorted", remove=True)
+        obs(self._on_new_model, "model", remove=True)
+
         obs(self._on_enable_lines_changed, "enable_lines", remove=True)
         obs(self._on_grid_line_color_changed, "grid_line_color", remove=True)
         obs(

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -1037,31 +1037,6 @@ class Grid(Widget):
         # has meaning to the edit control.
         key_code = evt.GetKeyCode()
 
-        # if (key_code == wx.WXK_RETURN) and not evt.ControlDown():
-        #    evt.Skip()#self._move_to_next_cell(evt.ShiftDown())
-
-        # elif (key_code == wx.WXK_TAB) and not evt.ControlDown():
-        #    if evt.ShiftDown():
-        #        # fixme: in a split window the shift tab is being eaten
-        #        # by tabbing between the splits
-        #        self._move_to_previous_cell()
-
-        #    else:
-        #        self._move_to_next_cell()
-
-        # elif key_code == ASCII_C:
-        #    data = self.__get_drag_value()
-        # deposit the data in our singleton clipboard
-        #    enClipboard.data = data
-
-        # build a wxCustomDataObject to notify the system clipboard
-        # that some in-process data is available
-        #    data_object = wx.CustomDataObject(PythonObject)
-        #    data_object.SetData('dummy')
-        #    if TheClipboard.Open():
-        #        TheClipboard.SetData(data_object)
-        #        TheClipboard.Close()
-
         evt.Skip()
 
     def _move_to_next_cell(self, expandSelection=False):
@@ -1334,34 +1309,9 @@ class Grid(Widget):
 
     def __get_drag_value(self):
         """ Calculates the drag value based on the current selection. """
-        # fixme: The following line seems like a more useful implementation than
-        # the previous commented out version below, but I am leaving the old
-        # version in the code for now just in case. If anyone sees this comment
-        # after 1/1/2009, it should be safe to delete this comment and the
-        # commented out code below...
         return self.model.get_cell_drag_value(
             self._grid.GetGridCursorRow(), self._grid.GetGridCursorCol()
         )
-
-        ###rows, cols = self.__get_selected_rows_and_cols()
-        ###
-        ###if len(rows) > 0:
-        #    rows.sort()
-        #    value = self.model.get_rows_drag_value(rows)
-        #    if len(rows) == 1 and len(value) == 1:
-        #        value = value[0]
-        ###elif len(cols) > 0:
-        #    cols.sort()
-        #    value = self.model.get_cols_drag_value(cols)
-        #    if len(cols) == 1 and len(value) == 1:
-        #        value = value[0]
-        ###else:
-        #    # our final option -- grab the cell that the cursor is currently in
-        #    row = self._grid.GetGridCursorRow()
-        #    col = self._grid.GetGridCursorCol()
-        #    value = self.model.get_cell_drag_value(row, col)
-        ###
-        ###return value
 
     def __get_selection(self):
         """ Returns a list of values for the current selection. """
@@ -1397,9 +1347,7 @@ class Grid(Widget):
         rows = self._grid.GetSelectedRows()
         cols = self._grid.GetSelectedCols()
 
-        # because wx is retarded we have to check this as well -- why
-        # the blazes can't they come up with one Q#$%@$#% API to manage
-        # selections??? makes me want to put the smack on somebody.
+        # because of wx we have to check this as well
         # note that all this malarkey is working on the assumption that
         # only entire rows or entire columns or single cells are selected.
         top_left = self._grid.GetSelectionBlockTopLeft()

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -226,39 +226,49 @@ class Grid(Widget):
         grid.Bind(grid_movers.EVT_GRID_COL_MOVE, self._on_col_move)
         grid.Bind(grid_movers.EVT_GRID_ROW_MOVE, self._on_row_move)
 
-        smobs = self.model.observe
-        obs = self.observe
-        smobs(self._on_model_content_changed, "content_changed")
-        smobs(self._on_model_structure_changed, "structure_changed")
-        smobs(self._on_row_sort, "row_sorted")
-        smobs(self._on_column_sort, "column_sorted")
-        obs(self._on_new_model, "model")
+        self.model.observe(self._on_model_content_changed, "content_changed")
+        self.model.observe(
+            self._on_model_structure_changed, "structure_changed"
+        )
+        self.model.observe(self._on_row_sort, "row_sorted")
+        self.model.observe(self._on_column_sort, "column_sorted")
+        self.observe(self._on_new_model, "model")
 
         # hook up style trait handlers - note that we have to use
         # dynamic notification hook-ups because these handlers should
         # not be called until after the control object is initialized.
         # static trait notifiers get called when the object inits.
-        obs(self._on_enable_lines_changed, "enable_lines")
-        obs(self._on_grid_line_color_changed, "grid_line_color")
-        obs(self._on_default_label_font_changed, "default_label_font")
-        obs(self._on_default_label_bg_color_changed, "default_label_bg_color")
-        obs(
+        self.observe(self._on_enable_lines_changed, "enable_lines")
+        self.observe(self._on_grid_line_color_changed, "grid_line_color")
+        self.observe(self._on_default_label_font_changed, "default_label_font")
+        self.observe(
+            self._on_default_label_bg_color_changed, "default_label_bg_color"
+        )
+        self.observe(
             self._on_default_label_text_color_changed,
             "default_label_text_color",
         )
-        obs(self._on_selection_bg_color_changed, "selection_bg_color")
-        obs(self._on_selection_text_color_changed, "selection_text_color")
-        obs(self._on_default_cell_font_changed, "default_cell_font")
-        obs(
+        self.observe(self._on_selection_bg_color_changed, "selection_bg_color")
+        self.observe(
+            self._on_selection_text_color_changed, "selection_text_color"
+        )
+        self.observe(self._on_default_cell_font_changed, "default_cell_font")
+        self.observe(
             self._on_default_cell_text_color_changed, "default_cell_text_color"
         )
-        obs(self._on_default_cell_bg_color_changed, "default_cell_bg_color")
-        obs(self._on_read_only_changed, "read_only_changed")
-        obs(self._on_selection_mode_changed, "selection_mode")
-        obs(self._on_column_label_height_changed, "column_label_height")
-        obs(self._on_row_label_width_changed, "row_label_width")
-        obs(self._on_show_column_headers_changed, "show_column_headers")
-        obs(self._on_show_row_headers_changed, "show_row_headers")
+        self.observe(
+            self._on_default_cell_bg_color_changed, "default_cell_bg_color"
+        )
+        self.observe(self._on_read_only_changed, "read_only_changed")
+        self.observe(self._on_selection_mode_changed, "selection_mode")
+        self.observe(
+            self._on_column_label_height_changed, "column_label_height"
+        )
+        self.observe(self._on_row_label_width_changed, "row_label_width")
+        self.observe(
+            self._on_show_column_headers_changed, "show_column_headers"
+        )
+        self.observe(self._on_show_row_headers_changed, "show_row_headers")
 
         # Initialize wx handlers:
         self._notify_select = True
@@ -347,72 +357,84 @@ class Grid(Widget):
             window.Unbind(wx.EVT_LEFT_DOWN)
             window.Unbind(wx.EVT_LEFT_UP)
 
-        smobs = self.model.observe
-        obs = self.observe
-        smobs(self._on_model_content_changed, "content_changed", remove=True)
-        smobs(
+        self.model.observe(
+            self._on_model_content_changed, "content_changed", remove=True
+        )
+        self.model.observe(
             self._on_model_structure_changed, "structure_changed", remove=True
         )
-        smobs(self._on_row_sort, "row_sorted", remove=True)
-        smobs(self._on_column_sort, "column_sorted", remove=True)
-        obs(self._on_new_model, "model", remove=True)
+        self.model.observe(self._on_row_sort, "row_sorted", remove=True)
+        self.model.observe(self._on_column_sort, "column_sorted", remove=True)
+        self.observe(self._on_new_model, "model", remove=True)
 
-        obs(self._on_enable_lines_changed, "enable_lines", remove=True)
-        obs(self._on_grid_line_color_changed, "grid_line_color", remove=True)
-        obs(
+        self.observe(
+            self._on_enable_lines_changed, "enable_lines", remove=True
+        )
+        self.observe(
+            self._on_grid_line_color_changed, "grid_line_color", remove=True
+        )
+        self.observe(
             self._on_default_label_font_changed,
             "default_label_font",
             remove=True,
         )
-        obs(
+        self.observe(
             self._on_default_label_bg_color_changed,
             "default_label_bg_color",
             remove=True,
         )
-        obs(
+        self.observe(
             self._on_default_label_text_color_changed,
             "default_label_text_color",
             remove=True,
         )
-        obs(
+        self.observe(
             self._on_selection_bg_color_changed,
             "selection_bg_color",
             remove=True,
         )
-        obs(
+        self.observe(
             self._on_selection_text_color_changed,
             "selection_text_color",
             remove=True,
         )
-        obs(
+        self.observe(
             self._on_default_cell_font_changed,
             "default_cell_font",
             remove=True,
         )
-        obs(
+        self.observe(
             self._on_default_cell_text_color_changed,
             "default_cell_text_color",
             remove=True,
         )
-        obs(
+        self.observe(
             self._on_default_cell_bg_color_changed,
             "default_cell_bg_color",
             remove=True,
         )
-        obs(self._on_read_only_changed, "read_only_changed", remove=True)
-        obs(self._on_selection_mode_changed, "selection_mode", remove=True)
-        obs(
+        self.observe(
+            self._on_read_only_changed, "read_only_changed", remove=True
+        )
+        self.observe(
+            self._on_selection_mode_changed, "selection_mode", remove=True
+        )
+        self.observe(
             self._on_column_label_height_changed,
             "column_label_height",
             remove=True,
         )
-        obs(self._on_row_label_width_changed, "row_label_width", remove=True)
-        obs(
+        self.observe(
+            self._on_row_label_width_changed, "row_label_width", remove=True
+        )
+        self.observe(
             self._on_show_column_headers_changed,
             "show_column_headers",
             remove=True,
         )
-        obs(self._on_show_row_headers_changed, "show_row_headers", remove=True)
+        self.observe(
+            self._on_show_row_headers_changed, "show_row_headers", remove=True
+        )
 
         self._grid_table_base.dispose()
         self._grid = None
@@ -440,7 +462,7 @@ class Grid(Widget):
             model changes. """
         self._grid.ForceRefresh()
 
-    def _on_model_structure_changed(self, event):
+    def _on_model_structure_changed(self, event=None):
         """ A notification method called when the underlying model has
         changed. Responsible for making sure the view object updates
         correctly. """
@@ -536,7 +558,7 @@ class Grid(Widget):
         self.__autosize()
 
         # Make sure everything updates to reflect the changes:
-        self._on_model_structure_changed(event=None)
+        self._on_model_structure_changed()
 
     def _on_column_sort(self, event):
         """ Handles a column_sorted event from the underlying model. """
@@ -555,17 +577,17 @@ class Grid(Widget):
         self.__autosize()
 
         # make sure everything updates to reflect the changes
-        self._on_model_structure_changed(event=None)
+        self._on_model_structure_changed()
 
-    def _on_enable_lines_changed(self, event):
+    def _on_enable_lines_changed(self, event=None):
         """ Handle a change to the enable_lines trait. """
         self._grid.EnableGridLines(self.enable_lines)
 
-    def _on_grid_line_color_changed(self, event):
+    def _on_grid_line_color_changed(self, event=None):
         """ Handle a change to the enable_lines trait. """
         self._grid.SetGridLineColour(self.grid_line_color)
 
-    def _on_default_label_font_changed(self, event):
+    def _on_default_label_font_changed(self, event=None):
         """ Handle a change to the default_label_font trait. """
 
         font = self.default_label_font
@@ -575,7 +597,7 @@ class Grid(Widget):
 
         self._grid.SetLabelFont(font)
 
-    def _on_default_label_text_color_changed(self, event):
+    def _on_default_label_text_color_changed(self, event=None):
         """ Handle a change to the default_cell_text_color trait. """
 
         if self.default_label_text_color is not None:
@@ -583,7 +605,7 @@ class Grid(Widget):
             self._grid.SetLabelTextColour(color)
             self._grid.ForceRefresh()
 
-    def _on_default_label_bg_color_changed(self, event):
+    def _on_default_label_bg_color_changed(self, event=None):
         """ Handle a change to the default_cell_text_color trait. """
 
         if self.default_label_bg_color is not None:
@@ -591,24 +613,24 @@ class Grid(Widget):
             self._grid.SetLabelBackgroundColour(color)
             self._grid.ForceRefresh()
 
-    def _on_selection_bg_color_changed(self, event):
+    def _on_selection_bg_color_changed(self, event=None):
         """ Handle a change to the selection_bg_color trait. """
         if self.selection_bg_color is not None:
             self._grid.SetSelectionBackground(self.selection_bg_color)
 
-    def _on_selection_text_color_changed(self, event):
+    def _on_selection_text_color_changed(self, event=None):
         """ Handle a change to the selection_text_color trait. """
         if self.selection_text_color is not None:
             self._grid.SetSelectionForeground(self.selection_text_color)
 
-    def _on_default_cell_font_changed(self, event):
+    def _on_default_cell_font_changed(self, event=None):
         """ Handle a change to the default_cell_font trait. """
 
         if self.default_cell_font is not None:
             self._grid.SetDefaultCellFont(self.default_cell_font)
             self._grid.ForceRefresh()
 
-    def _on_default_cell_text_color_changed(self, event):
+    def _on_default_cell_text_color_changed(self, event=None):
         """ Handle a change to the default_cell_text_color trait. """
 
         if self.default_cell_text_color is not None:
@@ -616,7 +638,7 @@ class Grid(Widget):
             self._grid.SetDefaultCellTextColour(color)
             self._grid.ForceRefresh()
 
-    def _on_default_cell_bg_color_changed(self, event):
+    def _on_default_cell_bg_color_changed(self, event=None):
         """ Handle a change to the default_cell_bg_color trait. """
 
         if self.default_cell_bg_color is not None:
@@ -624,7 +646,7 @@ class Grid(Widget):
             self._grid.SetDefaultCellBackgroundColour(color)
             self._grid.ForceRefresh()
 
-    def _on_read_only_changed(self, event):
+    def _on_read_only_changed(self, event=None):
         """ Handle a change to the read_only trait. """
 
         # should the whole grid be read-only?
@@ -633,7 +655,7 @@ class Grid(Widget):
         else:
             self._grid.EnableEditing(True)
 
-    def _on_selection_mode_changed(self, event):
+    def _on_selection_mode_changed(self, event=None):
         """ Handle a change to the selection_mode trait. """
 
         # should we allow individual cells to be selected or only rows
@@ -645,20 +667,20 @@ class Grid(Widget):
         elif self.selection_mode == "cols":
             self._grid.SetSelectionMode(wxGrid.SelectColumns)
 
-    def _on_column_label_height_changed(self, event):
+    def _on_column_label_height_changed(self, event=None):
         """ Handle a change to the column_label_height trait. """
 
         # handle setting for height of column labels
         if self.column_label_height is not None:
             self._grid.SetColLabelSize(self.column_label_height)
 
-    def _on_row_label_width_changed(self, event):
+    def _on_row_label_width_changed(self, event=None):
         """ Handle a change to the row_label_width trait. """
         # handle setting for width of row labels
         if self.row_label_width is not None:
             self._grid.SetRowLabelSize(self.row_label_width)
 
-    def _on_show_column_headers_changed(self, event):
+    def _on_show_column_headers_changed(self, event=None):
         """ Handle a change to the show_column_headers trait. """
 
         if not self.show_column_headers:
@@ -666,7 +688,7 @@ class Grid(Widget):
         else:
             self._grid.SetColLabelSize(self.column_label_height)
 
-    def _on_show_row_headers_changed(self, event):
+    def _on_show_row_headers_changed(self, event=None):
         """ Handle a change to the show_row_headers trait. """
 
         if not self.show_row_headers:
@@ -1238,10 +1260,10 @@ class Grid(Widget):
     def __initialize_fonts(self):
         """ Initialize the label fonts. """
 
-        self._on_default_label_font_changed(event=None)
-        self._on_default_cell_font_changed(event=None)
-        self._on_default_cell_text_color_changed(event=None)
-        self._on_grid_line_color_changed(event=None)
+        self._on_default_label_font_changed()
+        self._on_default_cell_font_changed()
+        self._on_default_cell_text_color_changed()
+        self._on_grid_line_color_changed()
 
         self._grid.SetColLabelAlignment(wx.ALIGN_CENTRE, wx.ALIGN_CENTRE)
         self._grid.SetRowLabelAlignment(wx.ALIGN_RIGHT, wx.ALIGN_CENTRE)
@@ -1291,21 +1313,21 @@ class Grid(Widget):
         self._col_sort_reversed = False
         self._row_sort_reversed = False
 
-    def __initialize_style_settings(self, event=None):
+    def __initialize_style_settings(self):
 
         # make sure all the handlers for traits defining styles get called
-        self._on_enable_lines_changed(event=None)
-        self._on_read_only_changed(event=None)
-        self._on_selection_mode_changed(event=None)
-        self._on_column_label_height_changed(event=None)
-        self._on_row_label_width_changed(event=None)
-        self._on_show_column_headers_changed(event=None)
-        self._on_show_row_headers_changed(event=None)
-        self._on_default_cell_bg_color_changed(event=None)
-        self._on_default_label_bg_color_changed(event=None)
-        self._on_default_label_text_color_changed(event=None)
-        self._on_selection_bg_color_changed(event=None)
-        self._on_selection_text_color_changed(event=None)
+        self._on_enable_lines_changed()
+        self._on_read_only_changed()
+        self._on_selection_mode_changed()
+        self._on_column_label_height_changed()
+        self._on_row_label_width_changed()
+        self._on_show_column_headers_changed()
+        self._on_show_row_headers_changed()
+        self._on_default_cell_bg_color_changed()
+        self._on_default_label_bg_color_changed()
+        self._on_default_label_text_color_changed()
+        self._on_selection_bg_color_changed()
+        self._on_selection_text_color_changed()
 
     def __get_drag_value(self):
         """ Calculates the drag value based on the current selection. """

--- a/pyface/ui/wx/grid/trait_grid_model.py
+++ b/pyface/ui/wx/grid/trait_grid_model.py
@@ -122,21 +122,21 @@ class TraitGridModel(GridModel):
                 self._auto_columns = []
 
         # attach trait handlers to the list object
-        self.on_trait_event(self._on_data_changed, "data")
-        self.on_trait_event(self._on_data_items_changed, "data_items")
+        self.observe(self._on_data_changed, "data")
+        self.observe(self._on_data_items_changed, "data:items")
 
         # attach appropriate trait handlers to objects in the list
         self.__manage_data_listeners(self.data)
 
         # attach a listener to the column definitions so we refresh when
         # they change
-        self.on_trait_change(self._on_columns_changed, "columns")
-        self.on_trait_event(self._on_columns_items_changed, "columns_items")
+        self.observe(self._on_columns_changed, "columns")
+        self.observe(self._on_columns_items_changed, "columns:items")
         # attach listeners to the column definitions themselves
         self.__manage_column_listeners(self.columns)
 
         # attach a listener to the row_name_trait
-        self.on_trait_change(self._on_row_name_trait_changed, "row_name_trait")
+        self.observe(self._on_row_name_trait_changed, "row_name_trait")
 
     # ------------------------------------------------------------------------
     # 'GridModel' interface.
@@ -559,13 +559,13 @@ class TraitGridModel(GridModel):
     # trait handlers
     # ------------------------------------------------------------------------
 
-    def _on_row_name_trait_changed(self, new):
+    def _on_row_name_trait_changed(self, event):
         """ Force the grid to refresh when any underlying trait changes. """
         self.fire_content_changed()
 
-    def _on_columns_changed(self, object, name, old, new):
+    def _on_columns_changed(self, event):
         """ Force the grid to refresh when any underlying trait changes. """
-        self.__manage_column_listeners(old, remove=True)
+        self.__manage_column_listeners(event.old, remove=True)
         self.__manage_column_listeners(self.columns)
         self._auto_columns = self.columns
         self.fire_structure_changed()
@@ -577,14 +577,14 @@ class TraitGridModel(GridModel):
         self.__manage_column_listeners(event.added)
         self.fire_structure_changed()
 
-    def _on_contained_trait_changed(self, new):
+    def _on_contained_trait_changed(self, event):
         """ Force the grid to refresh when any underlying trait changes. """
         self.fire_content_changed()
 
-    def _on_data_changed(self, object, name, old, new):
+    def _on_data_changed(self, event):
         """ Force the grid to refresh when the underlying list changes. """
 
-        self.__manage_data_listeners(old, remove=True)
+        self.__manage_data_listeners(event.old, remove=True)
         self.__manage_data_listeners(self.data)
         self.fire_structure_changed()
 
@@ -684,7 +684,7 @@ class TraitGridModel(GridModel):
         # attach appropriate trait handlers to objects in the list
         if list is not None:
             for item in list:
-                item.on_trait_change(
+                item.observe(
                     self._on_contained_trait_changed, remove=remove
                 )
 
@@ -693,6 +693,6 @@ class TraitGridModel(GridModel):
         if collist is not None:
             for col in collist:
                 if isinstance(col, TraitGridColumn):
-                    col.on_trait_change(
+                    col.observe(
                         self._on_columns_changed, remove=remove
                     )

--- a/pyface/ui/wx/list_box.py
+++ b/pyface/ui/wx/list_box.py
@@ -47,10 +47,10 @@ class ListBox(Widget):
         self._create_control(parent)
 
         # Listen for changes to the model.
-        self.model.on_trait_change(self._on_model_changed, "list_changed")
+        self.model.observe(self._on_model_changed, "list_changed")
 
     def dispose(self):
-        self.model.on_trait_change(
+        self.model.observe(
             self._on_model_changed, "list_changed", remove=True
         )
         self.model.dispose()

--- a/pyface/ui/wx/preference/preference_dialog.py
+++ b/pyface/ui/wx/preference/preference_dialog.py
@@ -134,7 +134,7 @@ class PreferenceDialog(SplitDialog):
             content_provider=DefaultTreeContentProvider(),
         )
 
-        tree_viewer.on_trait_change(self._on_selection_changed, "selection")
+        tree_viewer.observe(self._on_selection_changed, "selection")
 
         return tree_viewer.control
 
@@ -181,9 +181,9 @@ class PreferenceDialog(SplitDialog):
     # Trait event handlers.
     # ------------------------------------------------------------------------
 
-    def _on_selection_changed(self, selection):
+    def _on_selection_changed(self, event):
         """ Called when a node in the tree is selected. """
-
+        selection = event.new
         if len(selection) > 0:
             # The tree is in single selection mode.
             node = selection[0]

--- a/pyface/ui/wx/tree/tree.py
+++ b/pyface/ui/wx/tree/tree.py
@@ -940,7 +940,7 @@ class Tree(Widget):
 
     def _on_structure_changed(self, event):
         """ Called when the structure of a node has changed drastically. """
-        nodee_event = event.new
+        node_event = event.new
         self.refresh(node_event.node)
 
         return

--- a/pyface/ui/wx/tree/tree.py
+++ b/pyface/ui/wx/tree/tree.py
@@ -500,36 +500,28 @@ class Tree(Widget):
         """ Adds listeners for model changes. """
 
         # Listen for changes to the model.
-        model.on_trait_change(self._on_root_changed, "root")
-        model.on_trait_change(self._on_nodes_changed, "nodes_changed")
-        model.on_trait_change(self._on_nodes_inserted, "nodes_inserted")
-        model.on_trait_change(self._on_nodes_removed, "nodes_removed")
-        model.on_trait_change(self._on_nodes_replaced, "nodes_replaced")
-        model.on_trait_change(self._on_structure_changed, "structure_changed")
+        model.observe(self._on_root_changed, "root")
+        model.observe(self._on_nodes_changed, "nodes_changed")
+        model.observe(self._on_nodes_inserted, "nodes_inserted")
+        model.observe(self._on_nodes_removed, "nodes_removed")
+        model.observe(self._on_nodes_replaced, "nodes_replaced")
+        model.observe(self._on_structure_changed, "structure_changed")
 
     def _remove_model_listeners(self, model):
         """ Removes listeners for model changes. """
 
         # Unhook the model event listeners.
-        model.on_trait_change(self._on_root_changed, "root", remove=True)
+        model.observe(self._on_root_changed, "root", remove=True)
 
-        model.on_trait_change(
-            self._on_nodes_changed, "nodes_changed", remove=True
-        )
+        model.observe(self._on_nodes_changed, "nodes_changed", remove=True)
 
-        model.on_trait_change(
-            self._on_nodes_inserted, "nodes_inserted", remove=True
-        )
+        model.observe(self._on_nodes_inserted, "nodes_inserted", remove=True)
 
-        model.on_trait_change(
-            self._on_nodes_removed, "nodes_removed", remove=True
-        )
+        model.observe(self._on_nodes_removed, "nodes_removed", remove=True)
 
-        model.on_trait_change(
-            self._on_nodes_replaced, "nodes_replaced", remove=True
-        )
+        model.observe(self._on_nodes_replaced, "nodes_replaced", remove=True)
 
-        model.on_trait_change(
+        model.observe(
             self._on_structure_changed, "structure_changed", remove=True
         )
 
@@ -817,9 +809,9 @@ class Tree(Widget):
 
     # Trait event handlers -------------------------------------------------
 
-    def _on_root_changed(self, root):
+    def _on_root_changed(self, event):
         """ Called when the root of the model has changed. """
-
+        root = event.new
         # Delete everything...
         if self.control is not None:
             self.control.DeleteAllItems()
@@ -832,20 +824,19 @@ class Tree(Widget):
 
     def _on_nodes_changed(self, event):
         """ Called when nodes have been changed. """
-
-        self._update_node(self._get_wxid(event.node), event.node)
-
-        for child in event.children:
+        node_event = event.new
+        self._update_node(self._get_wxid(node_event.node), node_event.node)
+        for child in node_event.children:
             cid = self._get_wxid(child)
             if cid is not None:
                 self._update_node(cid, child)
 
     def _on_nodes_inserted(self, event):
         """ Called when nodes have been inserted. """
-
-        parent = event.node
-        children = event.children
-        index = event.index
+        node_event = event.new
+        parent = node_event.node
+        children = node_event.children
+        index = node_event.index
 
         # Has the node actually appeared in the tree yet?
         pid = self._get_wxid(parent)
@@ -889,14 +880,14 @@ class Tree(Widget):
 
     def _on_nodes_removed(self, event):
         """ Called when nodes have been removed. """
-
-        parent = event.node
-        children = event.children
+        node_event = event.new
+        parent = node_event.node
+        children = node_event.children
 
         # Has the node actually appeared in the tree yet?
         pid = self._get_wxid(parent)
         if pid is not None:
-            for child in event.children:
+            for child in node_event.children:
                 cid = self._get_wxid(child)
                 if cid is not None:
                     self.control.Delete(cid)
@@ -907,8 +898,9 @@ class Tree(Widget):
 
     def _on_nodes_replaced(self, event):
         """ Called when nodes have been replaced. """
-
-        for old_child, new_child in zip(event.old_children, event.children):
+        node_event = event.new
+        old_new_children = zip(node_event.old_children, node_event.children)
+        for old_child, new_child in old_new_children:
             cid = self._get_wxid(old_child)
             if cid is not None:
                 # Remove listeners from the old node.
@@ -948,8 +940,8 @@ class Tree(Widget):
 
     def _on_structure_changed(self, event):
         """ Called when the structure of a node has changed drastically. """
-
-        self.refresh(event.node)
+        nodee_event = event.new
+        self.refresh(node_event.node)
 
         return
 

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -125,13 +125,13 @@ class TableViewer(ContentViewer):
     # Trait event handlers.
     # ------------------------------------------------------------------------
 
-    def _on_input_changed(self, obj, trait_name, old, new):
+    def _on_input_changed(self,event):
         """ Called when the input is changed. """
 
         # Update the table contents.
         self._update_contents()
 
-        if old is None:
+        if event.old is None:
             self._update_column_widths()
 
         return

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -125,7 +125,7 @@ class TableViewer(ContentViewer):
     # Trait event handlers.
     # ------------------------------------------------------------------------
 
-    def _on_input_changed(self,event):
+    def _on_input_changed(self, event):
         """ Called when the input is changed. """
 
         # Update the table contents.

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -93,7 +93,7 @@ class TableViewer(ContentViewer):
 
         # We use a dynamic handler instead of a static handler here, as we
         # don't want to react if the input is set in the constructor.
-        self.on_trait_change(self._on_input_changed, "input")
+        self.observe(self._on_input_changed, "input")
 
         return
 

--- a/pyface/undo/action/abstract_command_stack_action.py
+++ b/pyface/undo/action/abstract_command_stack_action.py
@@ -49,7 +49,7 @@ class AbstractCommandStackAction(Action):
 
         super(AbstractCommandStackAction, self).__init__(**traits)
 
-        self.undo_manager.on_trait_event(
+        self.undo_manager.observe(
             self._on_stack_updated, "stack_updated"
         )
 
@@ -68,7 +68,7 @@ class AbstractCommandStackAction(Action):
 
         """
 
-        self.undo_manager.on_trait_event(
+        self.undo_manager.observe(
             self._on_stack_updated, "stack_updated", remove=True
         )
 
@@ -85,9 +85,9 @@ class AbstractCommandStackAction(Action):
     # Private interface.
     ###########################################################################
 
-    def _on_stack_updated(self, stack):
+    def _on_stack_updated(self, event):
         """ Handle changes to the state of a command stack. """
-
+        stack = event.new
         # Ignore unless it is the active stack.
         if stack is self.undo_manager.active_stack:
             self._update_action()

--- a/pyface/workbench/action/toggle_view_visibility_action.py
+++ b/pyface/workbench/action/toggle_view_visibility_action.py
@@ -68,7 +68,7 @@ class ToggleViewVisibilityAction(WorkbenchAction):
         if new is not None:
             self._add_view_listeners(new)
 
-        self._refresh_checked(event=None)
+        self._refresh_checked()
 
         return
 
@@ -86,7 +86,7 @@ class ToggleViewVisibilityAction(WorkbenchAction):
         view.observe(self._refresh_checked, "visible", remove=True)
         view.observe(self._refresh_checked, "window", remove=True)
 
-    def _refresh_checked(self, event):
+    def _refresh_checked(self, event=None):
         """ Refresh the checked state of the action. """
 
         self.checked = (

--- a/pyface/workbench/action/toggle_view_visibility_action.py
+++ b/pyface/workbench/action/toggle_view_visibility_action.py
@@ -68,7 +68,7 @@ class ToggleViewVisibilityAction(WorkbenchAction):
         if new is not None:
             self._add_view_listeners(new)
 
-        self._refresh_checked()
+        self._refresh_checked(event=None)
 
         return
 
@@ -77,16 +77,16 @@ class ToggleViewVisibilityAction(WorkbenchAction):
     def _add_view_listeners(self, view):
         """ Add listeners for trait events on a view. """
 
-        view.on_trait_change(self._refresh_checked, "visible")
-        view.on_trait_change(self._refresh_checked, "window")
+        view.observe(self._refresh_checked, "visible")
+        view.observe(self._refresh_checked, "window")
 
     def _remove_view_listeners(self, view):
         """ Add listeners for trait events on a view. """
 
-        view.on_trait_change(self._refresh_checked, "visible", remove=True)
-        view.on_trait_change(self._refresh_checked, "window", remove=True)
+        view.observe(self._refresh_checked, "visible", remove=True)
+        view.observe(self._refresh_checked, "window", remove=True)
 
-    def _refresh_checked(self):
+    def _refresh_checked(self, event):
         """ Refresh the checked state of the action. """
 
         self.checked = (

--- a/pyface/wx/grid/grid.py
+++ b/pyface/wx/grid/grid.py
@@ -54,7 +54,7 @@ class Grid(wxGrid):
         #
         # fixme: We should create a default model if one is not supplied.
         self.SetTable(model._grid_table_base, True)
-        model.on_trait_change(self._on_model_changed, "model_changed")
+        model.observe(self._on_model_changed, "model_changed")
 
         self.Bind(wx.grid.EVT_GRID_CELL_CHANGE, self._on_cell_change)
         self.Bind(wx.grid.EVT_GRID_SELECT_CELL, self._on_select_cell)

--- a/pyface/wx/grid/grid.py
+++ b/pyface/wx/grid/grid.py
@@ -216,9 +216,9 @@ class Grid(wxGrid):
     # Trait event handlers.
     # ------------------------------------------------------------------------
 
-    def _on_model_changed(self, message):
+    def _on_model_changed(self, event):
         """ Called when the model has changed. """
-
+        message = event.new
         self.BeginBatch()
         self.ProcessTableMessage(message)
         self.EndBatch()


### PR DESCRIPTION
closes #637 
closes #732 

This PR makes the last round of updates to replace use of `on_trait_change` with `observe`.  With the changes in this PR, `on_trait_change` is no longer present anywhere in the code base.  This PR also makes an update to the documentation section on `timers`.  Please confirm the changes made there are reasonable.  

Note to reviewer, be cautious: some of the code undergoing changes in this PR is not covered by the test suite.  I made some knowingly broken changes and ran the test suite only to find everything still passing. 

This PR also drive by removes some commented out code from the code base.