### PR TITLE
Replace depends_on with observe in properties

### DIFF
--- a/examples/application/python_editor/python_editor.py
+++ b/examples/application/python_editor/python_editor.py
@@ -67,10 +67,10 @@ class PythonEditor(TraitsEditor):
     code = Str()
 
     #: Whether or not undo operation is possible.
-    can_undo = Property(Bool, depends_on="ui.history.undoable")
+    can_undo = Property(Bool, observe="ui.history.undoable")
 
     #: Whether or not redo operation is possible.
-    can_redo = Property(Bool, depends_on="ui.history.redoable")
+    can_redo = Property(Bool, observe="ui.history.redoable")
 
     #: The current cursor line.
     line = Int(1)
@@ -82,7 +82,7 @@ class PythonEditor(TraitsEditor):
     selection = Str()
 
     #: The length of the currently selected text.
-    selection_length = Property(Int, depends_on="selection")
+    selection_length = Property(Int, observe="selection")
 
     #: The start of the currently selected text, if any.
     selection_start = Int()
@@ -99,12 +99,12 @@ class PythonEditor(TraitsEditor):
     obj = File()
 
     #: The editor's user-visible name.
-    name = Property(Str, depends_on="obj")
+    name = Property(Str, observe="obj")
 
     #: The tooltip for the editor.
-    tooltip = Property(Str, depends_on="obj")
+    tooltip = Property(Str, observe="obj")
 
-    dirty = Property(Bool, depends_on=["obj", "_last_save", "ui.history.now"])
+    dirty = Property(Bool, observe=["obj", "_last_save", "ui.history.now"])
 
     # -------------------------------------------------------------------------
     # PythonTextEditor interface

--- a/examples/application/python_editor/python_editor_task.py
+++ b/examples/application/python_editor/python_editor_task.py
@@ -91,7 +91,7 @@ class PythonEditorTask(Task):
 
     #: The currently active editor in the editor area, if any.
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     #: The editor area for this task.

--- a/examples/tasks/advanced/example_task.py
+++ b/examples/tasks/advanced/example_task.py
@@ -38,7 +38,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/advanced/python_editor_qt4.py
+++ b/examples/tasks/advanced/python_editor_qt4.py
@@ -38,9 +38,9 @@ class PythonEditor(Editor):
 
     dirty = Bool(False)
 
-    name = Property(Str, depends_on="path")
+    name = Property(Str, observe="path")
 
-    tooltip = Property(Str, depends_on="path")
+    tooltip = Property(Str, observe="path")
 
     show_line_numbers = Bool(True)
 

--- a/examples/tasks/advanced/python_editor_wx.py
+++ b/examples/tasks/advanced/python_editor_wx.py
@@ -40,9 +40,9 @@ class PythonEditor(Editor):
 
     dirty = Bool(False)
 
-    name = Property(Str, depends_on="path")
+    name = Property(Str, observe="path")
 
-    tooltip = Property(Str, depends_on="path")
+    tooltip = Property(Str, observe="path")
 
     show_line_numbers = Bool(True)
 

--- a/examples/tasks/steps/mac-menubar-switching.py
+++ b/examples/tasks/steps/mac-menubar-switching.py
@@ -51,7 +51,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step2.py
+++ b/examples/tasks/steps/step2.py
@@ -43,7 +43,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step3.py
+++ b/examples/tasks/steps/step3.py
@@ -53,7 +53,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step4.py
+++ b/examples/tasks/steps/step4.py
@@ -59,7 +59,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step5.py
+++ b/examples/tasks/steps/step5.py
@@ -71,7 +71,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step6.py
+++ b/examples/tasks/steps/step6.py
@@ -100,7 +100,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step6a.py
+++ b/examples/tasks/steps/step6a.py
@@ -100,7 +100,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step7.py
+++ b/examples/tasks/steps/step7.py
@@ -93,7 +93,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/examples/tasks/steps/step8.py
+++ b/examples/tasks/steps/step8.py
@@ -93,7 +93,7 @@ class ExampleTask(Task):
     name = "Multi-Tab Editor"
 
     active_editor = Property(
-        Instance(IEditor), depends_on="editor_area.active_editor"
+        Instance(IEditor), observe="editor_area.active_editor"
     )
 
     editor_area = Instance(IEditorAreaPane)

--- a/pyface/action/gui_application_action.py
+++ b/pyface/action/gui_application_action.py
@@ -28,7 +28,7 @@ class GUIApplicationAction(ListeningAction):
 
     # 'ListeningAction' interface --------------------------------------------
 
-    object = Property(depends_on="application")
+    object = Property(observe="application")
 
     # 'WindowAction' interface -----------------------------------------------
 
@@ -53,7 +53,7 @@ class ActiveWindowAction(GUIApplicationAction):
 
     # 'ListeningAction' interface --------------------------------------------
 
-    object = Property(depends_on="application.active_window")
+    object = Property(observe="application.active_window")
 
     # ------------------------------------------------------------------------
     # Protected interface.

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -16,7 +16,7 @@ import logging
 
 
 from pyface.action.action import Action
-from traits.api import Any, Str
+from traits.api import Any, Str, Undefined
 from traits.observation.api import trait
 
 # Logging.
@@ -125,7 +125,7 @@ class ListeningAction(Action):
         for kind in ("enabled", "visible"):
             method = getattr(self, "_%s_update" % kind)
             name = getattr(self, "%s_name" % kind)
-            if old:
+            if old and old is not Undefined:
                 old.observe(method, trait(name, optional=True), remove=True)
             if new:
                 new.observe(method, trait(name, optional=True))

--- a/pyface/action/window_action.py
+++ b/pyface/action/window_action.py
@@ -25,7 +25,7 @@ class WindowAction(ListeningAction):
 
     # 'ListeningAction' interface --------------------------------------------
 
-    object = Property(depends_on="window")
+    object = Property(observe="window")
 
     # 'WindowAction' interface -----------------------------------------------
 

--- a/pyface/color.py
+++ b/pyface/color.py
@@ -62,34 +62,34 @@ class Color(HasStrictTraits):
     rgba = AlphaChannelTuple()
 
     #: A tuple holding the red, green, and blue channels.
-    rgb = Property(ChannelTuple(), depends_on='rgba')
+    rgb = Property(ChannelTuple(), observe='rgba')
 
     #: The red channel.
-    red = Property(Channel, depends_on='rgba')
+    red = Property(Channel, observe='rgba')
 
     #: The green channel.
-    green = Property(Channel, depends_on='rgba')
+    green = Property(Channel, observe='rgba')
 
     #: The blue channel.
-    blue = Property(Channel, depends_on='rgba')
+    blue = Property(Channel, observe='rgba')
 
     #: The alpha channel.
-    alpha = Property(Channel, depends_on='rgba')
+    alpha = Property(Channel, observe='rgba')
 
     #: A tuple holding the hue, saturation, value, and alpha channels.
-    hsva = Property(AlphaChannelTuple, depends_on='rgba')
+    hsva = Property(AlphaChannelTuple, observe='rgba')
 
     #: A tuple holding the hue, saturation, and value channels.
-    hsv = Property(ChannelTuple, depends_on='rgb')
+    hsv = Property(ChannelTuple, observe='rgb')
 
     #: A tuple holding the hue, lightness, saturation, and alpha channels.
-    hlsa = Property(AlphaChannelTuple, depends_on='rgba')
+    hlsa = Property(AlphaChannelTuple, observe='rgba')
 
     #: A tuple holding the hue, lightness, and saturation channels.
-    hls = Property(ChannelTuple, depends_on='rgb')
+    hls = Property(ChannelTuple, observe='rgb')
 
     #: Whether the color is dark for contrast purposes.
-    is_dark = Property(Bool, depends_on='rgba')
+    is_dark = Property(Bool, observe='rgba')
 
     @classmethod
     def from_str(cls, text, **traits):

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -75,7 +75,7 @@ class MDataViewWidget(HasStrictTraits):
 
     #: The selected indices in the view.  This should never be mutated, any
     #: changes should be by replacement of the entire list.
-    selection = Property(depends_on='_selection[]')
+    selection = Property(observe='_selection.items')
 
     #: Exporters available for the DataViewWidget.
     exporters = List(Instance(AbstractDataExporter))

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -367,7 +367,7 @@ class DockItem(HasPrivateTraits):
     parent = Any()
 
     # The DockWindow that owns this item:
-    owner = Property(depends_on="parent")
+    owner = Property(observe="parent")
 
     # Bounds of the item:
     bounds = Bounds
@@ -385,10 +385,10 @@ class DockItem(HasPrivateTraits):
     tab_state = Any()
 
     # The tab displayable version of the control's UI name:
-    tab_name = Property(depends_on="name")
+    tab_name = Property(observe="name")
 
     # Width of the item's tab:
-    tab_width = Property(depends_on="control, tab_state, tab_name")
+    tab_width = Property(observe="control, tab_state, tab_name")
 
     # The DockWindowTheme for this item's DockWindow:
     theme = Property

--- a/pyface/fields/i_spin_field.py
+++ b/pyface/fields/i_spin_field.py
@@ -29,10 +29,10 @@ class ISpinField(IField):
     bounds = Tuple(Int, Int)
 
     #: The minimum value
-    minimum = Property(Int, depends_on="bounds")
+    minimum = Property(Int, observe="bounds")
 
     #: The maximum value
-    maximum = Property(Int, depends_on="bounds")
+    maximum = Property(Int, observe="bounds")
 
 
 class MSpinField(HasTraits):
@@ -44,10 +44,10 @@ class MSpinField(HasTraits):
     bounds = Tuple(Int, Int)
 
     #: The minimum value for the spinner
-    minimum = Property(Int, depends_on="bounds")
+    minimum = Property(Int, observe="bounds")
 
     #: The maximum value for the spinner
-    maximum = Property(Int, depends_on="bounds")
+    maximum = Property(Int, observe="bounds")
 
     # ------------------------------------------------------------------------
     # object interface

--- a/pyface/image/image.py
+++ b/pyface/image/image.py
@@ -520,7 +520,7 @@ class ImageVolume(HasPrivateTraits):
     images = List(ImageInfo)
 
     #: A dictionary mapping image names to ImageInfo objects:
-    catalog = Property(depends_on="images")
+    catalog = Property(observe="images")
 
     #: The time stamp of when the image library was last modified:
     time_stamp = Str()
@@ -956,7 +956,7 @@ class ImageLibrary(HasPrivateTraits):
     catalog = Dict(Str, ImageVolume)
 
     #: The list of available images in the library:
-    images = Property(List, depends_on="volumes.images")
+    images = Property(List, observe="volumes.items.images")
 
     # -- Private Traits ---------------------------------------------------------
 

--- a/pyface/tasks/action/dock_pane_toggle_group.py
+++ b/pyface/tasks/action/dock_pane_toggle_group.py
@@ -34,9 +34,9 @@ class DockPaneToggleAction(Action):
 
     # 'Action' interface ---------------------------------------------------
 
-    name = Property(Str, depends_on="dock_pane.name")
+    name = Property(Str, observe="dock_pane.name")
     style = "toggle"
-    tooltip = Property(Str, depends_on="name")
+    tooltip = Property(Str, observe="name")
 
     # ------------------------------------------------------------------------
     # 'Action' interface.
@@ -89,7 +89,7 @@ class DockPaneToggleGroup(Group):
 
     # 'DockPaneToggleGroup' interface -------------------------------------#
 
-    task = Property(depends_on="parent.controller")
+    task = Property(observe="parent.controller")
 
     @cached_property
     def _get_task(self):
@@ -100,7 +100,7 @@ class DockPaneToggleGroup(Group):
 
         return manager.controller.task
 
-    dock_panes = Property(depends_on="task.window._states.dock_panes")
+    dock_panes = Property(observe="task.window._states.items.dock_panes")
 
     @cached_property
     def _get_dock_panes(self):

--- a/pyface/tasks/action/task_action.py
+++ b/pyface/tasks/action/task_action.py
@@ -25,7 +25,7 @@ class TaskAction(ListeningAction):
 
     # ListeningAction interface --------------------------------------------
 
-    object = Property(depends_on="task")
+    object = Property(observe="task")
 
     # TaskAction interface -------------------------------------------------
 
@@ -51,7 +51,7 @@ class TaskWindowAction(TaskAction):
 
     # ListeningAction interface --------------------------------------------
 
-    object = Property(depends_on="task.window")
+    object = Property(observe="task.window")
 
     # ------------------------------------------------------------------------
     # Protected interface.
@@ -69,12 +69,12 @@ class CentralPaneAction(TaskAction):
 
     # ListeningAction interface --------------------------------------------
 
-    object = Property(depends_on="central_pane")
+    object = Property(observe="central_pane")
 
     # CentralPaneAction interface -----------------------------------------#
 
     #: The central pane with which the action is associated.
-    central_pane = Property(Instance(TaskPane), depends_on="task")
+    central_pane = Property(Instance(TaskPane), observe="task")
 
     # ------------------------------------------------------------------------
     # Protected interface.
@@ -96,12 +96,12 @@ class DockPaneAction(TaskAction):
 
     # ListeningAction interface --------------------------------------------
 
-    object = Property(depends_on="dock_pane")
+    object = Property(observe="dock_pane")
 
     # DockPaneAction interface ---------------------------------------------
 
     #: The dock pane with which the action is associated. Set by the framework.
-    dock_pane = Property(Instance(TaskPane), depends_on="task")
+    dock_pane = Property(Instance(TaskPane), observe="task")
 
     #: The ID of the dock pane with which the action is associated.
     dock_pane_id = Str()
@@ -126,13 +126,13 @@ class EditorAction(CentralPaneAction):
 
     # ListeningAction interface --------------------------------------------
 
-    object = Property(depends_on="active_editor")
+    object = Property(observe="active_editor")
 
     # EditorAction interface -----------------------------------------------
 
     #: The active editor in the central pane with which the action is associated.
     active_editor = Property(
-        Instance(Editor), depends_on="central_pane.active_editor"
+        Instance(Editor), observe="central_pane.active_editor"
     )
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/action/task_toggle_group.py
+++ b/pyface/tasks/action/task_toggle_group.py
@@ -24,13 +24,13 @@ class TaskToggleAction(Action):
     # 'Action' interface ---------------------------------------------------
 
     #: The user-visible name of the action, matches the task name.
-    name = Property(Str, depends_on="task.name")
+    name = Property(Str, observe="task.name")
 
     #: The action is a toggle menu item.
     style = "toggle"
 
     #: The tooltip to display for the menu item.
-    tooltip = Property(Str, depends_on="name")
+    tooltip = Property(Str, observe="name")
 
     # 'TaskToggleAction' interface -----------------------------------------
 

--- a/pyface/tasks/action/task_window_toggle_group.py
+++ b/pyface/tasks/action/task_window_toggle_group.py
@@ -20,7 +20,7 @@ class TaskWindowToggleAction(Action):
     # 'Action' interface -----------------------------------------------------
 
     #: The name of the action for the window.
-    name = Property(Str, depends_on="window.title")
+    name = Property(Str, observe="window.title")
 
     #: The action is a toggle action.
     style = "toggle"

--- a/pyface/tasks/i_editor.py
+++ b/pyface/tasks/i_editor.py
@@ -88,7 +88,7 @@ class MEditor(HasTraits):
     dirty = Bool(False)
 
     editor_area = Instance("pyface.tasks.i_editor_area_pane.IEditorAreaPane")
-    is_active = Property(Bool, depends_on="editor_area.active_editor")
+    is_active = Property(Bool, observe="editor_area.active_editor")
     has_focus = Bool(False)
 
     closing = VetoableEvent()

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -50,7 +50,7 @@ class TaskWindow(ApplicationWindow):
     # IWindow interface ----------------------------------------------------
 
     #: Unless a title is specifically assigned, delegate to the active task.
-    title = Property(Str, depends_on=["active_task.name", "_title"])
+    title = Property(Str, observe=["active_task.name", "_title"])
 
     # TaskWindow interface ------------------------------------------------
 

--- a/pyface/tasks/tasks_application.py
+++ b/pyface/tasks/tasks_application.py
@@ -71,7 +71,7 @@ class TasksApplication(GUIApplication):
     tasks = List(Instance("pyface.tasks.task.Task"))
 
     #: Currently active Task if any.
-    active_task = Property(depends_on="active_window.active_task")
+    active_task = Property(observe="active_window.active_task")
 
     #: List of all application task factories.
     task_factories = List()

--- a/pyface/timer/i_timer.py
+++ b/pyface/timer/i_timer.py
@@ -138,7 +138,7 @@ class BaseTimer(ABCHasTraits):
     expire = Either(None, Float)
 
     #: Property that controls the state of the timer.
-    active = Property(Bool, depends_on="_active")
+    active = Property(Bool, observe="_active")
 
     # Private interface ------------------------------------------------------
 

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -79,7 +79,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     _private_drop_handlers = List(IDropHandler)
     _all_drop_handlers = Property(
         List(IDropHandler),
-        depends_on=["drop_handlers", "_private_drop_handlers"],
+        observe=["drop_handlers", "_private_drop_handlers"],
     )
 
     def __private_drop_handlers_default(self):


### PR DESCRIPTION
This PR is part of the transition to depending on traits 6.2.  This PR replaces all use of `depends_on` with `observe` in property definitions throughout the code base.  I did so via VS code find an replace, but manually went through to confirm the changes/updated a couple occurrences where we observed containers and needed to use the updated traits mini language.