### PR TITLE
Remove unneeded setting of comparison_mode

### DIFF
--- a/docs/source/examples/dict_data_model.py
+++ b/docs/source/examples/dict_data_model.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import ComparisonMode, Dict, Instance, Str, observe
+from traits.api import Dict, Instance, Str, observe
 
 from pyface.data_view.api import (
     AbstractDataModel, AbstractValueType, DataViewSetError, IntIndexManager
@@ -19,7 +19,7 @@ class DictDataModel(AbstractDataModel):
     """ A data model that provides data from a dictionary. """
 
     #: The dictionary containing the data.
-    data = Dict(comparison_mode=ComparisonMode.identity)
+    data = Dict()
 
     #: The index manager.  Because the data is flat, we use the
     #: IntIndexManager.

--- a/examples/data_view/column_data_model.py
+++ b/examples/data_view/column_data_model.py
@@ -11,7 +11,7 @@
 from abc import abstractmethod
 
 from traits.api import (
-    ABCHasStrictTraits, ComparisonMode, Event, HasTraits, Instance,
+    ABCHasStrictTraits, Event, HasTraits, Instance,
     List, Str, observe
 )
 from traits.trait_base import xgetattr, xsetattr
@@ -30,10 +30,7 @@ class AbstractRowInfo(ABCHasStrictTraits):
     title = Str()
 
     #: The child rows of this row, if any.
-    rows = List(
-        Instance('AbstractRowInfo'),
-        comparison_mode=ComparisonMode.identity,
-    )
+    rows = List(Instance('AbstractRowInfo'))
 
     #: The value type of the data stored in this row.
     title_type = Instance(
@@ -155,10 +152,7 @@ class ColumnDataModel(AbstractDataModel):
     """
 
     #: A list of objects to display in columns.
-    data = List(
-        Instance(HasTraits),
-        comparison_mode=ComparisonMode.identity,
-    )
+    data = List(Instance(HasTraits))
 
     #: An object which describes how to map data for each row.
     row_info = Instance(AbstractRowInfo)


### PR DESCRIPTION
As of traits 6.2 it is no longer necessary to specify a trait comparison mode of `ComparisonMode.identity`.  This PR simply removes a couple of occurrences of that from examples in the code base.