### PR TITLE
Bump version for continued development (7.4.x)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ from setuptools import setup, find_packages
 # together with information from the version control system, and then injected
 # into the package source.
 MAJOR = 7
-MINOR = 3
+MINOR = 4
 MICRO = 0
 PRERELEASE = ""
 IS_RELEASED = False


### PR DESCRIPTION
This PR simply bumps the version number in setup.py for continued development in advance of the 7.3.0 minor release.