### PR TITLE
listen to correct trait name

### DIFF
--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -259,7 +259,7 @@ class Grid(Widget):
         self.observe(
             self._on_default_cell_bg_color_changed, "default_cell_bg_color"
         )
-        self.observe(self._on_read_only_changed, "read_only_changed")
+        self.observe(self._on_read_only_changed, "read_only")
         self.observe(self._on_selection_mode_changed, "selection_mode")
         self.observe(
             self._on_column_label_height_changed, "column_label_height"
@@ -414,7 +414,7 @@ class Grid(Widget):
             remove=True,
         )
         self.observe(
-            self._on_read_only_changed, "read_only_changed", remove=True
+            self._on_read_only_changed, "read_only", remove=True
         )
         self.observe(
             self._on_selection_mode_changed, "selection_mode", remove=True


### PR DESCRIPTION
This PR fixes a bug found via the traitsui cron job, see https://github.com/enthought/traitsui/actions/runs/619678526 

Previously we were trying to listen to a trait `read_only_changed` which didn't exist.  we meant to listen to `read_only`.
The new test failures surfaced from the switch from `on_trait_change` to `observe`.  The code was still broken before (we were trying to listen to a non-existent trait), `on_trait_change` was just quiet about it.

Unfortunately the relevant code does not seem to be under test in `pyface` itself?  I did not see any pyface wx test suite failures, but I used pyface from this branch on the traitsUI wx test suite and saw this resolved the errors.  
The allowed wx failures do let things like this slip by though 😬 