### PR TITLE
Add missing trait definitions on DockItem

### DIFF
--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -366,11 +366,17 @@ class DockItem(HasPrivateTraits):
     # The parent of this item:
     parent = Any()
 
+    # The control of this item:
+    control = Any()
+
     # The DockWindow that owns this item:
     owner = Property(observe="parent")
 
     # Bounds of the item:
     bounds = Bounds
+
+    # The user-visible name of the item:
+    name = Str()
 
     # Current width of the item:
     width = Int(-1)

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -366,8 +366,8 @@ class DockItem(HasPrivateTraits):
     # The parent of this item:
     parent = Any()
 
-    # The control of this item:
-    control = Any()
+    # The control associated with this item (used in subclasses):
+    control = Instance(wx.Control)
 
     # The DockWindow that owns this item:
     owner = Property(observe="parent")
@@ -375,7 +375,7 @@ class DockItem(HasPrivateTraits):
     # Bounds of the item:
     bounds = Bounds
 
-    # The user-visible name of the item:
+    # The name of this item (used in subclasses):
     name = Str()
 
     # Current width of the item:
@@ -425,12 +425,6 @@ class DockItem(HasPrivateTraits):
 
     # Current active set of features:
     active_features = Property
-
-    # The name of this item (implemented in subclasses):
-    # name = Str()
-
-    # The control associated with this item (implemented in subclasses):
-    # control = Instance( wx.Control )
 
     # ---------------------------------------------------------------------------
     #  Implementation of the 'owner' property:


### PR DESCRIPTION
fixes #901

This commit adds the missing `control` and `name` traits on the `DockItem` class, which other dock classes inherit from.