### PR TITLE
Allow passing a text format to a MessageDialog

### DIFF
--- a/pyface/i_window.py
+++ b/pyface/i_window.py
@@ -120,7 +120,12 @@ class IWindow(IWidget):
         """
 
     def information(
-        self, message, title="Information", detail="", informative=""
+        self,
+        message,
+        title="Information",
+        detail="",
+        informative="",
+        text_format="auto"
     ):
         """ Convenience method to show an information message dialog.
 
@@ -134,10 +139,20 @@ class IWindow(IWidget):
             Further details about the message.
         informative : str
             Explanatory text to display along with the message.
+        text_format : str
+            Specifies what text format to use in the resulting message dialog.
+            One of "auto", "plain", or "rich".
 
         """
 
-    def warning(self, message, title="Warning", detail="", informative=""):
+    def warning(
+        self,
+        message,
+        title="Warning",
+        detail="",
+        informative="",
+        text_format="auto"
+    ):
         """ Convenience method to show a warning message dialog.
 
         Parameters
@@ -150,10 +165,20 @@ class IWindow(IWidget):
             Further details about the message.
         informative : str
             Explanatory text to display along with the message.
+        text_format : str
+            Specifies what text format to use in the resulting message dialog.
+            One of "auto", "plain", or "rich".
 
         """
 
-    def error(self, message, title="Error", detail="", informative=""):
+    def error(
+        self,
+        message,
+        title="Error",
+        detail="",
+        informative="",
+        text_format="auto"
+    ):
         """ Convenience method to show an error message dialog.
 
         Parameters
@@ -166,6 +191,9 @@ class IWindow(IWidget):
             Further details about the message.
         informative : str
             Explanatory text to display along with the message.
+        text_format : str
+            Specifies what text format to use in the resulting message dialog.
+            One of "auto", "plain", or "rich".
 
         """
 
@@ -254,7 +282,12 @@ class MWindow(HasTraits):
         return confirm(self.control, message, title, cancel, default)
 
     def information(
-        self, message, title="Information", detail="", informative=""
+        self,
+        message,
+        title="Information",
+        detail="",
+        informative="",
+        text_format="auto"
     ):
         """ Convenience method to show an information message dialog.
 
@@ -268,13 +301,25 @@ class MWindow(HasTraits):
             Further details about the message.
         informative : str
             Explanatory text to display along with the message.
+        text_format : str
+            Specifies what text format to use in the resulting message dialog.
+            One of "auto", "plain", or "rich".
 
         """
         from .message_dialog import information
 
-        information(self.control, message, title, detail, informative)
+        information(
+            self.control, message, title, detail, informative, text_format
+        )
 
-    def warning(self, message, title="Warning", detail="", informative=""):
+    def warning(
+        self,
+        message,
+        title="Warning",
+        detail="",
+        informative="",
+        text_format="auto"
+    ):
         """ Convenience method to show a warning message dialog.
 
         Parameters
@@ -287,13 +332,25 @@ class MWindow(HasTraits):
             Further details about the message.
         informative : str
             Explanatory text to display along with the message.
+        text_format : str
+            Specifies what text format to use in the resulting message dialog.
+            One of "auto", "plain", or "rich".
 
         """
         from .message_dialog import warning
 
-        warning(self.control, message, title, detail, informative)
+        warning(
+            self.control, message, title, detail, informative, text_format
+        )
 
-    def error(self, message, title="Error", detail="", informative=""):
+    def error(
+        self,
+        message,
+        title="Error",
+        detail="",
+        informative="",
+        text_format="auto"
+    ):
         """ Convenience method to show an error message dialog.
 
         Parameters
@@ -306,8 +363,11 @@ class MWindow(HasTraits):
             Further details about the message.
         informative : str
             Explanatory text to display along with the message.
+        text_format : str
+            Specifies what text format to use in the resulting message dialog.
+            One of "auto", "plain", or "rich".
 
         """
         from .message_dialog import error
 
-        error(self.control, message, title, detail, informative)
+        error(self.control, message, title, detail, informative, text_format)

--- a/pyface/i_window.py
+++ b/pyface/i_window.py
@@ -303,7 +303,8 @@ class MWindow(HasTraits):
             Explanatory text to display along with the message.
         text_format : str
             Specifies what text format to use in the resulting message dialog.
-            One of "auto", "plain", or "rich".
+            One of "auto", "plain", or "rich". Only supported on the qt
+            backend.
 
         """
         from .message_dialog import information
@@ -334,7 +335,8 @@ class MWindow(HasTraits):
             Explanatory text to display along with the message.
         text_format : str
             Specifies what text format to use in the resulting message dialog.
-            One of "auto", "plain", or "rich".
+            One of "auto", "plain", or "rich". Only supported on the qt
+            backend.
 
         """
         from .message_dialog import warning
@@ -365,7 +367,8 @@ class MWindow(HasTraits):
             Explanatory text to display along with the message.
         text_format : str
             Specifies what text format to use in the resulting message dialog.
-            One of "auto", "plain", or "rich".
+            One of "auto", "plain", or "rich". Only supported on the qt
+            backend.
 
         """
         from .message_dialog import error

--- a/pyface/message_dialog.py
+++ b/pyface/message_dialog.py
@@ -13,7 +13,12 @@
 
 # Convenience functions.
 def information(
-    parent, message, title="Information", detail="", informative=""
+    parent,
+    message,
+    title="Information",
+    detail="",
+    informative="",
+    text_format="auto"
 ):
     """ Convenience method to show an information message dialog.
 
@@ -39,11 +44,19 @@ def information(
         severity="information",
         detail=detail,
         informative=informative,
+        text_format=text_format,
     )
     dialog.open()
 
 
-def warning(parent, message, title="Warning", detail="", informative=""):
+def warning(
+    parent,
+    message,
+    title="Warning",
+    detail="",
+    informative="",
+    text_format="auto"
+):
     """ Convenience function to show a warning message dialog.
 
     Parameters
@@ -68,11 +81,18 @@ def warning(parent, message, title="Warning", detail="", informative=""):
         severity="warning",
         detail=detail,
         informative=informative,
+        text_format=text_format,
     )
     dialog.open()
 
 
-def error(parent, message, title="Error", detail="", informative=""):
+def error(
+    parent,
+    message,
+    title="Error",
+    detail="",
+    informative="",
+    text_format="auto"):
     """ Convenience function to show an error message dialog.
 
     Parameters
@@ -97,6 +117,7 @@ def error(parent, message, title="Error", detail="", informative=""):
         severity="error",
         detail=detail,
         informative=informative,
+        text_format=text_format,
     )
     dialog.open()
 

--- a/pyface/message_dialog.py
+++ b/pyface/message_dialog.py
@@ -37,7 +37,7 @@ def information(
         Explanatory text to display along with the message.
     text_format : str
         Specifies what text format to use in the resulting message dialog.
-        One of "auto", "plain", or "rich".
+        One of "auto", "plain", or "rich". Only supported on the qt backend.
 
     """
     dialog = MessageDialog(
@@ -77,7 +77,7 @@ def warning(
         Explanatory text to display along with the message.
     text_format : str
         Specifies what text format to use in the resulting message dialog.
-        One of "auto", "plain", or "rich".
+        One of "auto", "plain", or "rich". Only supported on the qt backend.
 
     """
     dialog = MessageDialog(
@@ -117,7 +117,7 @@ def error(
         Explanatory text to display along with the message.
     text_format : str
         Specifies what text format to use in the resulting message dialog.
-        One of "auto", "plain", or "rich".
+        One of "auto", "plain", or "rich". Only supported on the qt backend.
 
     """
     dialog = MessageDialog(

--- a/pyface/message_dialog.py
+++ b/pyface/message_dialog.py
@@ -35,6 +35,9 @@ def information(
         "Show details").
     informative : str
         Explanatory text to display along with the message.
+    text_format : str
+        Specifies what text format to use in the resulting message dialog.
+        One of "auto", "plain", or "rich".
 
     """
     dialog = MessageDialog(
@@ -72,6 +75,9 @@ def warning(
         "Show details").
     informative : str
         Explanatory text to display along with the message.
+    text_format : str
+        Specifies what text format to use in the resulting message dialog.
+        One of "auto", "plain", or "rich".
 
     """
     dialog = MessageDialog(
@@ -92,7 +98,8 @@ def error(
     title="Error",
     detail="",
     informative="",
-    text_format="auto"):
+    text_format="auto"
+):
     """ Convenience function to show an error message dialog.
 
     Parameters
@@ -108,6 +115,9 @@ def error(
         "Show details").
     informative : str
         Explanatory text to display along with the message.
+    text_format : str
+        Specifies what text format to use in the resulting message dialog.
+        One of "auto", "plain", or "rich".
 
     """
     dialog = MessageDialog(

--- a/pyface/ui/qt4/message_dialog.py
+++ b/pyface/ui/qt4/message_dialog.py
@@ -29,6 +29,13 @@ _SEVERITY_TO_ICON_MAP = {
     "error": QtGui.QMessageBox.Critical,
 }
 
+_TEXT_FORMAT_MAP = {
+    "auto": QtCore.Qt.AutoText,
+    "log": QtCore.Qt.LogText,
+    "plain": QtCore.Qt.PlainText,
+    "rich": QtCore.Qt.RichText,
+}
+
 
 @provides(IMessageDialog)
 class MessageDialog(MMessageDialog, Dialog):
@@ -45,6 +52,8 @@ class MessageDialog(MMessageDialog, Dialog):
     detail = Str()
 
     severity = Enum("information", "warning", "error")
+
+    text_format = Enum("auto", "log", "plain", "rich")
 
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.
@@ -70,6 +79,7 @@ class MessageDialog(MMessageDialog, Dialog):
         message_box.setInformativeText(self.informative)
         message_box.setDetailedText(self.detail)
         message_box.setEscapeButton(QtGui.QMessageBox.Ok)
+        message_box.setTextFormat(_TEXT_FORMAT_MAP[self.text_format])
 
         if self.size != (-1, -1):
             message_box.resize(*self.size)

--- a/pyface/ui/qt4/message_dialog.py
+++ b/pyface/ui/qt4/message_dialog.py
@@ -12,7 +12,7 @@
 # However, when used with the GPL version of PyQt the additional terms described in the PyQt GPL exception also apply
 
 
-from pyface.qt import QtGui
+from pyface.qt import QtCore, QtGui
 
 
 from traits.api import Enum, provides, Str
@@ -31,7 +31,6 @@ _SEVERITY_TO_ICON_MAP = {
 
 _TEXT_FORMAT_MAP = {
     "auto": QtCore.Qt.AutoText,
-    "log": QtCore.Qt.LogText,
     "plain": QtCore.Qt.PlainText,
     "rich": QtCore.Qt.RichText,
 }

--- a/pyface/ui/qt4/message_dialog.py
+++ b/pyface/ui/qt4/message_dialog.py
@@ -52,7 +52,7 @@ class MessageDialog(MMessageDialog, Dialog):
 
     severity = Enum("information", "warning", "error")
 
-    text_format = Enum("auto", "log", "plain", "rich")
+    text_format = Enum("auto", "plain", "rich")
 
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.

--- a/pyface/ui/qt4/tests/test_message_dialog.py
+++ b/pyface/ui/qt4/tests/test_message_dialog.py
@@ -16,7 +16,7 @@ import contextlib
 import unittest
 
 from pyface.api import MessageDialog
-from pyface.qt import QtGui
+from pyface.qt import QtCore, QtGui
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 
 
@@ -55,6 +55,22 @@ class TestMessageDialog(GuiTestAssistant, unittest.TestCase):
             # It's possible for both the above to be None, so double check.
             self.assertIsNotNone(escape_button)
             self.assertIs(escape_button, ok_button)
+
+    def test_text_format(self):
+        dialog = MessageDialog(
+            parent=None,
+            title="Dialog title",
+            message="Printer on fire",
+            informative="Your printer is on fire",
+            details="Temperature exceeds 1000 degrees",
+            severity="error",
+            text_format="plain",
+            size=(600, 400),
+        )
+
+        with self.create_dialog(dialog):
+            text_format = dialog.control.textFormat()
+            self.assertEqual(text_format, QtCore.Qt.PlainText)
 
     @contextlib.contextmanager
     def create_dialog(self, dialog):

--- a/pyface/ui/wx/message_dialog.py
+++ b/pyface/ui/wx/message_dialog.py
@@ -47,6 +47,9 @@ class MessageDialog(MMessageDialog, Dialog):
 
     severity = Enum("information", "warning", "error")
 
+    # unused trait, this functionality is only supported on Qt
+    text_format = Enum("auto", "plain", "rich")
+
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.
     # ------------------------------------------------------------------------


### PR DESCRIPTION
Inspired by https://github.com/enthought/traitsui/pull/1546

This PR allows a user to specify the text format they want to use to a message dialog, to help avoid issues like https://github.com/enthought/traitsui/issues/1543

Note, there used to be a `LogText` option, and since qt 5.14 there is a `MarkdownText` option.  I have not added those here to avoid special handling for different Qt versions / because we have not had an explicit use case.  However, if they are needed or wanted, they could be added. 