### PR TITLE
Use EDM 3.2.3 instead of EDM 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ addons:
 
 env:
   global:
-    - INSTALL_EDM_VERSION=3.0.1
+    - INSTALL_EDM_VERSION=3.2.3
       PYTHONUNBUFFERED="1"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,7 +5,7 @@ environment:
 
   global:
     PYTHONUNBUFFERED: "1"
-    INSTALL_EDM_VERSION: "3.0.1"
+    INSTALL_EDM_VERSION: "3.2.3"
 
   matrix:
     - RUNTIME: '3.6'


### PR DESCRIPTION
This PR updates EDM to version 3.2.3 (the latest) instead of EDM version 3.0.1.