### PR TITLE
Flake8 - F401 fixes

### DIFF
--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -54,7 +54,7 @@ def load_tests(loader, standard_tests, pattern):
     """
     from os import environ
     from os.path import dirname
-    from pyface.util.testing import filter_tests, is_traits_version_ge
+    from pyface.util.testing import filter_tests
     from unittest import TestSuite
 
     # Make sure the right toolkit is up and running before importing tests

--- a/pyface/action/action_event.py
+++ b/pyface/action/action_event.py
@@ -13,7 +13,7 @@
 import time
 
 
-from traits.api import Float, HasTraits, Int
+from traits.api import Float, HasTraits
 
 
 class ActionEvent(HasTraits):

--- a/pyface/action/group.py
+++ b/pyface/action/group.py
@@ -20,7 +20,6 @@ from traits.trait_base import user_name_for
 
 from pyface.action.action import Action
 from pyface.action.action_item import ActionItem
-from pyface.action.action_manager_item import ActionManagerItem  # noqa: F401
 
 
 class Group(HasTraits):

--- a/pyface/action/group.py
+++ b/pyface/action/group.py
@@ -13,14 +13,14 @@
 from functools import partial
 
 
-from traits.api import Any, Bool, HasTraits, Instance, List, Property
+from traits.api import Any, Bool, HasTraits, List, Property
 from traits.api import Str
 from traits.trait_base import user_name_for
 
 
 from pyface.action.action import Action
 from pyface.action.action_item import ActionItem
-from pyface.action.action_manager_item import ActionManagerItem
+from pyface.action.action_manager_item import ActionManagerItem  # noqa: F401
 
 
 class Group(HasTraits):

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -17,7 +17,6 @@ import logging
 
 from pyface.action.action import Action
 from traits.api import Any, Str, Undefined
-from traits.observation.api import trait
 
 # Logging.
 logger = logging.getLogger(__name__)

--- a/pyface/action/tests/test_action_item.py
+++ b/pyface/action/tests/test_action_item.py
@@ -15,7 +15,6 @@ from traits.testing.api import UnittestTools
 
 from pyface.image_cache import ImageCache
 from pyface.toolkit import toolkit_object
-from pyface.widget import Widget
 from pyface.window import Window
 from ..action import Action
 from ..action_controller import ActionController

--- a/pyface/color.py
+++ b/pyface/color.py
@@ -25,7 +25,8 @@ from traits.api import (
     Bool, HasStrictTraits, Property, Range, Tuple, cached_property
 )
 
-from pyface.util.color_helpers import channels_to_ints, ints_to_channels, is_dark
+from pyface.util.color_helpers import channels_to_ints, is_dark
+from pyface.util.color_helpers import ints_to_channels  # noqa: F401
 from pyface.util.color_parser import parse_text
 
 

--- a/pyface/data_view/data_models/array_data_model.py
+++ b/pyface/data_view/data_models/array_data_model.py
@@ -12,15 +12,13 @@
 This module provides a concrete implementation of a data model for an
 n-dim numpy array.
 """
-from collections.abc import Sequence
-
 from traits.api import Array, HasRequiredTraits, Instance, observe
 
 from pyface.data_view.abstract_data_model import AbstractDataModel
 from pyface.data_view.data_view_errors import DataViewSetError
 from pyface.data_view.abstract_value_type import AbstractValueType
 from pyface.data_view.value_types.api import (
-    ConstantValue, FloatValue, IntValue, TextValue, no_value
+    ConstantValue, IntValue, no_value
 )
 from pyface.data_view.index_manager import TupleIndexManager
 

--- a/pyface/data_view/data_models/tests/test_data_accessors.py
+++ b/pyface/data_view/data_models/tests/test_data_accessors.py
@@ -15,7 +15,7 @@ from traits.api import TraitError
 from traits.testing.api import UnittestTools
 
 from pyface.data_view.abstract_data_model import DataViewSetError
-from pyface.data_view.value_types.api import IntValue, TextValue
+from pyface.data_view.value_types.api import TextValue
 from pyface.data_view.data_models.data_accessors import (
     AttributeDataAccessor,
     ConstantDataAccessor,

--- a/pyface/data_view/data_models/tests/test_row_table_data_model.py
+++ b/pyface/data_view/data_models/tests/test_row_table_data_model.py
@@ -12,13 +12,10 @@ import unittest
 
 from traits.trait_list_object import TraitList
 from traits.testing.api import UnittestTools
-from traits.testing.optional_dependencies import numpy as np, requires_numpy
 
 from pyface.data_view.abstract_data_model import DataViewSetError
 from pyface.data_view.abstract_value_type import AbstractValueType
-from pyface.data_view.value_types.api import (
-    FloatValue, IntValue, TextValue, no_value
-)
+from pyface.data_view.value_types.api import IntValue, TextValue
 from pyface.data_view.data_models.data_accessors import (
     AttributeDataAccessor, IndexDataAccessor, KeyDataAccessor
 )

--- a/pyface/data_view/tests/test_data_formats.py
+++ b/pyface/data_view/tests/test_data_formats.py
@@ -8,10 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-import csv
-import json
 from unittest import TestCase
-from unittest.mock import MagicMock, patch
 
 from traits.api import HasTraits, Int, Str
 from traits.testing.optional_dependencies import numpy as np, requires_numpy

--- a/pyface/data_view/value_types/tests/test_color_value.py
+++ b/pyface/data_view/value_types/tests/test_color_value.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from unittest import TestCase, expectedFailure
+from unittest import TestCase
 from unittest.mock import Mock
 
 from pyface.color import Color

--- a/pyface/dock/dock_window_shell.py
+++ b/pyface/dock/dock_window_shell.py
@@ -17,9 +17,8 @@
 import wx
 
 # Fixme: Hack to force 'image_slice' to be added via Category to Theme class:
-import traitsui.wx
+import traitsui.wx  # noqa: F401
 from traits.api import HasPrivateTraits, Instance
-from traitsui.api import View, Group
 
 from pyface.api import SystemMetrics
 from pyface.image_resource import ImageResource

--- a/pyface/grid/checkbox_image_renderer.py
+++ b/pyface/grid/checkbox_image_renderer.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.checkbox_image_renderer import *
+from pyface.ui.wx.grid.checkbox_image_renderer import *  # noqa: F401

--- a/pyface/grid/checkbox_renderer.py
+++ b/pyface/grid/checkbox_renderer.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.checkbox_renderer import *
+from pyface.ui.wx.grid.checkbox_renderer import *  # noqa: F401

--- a/pyface/grid/combobox_focus_handler.py
+++ b/pyface/grid/combobox_focus_handler.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.combobox_focus_handler import *
+from pyface.ui.wx.grid.combobox_focus_handler import *  # noqa: F401

--- a/pyface/grid/composite_grid_model.py
+++ b/pyface/grid/composite_grid_model.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.composite_grid_model import *
+from pyface.ui.wx.grid.composite_grid_model import *  # noqa: F401

--- a/pyface/grid/edit_image_renderer.py
+++ b/pyface/grid/edit_image_renderer.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.edit_image_renderer import *
+from pyface.ui.wx.grid.edit_image_renderer import *  # noqa: F401

--- a/pyface/grid/edit_renderer.py
+++ b/pyface/grid/edit_renderer.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.edit_renderer import *
+from pyface.ui.wx.grid.edit_renderer import *  # noqa: F401

--- a/pyface/grid/grid.py
+++ b/pyface/grid/grid.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.grid import *
+from pyface.ui.wx.grid.grid import *  # noqa: F401

--- a/pyface/grid/grid_cell_image_renderer.py
+++ b/pyface/grid/grid_cell_image_renderer.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.grid_cell_image_renderer import *
+from pyface.ui.wx.grid.grid_cell_image_renderer import *  # noqa: F401

--- a/pyface/grid/grid_cell_renderer.py
+++ b/pyface/grid/grid_cell_renderer.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.grid_cell_renderer import *
+from pyface.ui.wx.grid.grid_cell_renderer import *  # noqa: F401

--- a/pyface/grid/grid_model.py
+++ b/pyface/grid/grid_model.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.grid_model import *
+from pyface.ui.wx.grid.grid_model import *  # noqa: F401

--- a/pyface/grid/inverted_grid_model.py
+++ b/pyface/grid/inverted_grid_model.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.inverted_grid_model import *
+from pyface.ui.wx.grid.inverted_grid_model import *  # noqa: F401

--- a/pyface/grid/mapped_grid_cell_image_renderer.py
+++ b/pyface/grid/mapped_grid_cell_image_renderer.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.mapped_grid_cell_image_renderer import *
+from pyface.ui.wx.grid.mapped_grid_cell_image_renderer import *  # noqa: F401

--- a/pyface/grid/simple_grid_model.py
+++ b/pyface/grid/simple_grid_model.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.simple_grid_model import *
+from pyface.ui.wx.grid.simple_grid_model import *  # noqa: F401

--- a/pyface/grid/trait_grid_cell_adapter.py
+++ b/pyface/grid/trait_grid_cell_adapter.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.trait_grid_cell_adapter import *
+from pyface.ui.wx.grid.trait_grid_cell_adapter import *  # noqa: F401

--- a/pyface/grid/trait_grid_model.py
+++ b/pyface/grid/trait_grid_model.py
@@ -12,4 +12,4 @@ import logging
 logger = logging.getLogger(__name__)
 logger.warning("DEPRECATED: pyface.grid, use pyface.ui.wx.grid instead.")
 
-from pyface.ui.wx.grid.trait_grid_model import *
+from pyface.ui.wx.grid.trait_grid_model import *  # noqa: F401

--- a/pyface/ipython_widget.py
+++ b/pyface/ipython_widget.py
@@ -13,7 +13,7 @@
 
 # Import the toolkit specific version.
 try:
-    import IPython.frontend
+    import IPython.frontend  # noqa: F401
 except ImportError:
     raise ImportError(
         """

--- a/pyface/resource/resource_manager.py
+++ b/pyface/resource/resource_manager.py
@@ -13,7 +13,7 @@ A resource manager locates and loads application resources such as images and
 sounds etc.
 """
 
-import collections.abc, glob, inspect, os, sys, types
+import collections.abc, glob, inspect, os, types
 from os.path import join
 from zipfile import is_zipfile, ZipFile
 

--- a/pyface/sorter.py
+++ b/pyface/sorter.py
@@ -10,8 +10,6 @@
 
 """ Base class for all sorters. """
 
-from functools import cmp_to_key
-
 from traits.api import HasTraits
 
 

--- a/pyface/tasks/action/listening_action.py
+++ b/pyface/tasks/action/listening_action.py
@@ -12,4 +12,4 @@
 Please use :class:`pyface.action.listening_action.ListeningAction` instead.
 """
 
-from pyface.action.listening_action import ListeningAction
+from pyface.action.listening_action import ListeningAction  # noqa: F401

--- a/pyface/tasks/action/task_action.py
+++ b/pyface/tasks/action/task_action.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 
-from traits.api import Bool, Instance, Property, Str, cached_property
+from traits.api import Instance, Property, Str, cached_property
 
 
 from pyface.tasks.api import Editor, Task, TaskPane

--- a/pyface/tasks/i_advanced_editor_area_pane.py
+++ b/pyface/tasks/i_advanced_editor_area_pane.py
@@ -8,9 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Interface
-
-
 from pyface.tasks.i_editor_area_pane import IEditorAreaPane
 
 

--- a/pyface/tasks/i_dock_pane.py
+++ b/pyface/tasks/i_dock_pane.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Bool, Enum, HasTraits, Str, Tuple
+from traits.api import Bool, Enum, HasTraits, Tuple
 
 
 from pyface.tasks.i_task_pane import ITaskPane

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -16,7 +16,6 @@ from pyface.api import ApplicationWindow
 from traits.api import (
     Bool,
     Callable,
-    HasTraits,
     HasStrictTraits,
     Instance,
     List,

--- a/pyface/tasks/tasks_application.py
+++ b/pyface/tasks/tasks_application.py
@@ -12,7 +12,6 @@ the creation of tasks and corresponding windows.
 """
 
 
-from functools import partial
 import logging
 
 from traits.api import (

--- a/pyface/tests/python_shell_script.py
+++ b/pyface/tests/python_shell_script.py
@@ -10,7 +10,7 @@
 # dummy script for testing python shell and python editor widgets
 
 # simple import
-import sys
+import sys  # noqa: F401
 
 # set a variable
 x = 1

--- a/pyface/tests/python_shell_script.py
+++ b/pyface/tests/python_shell_script.py
@@ -10,7 +10,7 @@
 # dummy script for testing python shell and python editor widgets
 
 # simple import
-import sys  # noqa: F401
+import sys
 
 # set a variable
 x = 1

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -13,7 +13,6 @@ import unittest
 
 from ..about_dialog import AboutDialog
 from ..constant import OK, CANCEL
-from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 

--- a/pyface/tests/test_beep.py
+++ b/pyface/tests/test_beep.py
@@ -11,8 +11,6 @@
 
 import unittest
 
-from traits.testing.api import UnittestTools
-
 from ..beep import beep
 
 

--- a/pyface/tests/test_color.py
+++ b/pyface/tests/test_color.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 
 from traits.testing.api import UnittestTools
 
-from pyface.color import Color, channels_to_ints, ints_to_channels
+from pyface.color import Color
 
 
 class TestColor(UnittestTools, TestCase):

--- a/pyface/tests/test_directory_dialog.py
+++ b/pyface/tests/test_directory_dialog.py
@@ -13,7 +13,6 @@ import os
 import unittest
 
 from ..directory_dialog import DirectoryDialog
-from ..gui import GUI
 from ..toolkit import toolkit_object
 
 GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")

--- a/pyface/tests/test_file_dialog.py
+++ b/pyface/tests/test_file_dialog.py
@@ -13,7 +13,6 @@ import os
 import unittest
 
 from ..file_dialog import FileDialog
-from ..gui import GUI
 from ..toolkit import toolkit_object
 
 GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -10,7 +10,6 @@
 
 
 import os
-import sys
 import unittest
 
 from ..python_editor import PythonEditor

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -15,7 +15,6 @@ from traits.etsconfig.api import ETSConfig
 
 from ..single_choice_dialog import SingleChoiceDialog
 from ..constant import OK, CANCEL
-from ..gui import GUI
 from ..toolkit import toolkit_object
 from ..window import Window
 

--- a/pyface/tests/test_splash_screen.py
+++ b/pyface/tests/test_splash_screen.py
@@ -11,7 +11,6 @@
 
 import unittest
 
-from ..gui import GUI
 from ..image_resource import ImageResource
 from ..splash_screen import SplashScreen
 from ..toolkit import toolkit_object

--- a/pyface/tests/test_splash_screen_log_handler.py
+++ b/pyface/tests/test_splash_screen_log_handler.py
@@ -11,7 +11,7 @@
 
 import unittest
 
-from traits.api import Any, HasTraits, Str
+from traits.api import HasTraits, Str
 
 from ..splash_screen_log_handler import SplashScreenLogHandler
 

--- a/pyface/tests/test_ui_traits.py
+++ b/pyface/tests/test_ui_traits.py
@@ -17,7 +17,6 @@ from traits.testing.optional_dependencies import numpy as np, requires_numpy
 from traits.testing.api import UnittestTools
 
 from ..color import Color
-from ..i_image_resource import IImageResource
 from ..image_resource import ImageResource
 from ..ui_traits import (
     Border,

--- a/pyface/timer/i_timer.py
+++ b/pyface/timer/i_timer.py
@@ -15,7 +15,6 @@ provides a base implementation that can be easily specialized for a particular
 back-end, and mixins that provide additional capabilities.
 """
 from abc import abstractmethod
-import sys
 import time
 
 from traits.api import (

--- a/pyface/timer/tests/test_do_later.py
+++ b/pyface/timer/tests/test_do_later.py
@@ -9,7 +9,6 @@
 # Thanks for using Enthought open source!
 
 
-import time
 from unittest import TestCase, skipIf
 
 from pyface.toolkit import toolkit_object

--- a/pyface/tree/node_type.py
+++ b/pyface/tree/node_type.py
@@ -11,9 +11,9 @@
 """ The base class for all node types. """
 
 
-from traits.api import Any, HasPrivateTraits, Instance, List
+from traits.api import Any, HasPrivateTraits, Instance
 from pyface.api import ImageResource
-from pyface.action.api import Action, ActionManagerItem, Group
+from pyface.action.api import Action, Group
 from pyface.action.api import MenuManager
 
 

--- a/pyface/ui/null/action/menu_manager.py
+++ b/pyface/ui/null/action/menu_manager.py
@@ -17,7 +17,6 @@ from traits.api import Str
 
 from pyface.action.action_manager import ActionManager
 from pyface.action.action_manager_item import ActionManagerItem
-from pyface.action.group import Group
 
 
 class MenuManager(ActionManager, ActionManagerItem):

--- a/pyface/ui/null/action/tool_palette_manager.py
+++ b/pyface/ui/null/action/tool_palette_manager.py
@@ -11,12 +11,11 @@
 """ A tool bar manager realizes itself in a tool palette control. """
 
 
-from traits.api import Any, Bool, Enum, Instance, Tuple
+from traits.api import Bool, Instance, Tuple
 
 
 from pyface.image_cache import ImageCache
 from pyface.action.action_manager import ActionManager
-from .tool_palette import ToolPalette
 
 
 class ToolPaletteManager(ActionManager):

--- a/pyface/ui/null/window.py
+++ b/pyface/ui/null/window.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 
-from traits.api import Any, Event, Property, provides, Str
+from traits.api import Event, Property, provides, Str
 from traits.api import Tuple
 
 

--- a/pyface/ui/qt4/about_dialog.py
+++ b/pyface/ui/qt4/about_dialog.py
@@ -11,7 +11,6 @@
 
 
 import platform
-import sys
 
 
 from pyface.qt import QtCore, QtGui

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -15,7 +15,7 @@
 from inspect import getfullargspec
 
 
-from pyface.qt import QtGui, QtCore
+from pyface.qt import QtGui
 
 
 from traits.api import Any, Bool, HasTraits

--- a/pyface/ui/qt4/code_editor/code_widget.py
+++ b/pyface/ui/qt4/code_editor/code_widget.py
@@ -9,7 +9,6 @@
 # Thanks for using Enthought open source!
 
 
-import math
 import sys
 
 

--- a/pyface/ui/qt4/console/call_tip_widget.py
+++ b/pyface/ui/qt4/console/call_tip_widget.py
@@ -9,7 +9,6 @@
 # Thanks for using Enthought open source!
 
 import re
-from textwrap import dedent
 from unicodedata import category
 
 

--- a/pyface/ui/qt4/data_view/data_view_widget.py
+++ b/pyface/ui/qt4/data_view/data_view_widget.py
@@ -12,10 +12,9 @@ import logging
 
 from traits.api import Callable, Enum, Instance, observe, provides
 
-from pyface.qt.QtCore import QAbstractItemModel, QEvent, QObject
+from pyface.qt.QtCore import QAbstractItemModel
 from pyface.qt.QtGui import (
-    QAbstractItemView, QItemSelection, QItemSelectionModel, QPalette,
-    QTreeView
+    QAbstractItemView, QItemSelection, QItemSelectionModel, QTreeView
 )
 from pyface.data_view.i_data_view_widget import (
     IDataViewWidget, MDataViewWidget

--- a/pyface/ui/qt4/data_view/data_wrapper.py
+++ b/pyface/ui/qt4/data_view/data_wrapper.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import HasRequiredTraits, Instance, provides
+from traits.api import Instance, provides
 
 from pyface.data_view.i_data_wrapper import IDataWrapper, MDataWrapper
 from pyface.qt.QtCore import QMimeData

--- a/pyface/ui/qt4/heading_text.py
+++ b/pyface/ui/qt4/heading_text.py
@@ -12,7 +12,7 @@
 # However, when used with the GPL version of PyQt the additional terms described in the PyQt GPL exception also apply
 
 
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtGui
 
 
 from traits.api import Int, provides, Str

--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -40,7 +40,7 @@ if _app is None:
         # creating a QCoreApplication instance, otherwise importing
         # QtWebEngineWidgets later would fail (see enthought/pyface#581).
         # Import it here first before creating the instance.
-        from pyface.qt import QtWebKit
+        from pyface.qt import QtWebKit  # noqa: F401
     except ImportError:
         # This error will be raised in the context where
         # QtWebKit/QtWebEngine widgets are required.

--- a/pyface/ui/qt4/mimedata.py
+++ b/pyface/ui/qt4/mimedata.py
@@ -10,7 +10,6 @@
 from pickle import dumps, load, loads, PickleError
 import warnings
 import io
-import sys
 
 from pyface.qt import QtCore
 

--- a/pyface/ui/qt4/python_editor.py
+++ b/pyface/ui/qt4/python_editor.py
@@ -10,9 +10,6 @@
 # Thanks for using Enthought open source!
 
 
-import sys
-
-
 from pyface.qt import QtCore, QtGui
 
 

--- a/pyface/ui/qt4/splash_screen.py
+++ b/pyface/ui/qt4/splash_screen.py
@@ -18,7 +18,7 @@ from logging import DEBUG
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Any, Bool, Font, Instance, Int, provides
+from traits.api import Any, Bool, Instance, Int, provides
 from traits.api import Tuple, Str
 
 

--- a/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
@@ -13,7 +13,7 @@ import os
 import tempfile
 import unittest
 
-from traits.api import HasTraits, Instance
+from traits.api import Instance
 
 from pyface.qt import QtGui, QtCore
 from pyface.tasks.split_editor_area_pane import (

--- a/pyface/ui/qt4/timer/do_later.py
+++ b/pyface/ui/qt4/timer/do_later.py
@@ -13,4 +13,4 @@ DoLaterTimer class
 Provided for backward compatibility.
 """
 
-from pyface.timer.do_later import DoLaterTimer
+from pyface.timer.do_later import DoLaterTimer  # noqa: F401

--- a/pyface/ui/qt4/util/gui_test_assistant.py
+++ b/pyface/ui/qt4/util/gui_test_assistant.py
@@ -22,7 +22,7 @@ from traits.testing.unittest_tools import (
     _TraitsChangeCollector as TraitsChangeCollector,
 )
 
-from .testing import find_qt_widget, print_qt_widget_tree
+from .testing import find_qt_widget
 from .event_loop_helper import EventLoopHelper, ConditionTimeoutError
 
 
@@ -40,7 +40,7 @@ class GuiTestAssistant(UnittestTools):
             qt_app=self.qt_app, gui=self.gui
         )
         try:
-            import traitsui.api
+            import traitsui.api  # noqa: F401
         except ImportError:
             self.traitsui_raise_patch = None
         else:

--- a/pyface/ui/qt4/util/modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/modal_dialog_tester.py
@@ -11,12 +11,11 @@
 
 """
 import contextlib
-import platform
 import sys
 import traceback
 
 from pyface.api import GUI, OK, CANCEL, YES, NO
-from pyface.qt import QtCore, QtGui, qt_api
+from pyface.qt import QtCore, QtGui
 from traits.api import Undefined
 
 from .event_loop_helper import EventLoopHelper

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -13,22 +13,15 @@
 
 import unittest
 from io import StringIO
-import platform
 
 from pyface.qt import QtGui
 from pyface.api import Dialog, MessageDialog, OK, CANCEL
-from pyface.toolkit import toolkit_object
 from traits.api import HasStrictTraits
 
 from pyface.ui.qt4.util.testing import silence_output
 from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
 from pyface.ui.qt4.util.modal_dialog_tester import ModalDialogTester
 from pyface.util.testing import skip_if_no_traitsui
-
-
-is_qt = toolkit_object.toolkit == "qt4"
-if is_qt:
-    from pyface.qt import qt_api
 
 
 class MyClass(HasStrictTraits):

--- a/pyface/ui/qt4/widget.py
+++ b/pyface/ui/qt4/widget.py
@@ -10,7 +10,7 @@
 # Thanks for using Enthought open source!
 
 
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtCore
 
 
 from traits.api import Any, Bool, HasTraits, Instance, provides

--- a/pyface/ui/qt4/wizard/wizard_page.py
+++ b/pyface/ui/qt4/wizard/wizard_page.py
@@ -17,7 +17,7 @@
 """ A page in a wizard. """
 
 
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtGui
 
 
 from traits.api import Bool, HasTraits, provides, Str, Tuple, Str

--- a/pyface/ui/wx/action/tool_palette_manager.py
+++ b/pyface/ui/wx/action/tool_palette_manager.py
@@ -13,10 +13,7 @@
 """
 
 
-import wx
-
-
-from traits.api import Any, Bool, Enum, Instance, Tuple
+from traits.api import Bool, Instance, Tuple
 
 
 from pyface.image_cache import ImageCache

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -13,9 +13,6 @@
 """
 
 
-import sys
-
-
 import wx
 from pyface.wx.aui import aui, PyfaceAuiManager
 

--- a/pyface/ui/wx/data_view/data_view_widget.py
+++ b/pyface/ui/wx/data_view/data_view_widget.py
@@ -20,7 +20,7 @@ from wx.dataview import (
     wxEVT_DATAVIEW_SELECTION_CHANGED
 )
 
-from traits.api import Constant, Enum, Instance, observe, provides
+from traits.api import Enum, Instance, observe, provides
 
 from pyface.data_view.i_data_view_widget import (
     IDataViewWidget, MDataViewWidget

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -16,7 +16,7 @@ import wx
 import wx.lib.gridmovers as grid_movers
 from os.path import abspath, exists
 from wx.grid import Grid as wxGrid
-from wx.grid import GridCellAttr, GridCellBoolRenderer, GridTableBase
+from wx.grid import GridCellAttr, GridTableBase
 from wx.grid import (
     GridTableMessage,
     GRIDTABLE_NOTIFY_ROWS_APPENDED,
@@ -28,7 +28,6 @@ from wx.grid import (
     GRIDTABLE_REQUEST_VIEW_GET_VALUES,
     GRID_VALUE_STRING,
 )
-from wx import TheClipboard
 
 
 from pyface.api import Widget
@@ -47,7 +46,6 @@ from traits.api import (
 from pyface.wx.drag_and_drop import (
     PythonDropSource,
     PythonDropTarget,
-    PythonObject,
 )
 from pyface.wx.drag_and_drop import clipboard as enClipboard, FileDropSource
 

--- a/pyface/ui/wx/grid/grid_model.py
+++ b/pyface/ui/wx/grid/grid_model.py
@@ -12,7 +12,6 @@
 
 
 from traits.api import (
-    Any,
     Bool,
     Event,
     HasPrivateTraits,

--- a/pyface/ui/wx/grid/simple_grid_model.py
+++ b/pyface/ui/wx/grid/simple_grid_model.py
@@ -14,7 +14,7 @@ for rows and columns. By default these are built off the data itself,
 with row/column labels as the index + 1."""
 
 
-from pyface.action.api import Action, Group, MenuManager, Separator
+from pyface.action.api import Action, Group, MenuManager
 from traits.api import Either, Any, Instance, List
 from pyface.wx.drag_and_drop import clipboard as enClipboard
 

--- a/pyface/ui/wx/mdi_application_window.py
+++ b/pyface/ui/wx/mdi_application_window.py
@@ -22,7 +22,7 @@ from .image_resource import ImageResource
 
 try:
     # import wx.aui
-    from wx.lib.agw import aui
+    from wx.lib.agw import aui  # noqa: F401
 
     AUI = True
 except:

--- a/pyface/ui/wx/preference/preference_dialog.py
+++ b/pyface/ui/wx/preference/preference_dialog.py
@@ -25,7 +25,6 @@ from pyface.ui.wx.viewer.tree_viewer import TreeViewer
 from pyface.viewer.default_tree_content_provider import (
     DefaultTreeContentProvider,
 )
-from pyface.wx.util.font_helper import new_font_like
 
 
 class PreferenceDialog(SplitDialog):

--- a/pyface/ui/wx/progress_dialog.py
+++ b/pyface/ui/wx/progress_dialog.py
@@ -16,10 +16,10 @@ import wx
 import time
 
 
-from traits.api import Bool, Enum, Instance, Int, Property, provides, Str
+from traits.api import Bool, Enum, Instance, Int, Property, Str
 
 
-from pyface.i_progress_dialog import IProgressDialog, MProgressDialog
+from pyface.i_progress_dialog import MProgressDialog
 from .widget import Widget
 from .window import Window
 

--- a/pyface/ui/wx/resource_manager.py
+++ b/pyface/ui/wx/resource_manager.py
@@ -23,8 +23,6 @@ import wx
 
 from pyface.resource.api import ResourceFactory
 
-from traits.api import Undefined
-
 
 class PyfaceResourceFactory(ResourceFactory):
     """ The implementation of a shared resource manager. """

--- a/pyface/ui/wx/splash_screen.py
+++ b/pyface/ui/wx/splash_screen.py
@@ -20,7 +20,7 @@ import wx
 import wx.adv
 
 
-from traits.api import Any, Bool, Font, Instance, Int, provides
+from traits.api import Any, Bool, Instance, Int, provides
 from traits.api import Tuple, Str
 
 

--- a/pyface/ui/wx/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/wx/tasks/advanced_editor_area_pane.py
@@ -8,9 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-import sys
-
-
 from traits.api import provides
 
 

--- a/pyface/ui/wx/tasks/dock_pane.py
+++ b/pyface/ui/wx/tasks/dock_pane.py
@@ -8,7 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-from contextlib import contextmanager
 import logging
 
 

--- a/pyface/ui/wx/tasks/editor_area_pane.py
+++ b/pyface/ui/wx/tasks/editor_area_pane.py
@@ -8,7 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-import sys
 import logging
 
 

--- a/pyface/ui/wx/tasks/main_window_layout.py
+++ b/pyface/ui/wx/tasks/main_window_layout.py
@@ -8,21 +8,17 @@
 #
 # Thanks for using Enthought open source!
 
-from itertools import combinations
 import logging
 
 
-from traits.api import Any, HasTraits
+from traits.api import HasTraits
 
 
 from .dock_pane import AREA_MAP, INVERSE_AREA_MAP
 from pyface.tasks.task_layout import (
-    LayoutContainer,
     PaneItem,
     Tabbed,
     Splitter,
-    HSplitter,
-    VSplitter,
 )
 
 # row/col orientation for AUI

--- a/pyface/ui/wx/tasks/split_editor_area_pane.py
+++ b/pyface/ui/wx/tasks/split_editor_area_pane.py
@@ -8,9 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-import sys
-
-
 from traits.api import provides
 
 

--- a/pyface/ui/wx/tasks/task_window_backend.py
+++ b/pyface/ui/wx/tasks/task_window_backend.py
@@ -11,7 +11,6 @@
 import logging
 
 
-import wx
 from pyface.wx.aui import aui
 
 

--- a/pyface/ui/wx/timer/do_later.py
+++ b/pyface/ui/wx/timer/do_later.py
@@ -13,4 +13,4 @@ DoLaterTimer class
 Provided for backward compatibility.
 """
 
-from pyface.timer.do_later import DoLaterTimer
+from pyface.timer.do_later import DoLaterTimer  # noqa: F401

--- a/pyface/ui/wx/timer/timer.py
+++ b/pyface/ui/wx/timer/timer.py
@@ -12,7 +12,7 @@
 
 import wx
 
-from traits.api import Bool, Instance, Property
+from traits.api import Instance
 
 from pyface.timer.i_timer import BaseTimer
 

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -12,10 +12,8 @@
 
 
 import wx
-from wx.lib.agw import ultimatelistctrl as ULC
 
-
-from traits.api import Color, Event, Instance, Trait
+from traits.api import Color, Event, Instance
 
 
 from pyface.ui.wx.image_list import ImageList

--- a/pyface/ui/wx/viewer/tree_viewer.py
+++ b/pyface/ui/wx/viewer/tree_viewer.py
@@ -14,7 +14,7 @@
 import wx
 
 
-from traits.api import Any, Bool, Enum, Event, Instance, List
+from traits.api import Bool, Enum, Event, Instance, List
 
 
 from pyface.ui.wx.image_list import ImageList

--- a/pyface/undo/action/tests/test_actions.py
+++ b/pyface/undo/action/tests/test_actions.py
@@ -10,10 +10,8 @@
 
 import unittest
 
-from traits.testing.api import UnittestTools
-
 from pyface.undo.api import CommandStack, UndoManager
-from pyface.undo.tests.testing_commands import SimpleCommand, UnnamedCommand
+from pyface.undo.tests.testing_commands import SimpleCommand
 
 from pyface.undo.action.api import RedoAction, UndoAction
 

--- a/pyface/undo/tests/test_undo_manager.py
+++ b/pyface/undo/tests/test_undo_manager.py
@@ -13,7 +13,7 @@ import unittest
 from traits.testing.api import UnittestTools
 
 from pyface.undo.api import CommandStack, UndoManager
-from pyface.undo.tests.testing_commands import SimpleCommand, UnnamedCommand
+from pyface.undo.tests.testing_commands import SimpleCommand
 
 
 class TestUndoManager(unittest.TestCase, UnittestTools):

--- a/pyface/util/fix_introspect_bug.py
+++ b/pyface/util/fix_introspect_bug.py
@@ -25,8 +25,6 @@ introspect module.
 # Import introspect.
 from wx.py import introspect
 
-import types
-
 # The fixed function.
 def getAttributeNames(
     object, includeMagic=1, includeSingle=1, includeDouble=1

--- a/pyface/util/testing.py
+++ b/pyface/util/testing.py
@@ -7,14 +7,9 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-import contextlib
 from functools import wraps
-import operator
 import re
-from unittest import (
-    mock,
-    TestSuite,
-)
+from unittest import TestSuite
 
 from packaging.version import Version
 
@@ -41,7 +36,7 @@ def filter_tests(test_suite, exclusion_pattern):
 def has_traitsui():
     """ Is traitsui installed? """
     try:
-        import traitsui
+        import traitsui  # noqa: F401
     except ImportError:
         return False
     return True

--- a/pyface/viewer/table_column_provider.py
+++ b/pyface/viewer/table_column_provider.py
@@ -11,9 +11,6 @@
 """ Base class for all table column providers. """
 
 
-from traits.api import Int
-
-
 from .column_provider import ColumnProvider
 
 

--- a/pyface/workbench/action/action_controller.py
+++ b/pyface/workbench/action/action_controller.py
@@ -12,7 +12,7 @@
 
 from pyface.action.api import ActionController
 from pyface.workbench.api import WorkbenchWindow
-from traits.api import HasTraits, Instance
+from traits.api import Instance
 
 
 class ActionController(ActionController):

--- a/pyface/workbench/i_editor.py
+++ b/pyface/workbench/i_editor.py
@@ -19,9 +19,7 @@ from traits.api import (
     Event,
     VetoableEvent,
     Vetoable,
-    HasTraits,
     Instance,
-    Interface,
 )
 from traits.api import provides
 

--- a/pyface/workbench/i_view.py
+++ b/pyface/workbench/i_view.py
@@ -15,7 +15,7 @@ import logging
 
 
 from pyface.api import ImageResource
-from traits.api import Bool, Enum, Float, Instance, List, provides, Str
+from traits.api import Bool, Instance, provides, Str
 from traits.util.camel_case import camel_case_to_words
 
 

--- a/pyface/workbench/i_workbench.py
+++ b/pyface/workbench/i_workbench.py
@@ -11,7 +11,7 @@
 
 
 from traits.api import Event, Instance, Interface, List, Str
-from traits.api import provides, VetoableEvent
+from traits.api import VetoableEvent
 
 
 from .user_perspective_manager import UserPerspectiveManager

--- a/pyface/workbench/tests/test_workbench_window.py
+++ b/pyface/workbench/tests/test_workbench_window.py
@@ -10,7 +10,6 @@
 
 import tempfile
 import shutil
-import os
 import unittest
 from unittest import mock
 
@@ -18,7 +17,6 @@ from traits.testing.api import UnittestTools
 
 from pyface.workbench.perspective import Perspective
 from pyface.workbench.api import Workbench
-from pyface.workbench.user_perspective_manager import UserPerspectiveManager
 from pyface.workbench.workbench_window import (
     WorkbenchWindow,
     WorkbenchWindowLayout,

--- a/pyface/workbench/workbench_window.py
+++ b/pyface/workbench/workbench_window.py
@@ -14,9 +14,9 @@ import logging
 
 
 from pyface.api import ApplicationWindow, GUI
-from traits.api import Callable, Constant, Delegate, Event, Instance
+from traits.api import Constant, Delegate, Instance
 from traits.api import List, Str, Tuple, Str, Vetoable, Undefined
-from traits.api import observe, provides
+from traits.api import observe
 
 
 from .i_editor import IEditor

--- a/pyface/wx/aui.py
+++ b/pyface/wx/aui.py
@@ -10,9 +10,6 @@
 
 import logging
 
-import os
-
-
 import wx
 
 # Logger.

--- a/pyface/wx/grid/grid.py
+++ b/pyface/wx/grid/grid.py
@@ -15,9 +15,6 @@ import wx
 from wx.grid import Grid as wxGrid
 
 
-from .grid_model import GridModel
-
-
 class Grid(wxGrid):
     """ A grid (spreadsheet) widget. """
 

--- a/pyface/wx/grid/grid_model.py
+++ b/pyface/wx/grid/grid_model.py
@@ -11,7 +11,6 @@
 """ A model that provides data for a grid. """
 
 
-import wx
 from wx.grid import (
     GridTableBase,
     GridTableMessage,
@@ -19,7 +18,7 @@ from wx.grid import (
 )
 
 
-from traits.api import Any, Bool, HasTraits, Trait, Event, List
+from traits.api import Any, Bool, HasTraits, Event, List
 
 
 from .grid_column import GridColumn

--- a/pyface/wx/spreadsheet/abstract_grid_view.py
+++ b/pyface/wx/spreadsheet/abstract_grid_view.py
@@ -8,15 +8,9 @@
 #
 # Thanks for using Enthought open source!
 
-from numpy import arange
-
 import wx
 from wx.grid import Grid
-from wx.grid import PyGridCellRenderer
-from wx.grid import GridCellTextEditor, GridCellStringRenderer
 from wx.grid import GridCellFloatRenderer, GridCellFloatEditor
-
-from wx.lib.mixins.grid import GridAutoEditMixin
 
 
 class AbstractGridView(Grid):

--- a/pyface/wx/spreadsheet/default_renderer.py
+++ b/pyface/wx/spreadsheet/default_renderer.py
@@ -9,7 +9,6 @@
 # Thanks for using Enthought open source!
 
 
-import types
 from string import atof
 import wx
 from wx.grid import PyGridCellRenderer

--- a/pyface/wx/spreadsheet/virtual_model.py
+++ b/pyface/wx/spreadsheet/virtual_model.py
@@ -10,11 +10,9 @@
 
 
 from wx.grid import (
-    Grid,
     PyGridTableBase,
     GridCellAttr,
     GridTableMessage,
-    GridCellFloatRenderer,
 )
 from wx.grid import (
     GRIDTABLE_NOTIFY_ROWS_DELETED,
@@ -25,10 +23,6 @@ from wx.grid import (
     GRIDTABLE_NOTIFY_COLS_APPENDED,
 )
 from wx.grid import GRIDTABLE_REQUEST_VIEW_GET_VALUES
-from wx.grid import GRID_VALUE_BOOL
-from wx import ALIGN_LEFT, ALIGN_CENTRE, Colour
-
-from .default_renderer import DefaultRenderer
 
 
 class VirtualModel(PyGridTableBase):


### PR DESCRIPTION
Fixes #911 and in general all F401 flake8 failures - "module imported but unused". This is one small step towards making the codebase flake8 clean.

With these changes and the following `setup.cfg`, I don't see any F401 flake8 failures - `flake8 --select=F401 pyface`

```
> type .\setup.cfg
[flake8]
exclude = pyface/qt/*,
per-file-ignores = */api.py:F401, */test_qt_imports.py:F401
```