### PR TITLE
Handle the events correctly

### DIFF
--- a/pyface/ui/wx/action/tool_bar_manager.py
+++ b/pyface/ui/wx/action/tool_bar_manager.py
@@ -223,12 +223,12 @@ class _ToolBar(wx.ToolBar):
     def _on_tool_bar_manager_enabled_changed(self, event):
         """ Dynamic trait change handler. """
 
-        obj.window._wx_enable_tool_bar(self, event.new)
+        event.object.window._wx_enable_tool_bar(self, event.new)
 
     def _on_tool_bar_manager_visible_changed(self, event):
         """ Dynamic trait change handler. """
 
-        obj.window._wx_show_tool_bar(self, event.new)
+        event.object.window._wx_show_tool_bar(self, event.new)
 
 
 class _AuiToolBar(AUI.AuiToolBar):
@@ -409,7 +409,9 @@ class _AuiToolBar(AUI.AuiToolBar):
         """ Dynamic trait change handler. """
 
         try:
-            obj.controller.task.window._wx_enable_tool_bar(self, event.new)
+            event.object.controller.task.window._wx_enable_tool_bar(
+                self, event.new
+            )
         except:
 
             pass
@@ -418,7 +420,9 @@ class _AuiToolBar(AUI.AuiToolBar):
         """ Dynamic trait change handler. """
 
         try:
-            obj.controller.task.window._wx_show_tool_bar(self, event.new)
+            event.object.controller.task.window._wx_show_tool_bar(
+                self, event.new
+            )
         except:
 
             pass


### PR DESCRIPTION
This was missed in the `on_trait_change` to `observe` changes introduced in #880 . The methods were previously receiving
`obj` as an argument to the trait change handler which should have been replaced with `event.object` in #880.

This was discovered when fixing `F821` flake8 failures in pyface.