### PR TITLE
Create generic module for GuiTestAssistant and ModalDialogTester

### DIFF
--- a/pyface/util/gui_test_assistant.py
+++ b/pyface/util/gui_test_assistant.py
@@ -1,0 +1,17 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" The implementation of a Gui Test Assistant. """
+
+
+# Import the toolkit specific version.
+from pyface.toolkit import toolkit_object
+
+GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")

--- a/pyface/util/modal_dialog_tester.py
+++ b/pyface/util/modal_dialog_tester.py
@@ -1,0 +1,19 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" The implementation of a Modal Dialog Tester. """
+
+
+# Import the toolkit specific version.
+from pyface.toolkit import toolkit_object
+
+ModalDialogTester = toolkit_object(
+    "util.modal_dialog_tester:ModalDialogTester"
+)

--- a/pyface/util/tests/test_gui_test_assistant.py
+++ b/pyface/util/tests/test_gui_test_assistant.py
@@ -1,0 +1,22 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!from unittest import TestCase
+
+import unittest
+
+from pyface.toolkit import toolkit
+
+is_wx = (toolkit.toolkit == "wx")
+
+class TestGuiTestAssistant(unittest.TestCase):
+
+    @unittest.skipIf(is_wx, "wx is not supported")
+    def test_import(self):
+        from pyface.util.gui_test_assistant import GuiTestAssistant
+        self.assertNotEqual(GuiTestAssistant.__name__, "Unimplemented")

--- a/pyface/util/tests/test_modal_dialog_tester.py
+++ b/pyface/util/tests/test_modal_dialog_tester.py
@@ -1,0 +1,22 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!from unittest import TestCase
+
+import unittest
+
+from pyface.toolkit import toolkit
+
+is_wx = (toolkit.toolkit == "wx")
+
+class TestModalDialogTester(unittest.TestCase):
+
+    @unittest.skipIf(is_wx, "wx is not supported")
+    def test_import(self):
+        from pyface.util.modal_dialog_tester import ModalDialogTester
+        self.assertNotEqual(ModalDialogTester.__name__, "Unimplemented")


### PR DESCRIPTION
closes #905 

This PR creates modules for `GuiTestAssistant` and `ModalDialogTester` so that they can more easily be imported via 
`from pyface.util.{gui_test_assistant/modal_dialog_tester} import {GuiTestAssistant/ModalDialogTester}`

It is still important to now check if the imported item is `Unimplemented` as these are both currently only supported for qt.

This PR also adds very simply tests to test importing the objects from the modules