### PR TITLE
Replace "Either" trait with "Union"

### DIFF
--- a/pyface/tasks/action/schema.py
+++ b/pyface/tasks/action/schema.py
@@ -20,7 +20,6 @@ from pyface.util.id_helper import get_unique_id
 from traits.api import (
     Bool,
     Callable,
-    Either,
     Enum,
     HasTraits,
     Instance,
@@ -28,10 +27,11 @@ from traits.api import (
     Property,
     Str,
     Tuple,
+    Union,
 )
 
 # Trait definitions.
-SubSchema = Either(
+SubSchema = Union(
     None,
     Instance(Action),
     Instance(ActionItem),

--- a/pyface/tasks/task_layout.py
+++ b/pyface/tasks/task_layout.py
@@ -12,7 +12,7 @@ from io import StringIO
 import sys
 
 
-from traits.api import Either, Enum, HasStrictTraits, Int, Instance, List, Str
+from traits.api import Enum, HasStrictTraits, Int, Instance, List, Str, Union
 
 
 class LayoutItem(HasStrictTraits):
@@ -108,7 +108,7 @@ class PaneItem(LayoutItem):
 
     #: The ID of the item. If the item refers to a TaskPane, this is the ID of
     #: that TaskPane.
-    id = Either(Str, Int, default="", pretty_skip=True)
+    id = Union(Str, Int, default_value="", pretty_skip=True)
 
     #: The width of the pane in pixels. If not specified, the pane will be
     #: sized according to its size hint.
@@ -136,7 +136,7 @@ class Tabbed(LayoutContainer):
 
     #: The ID of the TaskPane which is active in layout. If not specified, the
     #: first pane is active.
-    active_tab = Either(Str, Int, default="")
+    active_tab = Union(Str, Int, default_value="")
 
 
 class Splitter(LayoutContainer):
@@ -149,7 +149,7 @@ class Splitter(LayoutContainer):
     #: The sub-items of the splitter, which are PaneItems, Tabbed layouts, and
     #: other Splitters.
     items = List(
-        Either(
+        Union(
             Instance(PaneItem),
             Instance(Tabbed),
             Instance("pyface.tasks.task_layout.Splitter"),
@@ -177,10 +177,10 @@ class DockLayout(LayoutItem):
     """
 
     #: The layouts for the task's dock panes.
-    left = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
-    right = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
-    top = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
-    bottom = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    left = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    right = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    top = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    bottom = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
 
     #: Assignments of dock areas to the window's corners. By default, the top
     #: and bottom dock areas extend into both of the top and both of the

--- a/pyface/tasks/task_layout.py
+++ b/pyface/tasks/task_layout.py
@@ -12,7 +12,9 @@ from io import StringIO
 import sys
 
 
-from traits.api import Enum, HasStrictTraits, Int, Instance, List, Str, Union
+from traits.api import (
+    Either, Enum, HasStrictTraits, Int, Instance, List, Str, Union,
+)
 
 
 class LayoutItem(HasStrictTraits):
@@ -149,7 +151,7 @@ class Splitter(LayoutContainer):
     #: The sub-items of the splitter, which are PaneItems, Tabbed layouts, and
     #: other Splitters.
     items = List(
-        Union(
+        Either(
             Instance(PaneItem),
             Instance(Tabbed),
             Instance("pyface.tasks.task_layout.Splitter"),
@@ -177,10 +179,10 @@ class DockLayout(LayoutItem):
     """
 
     #: The layouts for the task's dock panes.
-    left = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
-    right = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
-    top = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
-    bottom = Union(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    left = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    right = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    top = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
+    bottom = Either(Instance(PaneItem), Instance(Tabbed), Instance(Splitter))
 
     #: Assignments of dock areas to the window's corners. By default, the top
     #: and bottom dock areas extend into both of the top and both of the

--- a/pyface/tasks/task_window_layout.py
+++ b/pyface/tasks/task_window_layout.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import List, Str, Tuple, Enum, Instance, Union
+from traits.api import Either, List, Str, Tuple, Enum, Instance, Union
 
 
 from pyface.tasks.task_layout import LayoutContainer, TaskLayout
@@ -24,7 +24,7 @@ class TaskWindowLayout(LayoutContainer):
 
     #: The tasks contained in the window. If an ID is specified, the task will
     #: use its default layout. Otherwise, it will use the specified TaskLayout
-    items = List(Union(Str, Instance(TaskLayout)), pretty_skip=True)
+    items = List(Either(Str, Instance(TaskLayout)), pretty_skip=True)
 
     #: The position of the window.
     position = Tuple(-1, -1)

--- a/pyface/tasks/task_window_layout.py
+++ b/pyface/tasks/task_window_layout.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Either, List, Str, Tuple, Enum, Instance
+from traits.api import List, Str, Tuple, Enum, Instance, Union
 
 
 from pyface.tasks.task_layout import LayoutContainer, TaskLayout
@@ -24,7 +24,7 @@ class TaskWindowLayout(LayoutContainer):
 
     #: The tasks contained in the window. If an ID is specified, the task will
     #: use its default layout. Otherwise, it will use the specified TaskLayout
-    items = List(Either(Str, Instance(TaskLayout)), pretty_skip=True)
+    items = List(Union(Str, Instance(TaskLayout)), pretty_skip=True)
 
     #: The position of the window.
     position = Tuple(-1, -1)

--- a/pyface/timer/i_timer.py
+++ b/pyface/timer/i_timer.py
@@ -22,7 +22,6 @@ from traits.api import (
     Bool,
     Callable,
     Dict,
-    Either,
     Event,
     Float,
     HasTraits,
@@ -32,6 +31,7 @@ from traits.api import (
     Range,
     Tuple,
     provides,
+    Union,
 )
 
 perf_counter = time.perf_counter
@@ -50,10 +50,10 @@ class ITimer(Interface):
     interval = Range(low=0.0)
 
     #: The number of times to repeat the callback, or None if no limit.
-    repeat = Either(None, Int)
+    repeat = Union(None, Int)
 
     #: The maximum length of time to run in seconds, or None if no limit.
-    expire = Either(None, Float)
+    expire = Union(None, Float)
 
     #: Whether or not the timer is currently running.
     active = Bool()
@@ -131,10 +131,10 @@ class BaseTimer(ABCHasTraits):
     interval = Range(low=0.0, value=0.05)
 
     #: The number of times to repeat the callback, or None if no limit.
-    repeat = Either(None, Int)
+    repeat = Union(None, Int)
 
     #: The maximum length of time to run in seconds, or None if no limit.
-    expire = Either(None, Float)
+    expire = Union(None, Float)
 
     #: Property that controls the state of the timer.
     active = Property(Bool, observe="_active")

--- a/pyface/ui/wx/grid/composite_grid_model.py
+++ b/pyface/ui/wx/grid/composite_grid_model.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 
-from traits.api import Dict, Either, Instance, List
+from traits.api import Dict, Instance, List, Union
 
 
 from .grid_model import GridModel, GridRow
@@ -23,7 +23,7 @@ class CompositeGridModel(GridModel):
     data = List(Instance(GridModel))
 
     # The rows in the model.
-    rows = Either(None, List(Instance(GridRow)))
+    rows = Union(None, List(Instance(GridRow)))
 
     # The cached data indexes.
     _data_index = Dict()

--- a/pyface/ui/wx/grid/simple_grid_model.py
+++ b/pyface/ui/wx/grid/simple_grid_model.py
@@ -15,7 +15,7 @@ with row/column labels as the index + 1."""
 
 
 from pyface.action.api import Action, Group, MenuManager
-from traits.api import Either, Any, Instance, List
+from traits.api import Any, Instance, List, Union
 from pyface.wx.drag_and_drop import clipboard as enClipboard
 
 
@@ -32,10 +32,10 @@ class SimpleGridModel(GridModel):
     data = Any()
 
     # The rows in the model.
-    rows = Either(None, List(Instance(GridRow)))
+    rows = Union(None, List(Instance(GridRow)))
 
     # The columns in the model.
-    columns = Either(None, List(Instance(GridColumn)))
+    columns = Union(None, List(Instance(GridColumn)))
 
     # ------------------------------------------------------------------------
     # 'object' interface.

--- a/pyface/ui/wx/grid/trait_grid_model.py
+++ b/pyface/ui/wx/grid/trait_grid_model.py
@@ -22,13 +22,13 @@ from traits.api import (
     Bool,
     Callable,
     Dict,
-    Either,
     HasTraits,
     Instance,
     Int,
     List,
     Str,
     Type,
+    Union,
 )
 
 
@@ -40,20 +40,20 @@ class TraitGridColumn(GridColumn):
     """ Structure for holding column specifications in a TraitGridModel. """
 
     # The trait name for this column. This takes precedence over method
-    name = Either(None, Str)
+    name = Union(None, Str)
 
     # A method name to call to get the value for this column
-    method = Either(None, Str)
+    method = Union(None, Str)
 
     # A method to be used to sort on this column
     sorter = Callable
 
     # A dictionary of formats for the display of different types. If it is
     # defined as a callable, then that callable must accept a single argument.
-    formats = Dict(Type, Either(Str, Callable))
+    formats = Dict(Type, Union(Str, Callable))
 
     # A name to designate the type of this column
-    typename = Either(None, Str)
+    typename = Union(None, Str)
     # note: context menus should go in here as well? but we need
     #       more info than we have available at this point
 
@@ -67,7 +67,7 @@ class TraitGridSelection(HasTraits):
     obj = Instance(HasTraits)
 
     # The specific trait selected on the object
-    trait_name = Either(None, Str)
+    trait_name = Union(None, Str)
 
 
 # The meat.
@@ -83,10 +83,10 @@ class TraitGridModel(GridModel):
     data = List(Any)
 
     # The column definitions
-    columns = Either(None, List(Either(None, Str, Instance(TraitGridColumn))))
+    columns = Union(None, List(Union(None, Str, Instance(TraitGridColumn))))
 
     # The trait to look at to get the row name
-    row_name_trait = Either(None, Str)
+    row_name_trait = Union(None, Str)
 
     # Allow column sorting?
     allow_column_sort = Bool(True)

--- a/pyface/ui/wx/grid/trait_grid_model.py
+++ b/pyface/ui/wx/grid/trait_grid_model.py
@@ -22,6 +22,7 @@ from traits.api import (
     Bool,
     Callable,
     Dict,
+    Either,
     HasTraits,
     Instance,
     Int,
@@ -50,7 +51,7 @@ class TraitGridColumn(GridColumn):
 
     # A dictionary of formats for the display of different types. If it is
     # defined as a callable, then that callable must accept a single argument.
-    formats = Dict(Type, Union(Str, Callable))
+    formats = Dict(Type, Either(Str, Callable))
 
     # A name to designate the type of this column
     typename = Union(None, Str)


### PR DESCRIPTION
This PR replaces the `Either` trait with the `Union` trait.

> A new Union trait type has been added. This is intended as a simpler replacement for the existing Either trait type, which will eventually be deprecated.

See https://github.com/enthought/traits/releases/tag/6.1.0.

See similar PR in traitsui https://github.com/enthought/traitsui/pull/1581