### PR TITLE
Remove unnecessary try/except around ETSConfig.provisional_toolkit

### DIFF
--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -77,32 +77,6 @@ except ImportError:
 from traits.api import HasTraits, List, ReadOnly, Str, TraitError
 from traits.etsconfig.api import ETSConfig
 
-
-try:
-    provisional_toolkit = ETSConfig.provisional_toolkit
-except AttributeError:
-    from contextlib import contextmanager
-
-    # for backward compatibility
-    @contextmanager
-    def provisional_toolkit(toolkit_name):
-        """ Perform an operation with toolkit provisionally set
-
-        This sets the toolkit attribute of the ETSConfig object set to the
-        provided value. If the operation fails with an exception, the toolkit
-        is reset to nothing.
-        """
-        if ETSConfig.toolkit:
-            raise AttributeError("ETSConfig toolkit is already set")
-        ETSConfig.toolkit = toolkit_name
-        try:
-            yield
-        except:
-            # reset the toolkit state
-            ETSConfig._toolkit = ""
-            raise
-
-
 logger = logging.getLogger(__name__)
 
 

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -141,7 +141,7 @@ class Toolkit(HasTraits):
                     # the traceback's stack frame mentions the toolkit in question.
                     import traceback
 
-                    frames = traceback.extract_tb(sys.exc_traceback)
+                    frames = traceback.extract_tb(sys.exc_info()[2])
                     filename, lineno, function, text = frames[-1]
                     if package not in filename:
                         raise

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -141,7 +141,7 @@ class Toolkit(HasTraits):
                     # the traceback's stack frame mentions the toolkit in question.
                     import traceback
 
-                    frames = traceback.extract_tb(sys.exc_info()[2])
+                    frames = traceback.extract_tb(sys.exc_traceback)
                     filename, lineno, function, text = frames[-1]
                     if package not in filename:
                         raise


### PR DESCRIPTION
closes #927 

Note, that later in the file we were already just directly using `ETSConfig.provisional_toolkit` not `provisional_toolkit` (effectively assuming the try portion of the try...except would succeed).  This PR removes the whole try...except which is now unnecessary.