### PR TITLE
replace sys.exc_traceback with sys.exc_info()[2]

### DIFF
--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -167,7 +167,7 @@ class Toolkit(HasTraits):
                     # the traceback's stack frame mentions the toolkit in question.
                     import traceback
 
-                    frames = traceback.extract_tb(sys.exc_traceback)
+                    frames = traceback.extract_tb(sys.exc_info()[2])
                     filename, lineno, function, text = frames[-1]
                     if package not in filename:
                         raise


### PR DESCRIPTION
closes #930 

`sys._exc_traceback` has been deprecated and was causing an error if running the test suite with `ETS_DEBUG=True`.  This PR replaces it and we no longer see that error.

Unfortunately, running the test suite with `ETS_DEBUG=True` is still not a pretty sight, with numerous errors.  Those can be addressed in separate PRs