### PR TITLE
Dont complain about old versions of PyQt4 and Qt4

### DIFF
--- a/pyface/ui/qt4/init.py
+++ b/pyface/ui/qt4/init.py
@@ -14,21 +14,9 @@ import sys
 
 from traits.trait_notifiers import set_ui_handler, ui_handler
 
-from pyface.qt import QtCore, QtGui, qt_api
+from pyface.qt import QtCore, QtGui
 from pyface.base_toolkit import Toolkit
 from .gui import GUI
-
-if qt_api == "pyqt":
-    # Check the version numbers are late enough.
-    if QtCore.QT_VERSION < 0x040200:
-        raise RuntimeError(
-            "Need Qt v4.2 or higher, but got v%s" % QtCore.QT_VERSION_STR
-        )
-
-    if QtCore.PYQT_VERSION < 0x040100:
-        raise RuntimeError(
-            "Need PyQt v4.1 or higher, but got v%s" % QtCore.PYQT_VERSION_STR
-        )
 
 # It's possible that it has already been initialised.
 _app = QtGui.QApplication.instance()


### PR DESCRIPTION
This PR removes the runtime errors that were being reaised for very old versions of PyQt4 and Qt4, specifically `< 4.1` for PyQt4 and `< 4.2` for Qt4. This is acceptable as the only available versions of PyQt4 on EDM for Python 3 are `>= 4.11`.