### PR TITLE
Cleanup code handling wx version < 2.8

### DIFF
--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -16,14 +16,6 @@ from traits.trait_notifiers import set_ui_handler, ui_handler
 from pyface.base_toolkit import Toolkit
 from .gui import GUI
 
-
-# Check the version number is late enough.
-if wx.VERSION < (2, 8):
-    raise RuntimeError(
-        "Need wx version 2.8 or higher, but got %s" % str(wx.VERSION)
-    )
-
-
 # It's possible that it has already been initialised.
 _app = wx.GetApp()
 if _app is None:


### PR DESCRIPTION
This PR removes code that was handling wx version < 2.8. Wx less than 2.8 isnt even available via pypi for python 3. Ref https://pypi.org/project/wxPython/#history