### PR TITLE
Use importlib.resources.files and importlib.metadata if available

### DIFF
--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -19,8 +19,8 @@ except ImportError:
 
 
 __requires__ = [
-    "importlib-metadata",
-    "importlib-resources>=1.1.0",
+    'importlib-metadata; python_version<"3.8"',
+    'importlib-resources>=1.1.0; python_version<"3.9"',
     "traits>=6.2"
 ]
 __extras_require__ = {

--- a/pyface/resource/resource_manager.py
+++ b/pyface/resource/resource_manager.py
@@ -21,7 +21,13 @@ from os.path import join
 import types
 from zipfile import is_zipfile, ZipFile
 
-from importlib_resources import files
+# importlib.resources is new in Python 3.7, and importlib.resources.files is
+# new in Python 3.9, so for Python < 3.9 we must rely on the 3rd party
+# importlib_resources package.
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 from traits.api import HasTraits, Instance, List
 from traits.util.resource import get_path

--- a/pyface/tests/test_image_resource.py
+++ b/pyface/tests/test_image_resource.py
@@ -13,7 +13,13 @@ import os
 import platform
 import unittest
 
-from importlib_resources import files
+# importlib.resources is new in Python 3.7, and importlib.resources.files is
+# new in Python 3.9, so for Python < 3.9 we must rely on the 3rd party
+# importlib_resources package.
+try:
+    from importlib.resources import files
+except ImportError:
+    from importlib_resources import files
 
 import pyface
 import pyface.tests


### PR DESCRIPTION
This PR:

- updates the core code to use `importlib.resources.files` in preference to `importlib_resources.files`
- updates the `setup.py` requirements so that `importlib_resources` and `importlib_metadata` aren't installed if they're not needed


Closes #942.