### PR TITLE
Update super usage in the "qt" backend

### DIFF
--- a/pyface/ui/qt4/about_dialog.py
+++ b/pyface/ui/qt4/about_dialog.py
@@ -86,7 +86,7 @@ class AboutDialog(MAboutDialog, Dialog):
             signal, handler = self._connections_to_remove.pop()
             signal.disconnect(handler)
 
-        super(AboutDialog, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -26,7 +26,7 @@ from pyface.action.action_event import ActionEvent
 
 class PyfaceWidgetAction(QtGui.QWidgetAction):
     def __init__(self, parent, action):
-        super(PyfaceWidgetAction, self).__init__(parent)
+        super().__init__(parent)
         self.action = action
 
     def createWidget(self, parent):

--- a/pyface/ui/qt4/action/menu_manager.py
+++ b/pyface/ui/qt4/action/menu_manager.py
@@ -75,7 +75,7 @@ class MenuManager(ActionManager, ActionManagerItem):
             menu = self._menus.pop()
             menu.dispose()
 
-        super(MenuManager, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # 'ActionManagerItem' interface.
@@ -171,7 +171,7 @@ class _Menu(QtGui.QMenu):
 
         self.menu_items = []
 
-        super(_Menu, self).clear()
+        super().clear()
 
     def is_empty(self):
         """ Is the menu empty? """

--- a/pyface/ui/qt4/action/tool_bar_manager.py
+++ b/pyface/ui/qt4/action/tool_bar_manager.py
@@ -66,7 +66,7 @@ class ToolBarManager(ActionManager):
         """ Creates a new tool bar manager. """
 
         # Base class constructor.
-        super(ToolBarManager, self).__init__(*args, **traits)
+        super().__init__(*args, **traits)
 
         # An image cache to make sure that we only load each image used in the
         # tool bar exactly once.
@@ -121,7 +121,7 @@ class ToolBarManager(ActionManager):
             toolbar = self._toolbars.pop()
             toolbar.dispose()
 
-        super(ToolBarManager, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # Private interface.

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -129,7 +129,7 @@ class ApplicationWindow(MApplicationWindow, Window):
     # ------------------------------------------------------------------------
 
     def _create(self):
-        super(ApplicationWindow, self)._create()
+        super()._create()
 
         contents = self._create_contents(self.control)
         self.control.setCentralWidget(contents)
@@ -137,7 +137,7 @@ class ApplicationWindow(MApplicationWindow, Window):
         self._create_trim_widgets(self.control)
 
     def _create_control(self, parent):
-        control = super(ApplicationWindow, self)._create_control(parent)
+        control = super()._create_control(parent)
         control.setObjectName("ApplicationWindow")
 
         control.setAnimated(False)

--- a/pyface/ui/qt4/code_editor/code_widget.py
+++ b/pyface/ui/qt4/code_editor/code_widget.py
@@ -33,7 +33,7 @@ class CodeWidget(QtGui.QPlainTextEdit):
     def __init__(
         self, parent, should_highlight_current_line=True, font=None, lexer=None
     ):
-        super(CodeWidget, self).__init__(parent)
+        super().__init__(parent)
 
         self.highlighter = PygmentsHighlighter(self.document(), lexer)
         self.line_number_widget = LineNumberWidget(self)
@@ -387,7 +387,7 @@ class CodeWidget(QtGui.QPlainTextEdit):
 
     def keyPressEvent(self, event):
         if self.isReadOnly():
-            return super(CodeWidget, self).keyPressEvent(event)
+            return super().keyPressEvent(event)
 
         key_sequence = QtGui.QKeySequence(event.key() + int(event.modifiers()))
 
@@ -432,7 +432,7 @@ class CodeWidget(QtGui.QPlainTextEdit):
             event.accept()
             return self.block_unindent()
 
-        return super(CodeWidget, self).keyPressEvent(event)
+        return super().keyPressEvent(event)
 
     def resizeEvent(self, event):
         QtGui.QPlainTextEdit.resizeEvent(self, event)
@@ -558,7 +558,7 @@ class AdvancedCodeWidget(QtGui.QWidget):
     # ------------------------------------------------------------------------
 
     def __init__(self, parent, font=None, lexer=None):
-        super(AdvancedCodeWidget, self).__init__(parent)
+        super().__init__(parent)
 
         self.code = CodeWidget(self, font=font, lexer=lexer)
         self.find = FindWidget(self)
@@ -804,7 +804,7 @@ class AdvancedCodeWidget(QtGui.QWidget):
                 self.previous_find_widget = self.active_find_widget
                 self.active_find_widget = None
 
-        return super(AdvancedCodeWidget, self).keyPressEvent(event)
+        return super().keyPressEvent(event)
 
     # ------------------------------------------------------------------------
     # Private methods

--- a/pyface/ui/qt4/code_editor/find_widget.py
+++ b/pyface/ui/qt4/code_editor/find_widget.py
@@ -16,7 +16,7 @@ from pyface.qt import QtGui, QtCore
 
 class FindWidget(QtGui.QWidget):
     def __init__(self, parent):
-        super(FindWidget, self).__init__(parent)
+        super().__init__(parent)
         self.adv_code_widget = weakref.ref(parent)
 
         # QFontMetrics.width() is deprecated and Qt docs suggest using

--- a/pyface/ui/qt4/code_editor/gutters.py
+++ b/pyface/ui/qt4/code_editor/gutters.py
@@ -39,7 +39,7 @@ class StatusGutterWidget(GutterWidget):
     """
 
     def __init__(self, *args, **kw):
-        super(StatusGutterWidget, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         self.error_lines = []
         self.warn_lines = []

--- a/pyface/ui/qt4/code_editor/pygments_highlighter.py
+++ b/pyface/ui/qt4/code_editor/pygments_highlighter.py
@@ -138,7 +138,7 @@ class PygmentsHighlighter(QtGui.QSyntaxHighlighter):
     """ Syntax highlighter that uses Pygments for parsing. """
 
     def __init__(self, parent, lexer=None):
-        super(PygmentsHighlighter, self).__init__(parent)
+        super().__init__(parent)
 
         try:
             self._lexer = get_lexer_by_name(lexer)

--- a/pyface/ui/qt4/code_editor/replace_widget.py
+++ b/pyface/ui/qt4/code_editor/replace_widget.py
@@ -18,7 +18,9 @@ from .find_widget import FindWidget
 
 class ReplaceWidget(FindWidget):
     def __init__(self, parent):
-        super().__init__(parent)
+        # We explicitly call __init__ on the classes which FindWidget inherits from
+        # instead of calling FindWidget.__init__.
+        super(FindWidget, self).__init__(parent)
         self.adv_code_widget = weakref.ref(parent)
 
         # QFontMetrics.width() is deprecated and Qt docs suggest using

--- a/pyface/ui/qt4/code_editor/replace_widget.py
+++ b/pyface/ui/qt4/code_editor/replace_widget.py
@@ -18,7 +18,7 @@ from .find_widget import FindWidget
 
 class ReplaceWidget(FindWidget):
     def __init__(self, parent):
-        super(FindWidget, self).__init__(parent)
+        super().__init__(parent)
         self.adv_code_widget = weakref.ref(parent)
 
         # QFontMetrics.width() is deprecated and Qt docs suggest using

--- a/pyface/ui/qt4/console/bracket_matcher.py
+++ b/pyface/ui/qt4/console/bracket_matcher.py
@@ -32,7 +32,7 @@ class BracketMatcher(QtCore.QObject):
             text edit widget.
         """
         assert isinstance(text_edit, (QtGui.QTextEdit, QtGui.QPlainTextEdit))
-        super(BracketMatcher, self).__init__()
+        super().__init__()
 
         # The format to apply to matching brackets.
         self.format = QtGui.QTextCharFormat()

--- a/pyface/ui/qt4/console/call_tip_widget.py
+++ b/pyface/ui/qt4/console/call_tip_widget.py
@@ -28,7 +28,7 @@ class CallTipWidget(QtGui.QLabel):
             text edit widget.
         """
         assert isinstance(text_edit, (QtGui.QTextEdit, QtGui.QPlainTextEdit))
-        super(CallTipWidget, self).__init__(None, QtCore.Qt.ToolTip)
+        super().__init__(None, QtCore.Qt.ToolTip)
 
         self._hide_timer = QtCore.QBasicTimer()
         self._text_edit = text_edit
@@ -78,7 +78,7 @@ class CallTipWidget(QtGui.QLabel):
             elif etype == QtCore.QEvent.Leave:
                 self._leave_event_hide()
 
-        return super(CallTipWidget, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)
 
     def timerEvent(self, event):
         """ Reimplemented to hide the widget when the hide timer fires.
@@ -94,13 +94,13 @@ class CallTipWidget(QtGui.QLabel):
     def enterEvent(self, event):
         """ Reimplemented to cancel the hide timer.
         """
-        super(CallTipWidget, self).enterEvent(event)
+        super().enterEvent(event)
         self._hide_timer.stop()
 
     def hideEvent(self, event):
         """ Reimplemented to disconnect signal handlers and event filter.
         """
-        super(CallTipWidget, self).hideEvent(event)
+        super().hideEvent(event)
         self._text_edit.cursorPositionChanged.disconnect(
             self._cursor_position_changed
         )
@@ -109,7 +109,7 @@ class CallTipWidget(QtGui.QLabel):
     def leaveEvent(self, event):
         """ Reimplemented to start the hide timer.
         """
-        super(CallTipWidget, self).leaveEvent(event)
+        super().leaveEvent(event)
         self._leave_event_hide()
 
     def paintEvent(self, event):
@@ -121,17 +121,17 @@ class CallTipWidget(QtGui.QLabel):
         painter.drawPrimitive(QtGui.QStyle.PE_PanelTipLabel, option)
         painter.end()
 
-        super(CallTipWidget, self).paintEvent(event)
+        super().paintEvent(event)
 
     def setFont(self, font):
         """ Reimplemented to allow use of this method as a slot.
         """
-        super(CallTipWidget, self).setFont(font)
+        super().setFont(font)
 
     def showEvent(self, event):
         """ Reimplemented to connect signal handlers and event filter.
         """
-        super(CallTipWidget, self).showEvent(event)
+        super().showEvent(event)
         self._text_edit.cursorPositionChanged.connect(
             self._cursor_position_changed
         )

--- a/pyface/ui/qt4/console/console_widget.py
+++ b/pyface/ui/qt4/console/console_widget.py
@@ -134,7 +134,7 @@ class ConsoleWidget(QtGui.QWidget):
         parent : QWidget, optional [default None]
             The parent for this widget.
         """
-        super(ConsoleWidget, self).__init__(parent)
+        super().__init__(parent)
 
         # A list of connected Qt signals to be removed before destruction.
         # First item in the tuple is the Qt signal. The second item is the
@@ -310,7 +310,7 @@ class ConsoleWidget(QtGui.QWidget):
             QtGui.QApplication.sendEvent(obj, QtGui.QDragLeaveEvent())
             return True
 
-        return super(ConsoleWidget, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)
 
     def _remove_event_listeners(self):
         while self._connections_to_remove:

--- a/pyface/ui/qt4/console/history_console_widget.py
+++ b/pyface/ui/qt4/console/history_console_widget.py
@@ -25,7 +25,7 @@ class HistoryConsoleWidget(ConsoleWidget):
     # ---------------------------------------------------------------------------
 
     def __init__(self, *args, **kw):
-        super(HistoryConsoleWidget, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
         # HistoryConsoleWidget protected variables.
         self._history = []
@@ -42,9 +42,7 @@ class HistoryConsoleWidget(ConsoleWidget):
         if not hidden:
             history = self.input_buffer if source is None else source
 
-        executed = super(HistoryConsoleWidget, self).execute(
-            source, hidden, interactive
-        )
+        executed = super().execute(source, hidden, interactive)
 
         if executed and not hidden:
             # Save the command unless it was an empty string or was identical

--- a/pyface/ui/qt4/dialog.py
+++ b/pyface/ui/qt4/dialog.py
@@ -157,7 +157,7 @@ class Dialog(MDialog, Window):
             signal, handler = self._connections_to_remove.pop()
             signal.disconnect(handler)
 
-        super(Dialog, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/ui/qt4/directory_dialog.py
+++ b/pyface/ui/qt4/directory_dialog.py
@@ -60,7 +60,7 @@ class DirectoryDialog(MDirectoryDialog, Dialog):
             self.path = ""
 
         # Let the window close as normal.
-        super(DirectoryDialog, self).close()
+        super().close()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/ui/qt4/file_dialog.py
+++ b/pyface/ui/qt4/file_dialog.py
@@ -104,7 +104,7 @@ class FileDialog(MFileDialog, Dialog):
         )
 
         # Let the window close as normal.
-        super(FileDialog, self).close()
+        super().close()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/ui/qt4/gui.py
+++ b/pyface/ui/qt4/gui.py
@@ -142,7 +142,7 @@ class _FutureCall(QtCore.QObject):
     _pyface_event = QtCore.QEvent.Type(QtCore.QEvent.registerEventType())
 
     def __init__(self, ms, callable, *args, **kw):
-        super(_FutureCall, self).__init__()
+        super().__init__()
 
         # Save the arguments.
         self._ms = ms
@@ -184,7 +184,7 @@ class _FutureCall(QtCore.QObject):
                 QtCore.QTimer.singleShot(self._ms, self._dispatch)
             return True
 
-        return super(_FutureCall, self).event(event)
+        return super().event(event)
 
     def _dispatch(self):
         """ Invoke the callable.

--- a/pyface/ui/qt4/heading_text.py
+++ b/pyface/ui/qt4/heading_text.py
@@ -42,7 +42,7 @@ class HeadingText(MHeadingText, Widget):
         """ Creates the panel. """
 
         # Base class constructor.
-        super(HeadingText, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self._create_control(parent)

--- a/pyface/ui/qt4/progress_dialog.py
+++ b/pyface/ui/qt4/progress_dialog.py
@@ -96,7 +96,7 @@ class ProgressDialog(MProgressDialog, Window):
 
     def open(self):
         """ Opens the window. """
-        super(ProgressDialog, self).open()
+        super().open()
         self._start_time = time.time()
 
     def close(self):
@@ -104,7 +104,7 @@ class ProgressDialog(MProgressDialog, Window):
         self.progress_bar.destroy()
         self.progress_bar = None
 
-        super(ProgressDialog, self).close()
+        super().close()
 
     # -------------------------------------------------------------------------
     # 'IWidget' interface.
@@ -115,7 +115,7 @@ class ProgressDialog(MProgressDialog, Window):
             signal, handler = self._connections_to_remove.pop()
             signal.disconnect(handler)
 
-        super(ProgressDialog, self).destroy()
+        super().destroy()
 
     # -------------------------------------------------------------------------
     # IProgressDialog Interface
@@ -273,7 +273,7 @@ class ProgressDialog(MProgressDialog, Window):
         return QtGui.QDialog(parent)
 
     def _create(self):
-        super(ProgressDialog, self)._create()
+        super()._create()
         self._create_contents(self.control)
 
     def _create_contents(self, parent):

--- a/pyface/ui/qt4/python_editor.py
+++ b/pyface/ui/qt4/python_editor.py
@@ -47,7 +47,7 @@ class PythonEditor(MPythonEditor, Widget):
     # ------------------------------------------------------------------------
 
     def __init__(self, parent, **traits):
-        super(PythonEditor, self).__init__(parent=parent, **traits)
+        super().__init__(parent=parent, **traits)
         self._create()
 
     # ------------------------------------------------------------------------
@@ -96,7 +96,7 @@ class PythonEditor(MPythonEditor, Widget):
     # ------------------------------------------------------------------------
 
     def _add_event_listeners(self):
-        super(PythonEditor, self)._add_event_listeners()
+        super()._add_event_listeners()
         self.control.code.installEventFilter(self._event_filter)
 
         # Connect signals for text changes.
@@ -116,7 +116,7 @@ class PythonEditor(MPythonEditor, Widget):
             if self._event_filter is not None:
                 self.control.code.removeEventFilter(self._event_filter)
 
-        super(PythonEditor, self)._remove_event_listeners()
+        super()._remove_event_listeners()
 
     def __event_filter_default(self):
         return PythonEditorEventFilter(self, self.control)
@@ -168,7 +168,7 @@ class PythonEditorEventFilter(QtCore.QObject):
     """
 
     def __init__(self, editor, parent):
-        super(PythonEditorEventFilter, self).__init__(parent)
+        super().__init__(parent)
         self.__editor = editor
 
     def eventFilter(self, obj, event):
@@ -211,4 +211,4 @@ class PythonEditorEventFilter(QtCore.QObject):
                 event=event,
             )
 
-        return super(PythonEditorEventFilter, self).eventFilter(obj, event)
+        return super().eventFilter(obj, event)

--- a/pyface/ui/qt4/python_shell.py
+++ b/pyface/ui/qt4/python_shell.py
@@ -57,7 +57,7 @@ class PythonShell(MPythonShell, Widget):
     # FIXME v3: Either make this API consistent with other Widget sub-classes
     # or make it a sub-class of HasTraits.
     def __init__(self, parent, **traits):
-        super(PythonShell, self).__init__(parent=parent, **traits)
+        super().__init__(parent=parent, **traits)
 
         # Create the toolkit-specific control that represents the widget.
         self._create()
@@ -109,7 +109,7 @@ class PythonShell(MPythonShell, Widget):
         return PyfacePythonWidget(self, parent)
 
     def _add_event_listeners(self):
-        super(PythonShell, self)._add_event_listeners()
+        super()._add_event_listeners()
 
         # Connect signals for events.
         self.control.executed.connect(self._on_command_executed)
@@ -123,7 +123,7 @@ class PythonShell(MPythonShell, Widget):
 
             self.control._remove_event_listeners()
 
-        super(PythonShell, self)._remove_event_listeners()
+        super()._remove_event_listeners()
 
     def __event_filter_default(self):
         return _DropEventEmitter(self.control)
@@ -169,7 +169,7 @@ class PythonWidget(HistoryConsoleWidget):
     # --------------------------------------------------------------------------
 
     def __init__(self, parent=None):
-        super(PythonWidget, self).__init__(parent)
+        super().__init__(parent)
 
         # PythonWidget attributes.
         self.locals = dict(__name__="__console__", __doc__=None)
@@ -209,7 +209,7 @@ class PythonWidget(HistoryConsoleWidget):
 
         self._bracket_matcher._remove_event_listeners()
 
-        super(PythonWidget, self)._remove_event_listeners()
+        super()._remove_event_listeners()
 
     # --------------------------------------------------------------------------
     # file-like object interface
@@ -352,12 +352,12 @@ class PythonWidget(HistoryConsoleWidget):
                     cursor.removeSelectedText()
                     return True
 
-        return super(PythonWidget, self)._event_filter_console_keypress(event)
+        return super()._event_filter_console_keypress(event)
 
     def _insert_continuation_prompt(self, cursor):
         """ Reimplemented for auto-indentation.
         """
-        super(PythonWidget, self)._insert_continuation_prompt(cursor)
+        super()._insert_continuation_prompt(cursor)
         source = self.input_buffer
         space = 0
         for c in source.splitlines()[-1]:
@@ -514,9 +514,7 @@ class PythonWidgetHighlighter(PygmentsHighlighter):
     """
 
     def __init__(self, python_widget):
-        super(PythonWidgetHighlighter, self).__init__(
-            python_widget._control.document()
-        )
+        super().__init__(python_widget._control.document())
         self._current_offset = 0
         self._python_widget = python_widget
         self.highlighting_on = False
@@ -546,21 +544,21 @@ class PythonWidgetHighlighter(PygmentsHighlighter):
         else:
             self._current_offset = 0
 
-        super(PythonWidgetHighlighter, self).highlightBlock(string)
+        super().highlightBlock(string)
 
     def rehighlightBlock(self, block):
         """ Reimplemented to temporarily enable highlighting if disabled.
         """
         old = self.highlighting_on
         self.highlighting_on = True
-        super(PythonWidgetHighlighter, self).rehighlightBlock(block)
+        super().rehighlightBlock(block)
         self.highlighting_on = old
 
     def setFormat(self, start, count, format):
         """ Reimplemented to highlight selectively.
         """
         start += self._current_offset
-        super(PythonWidgetHighlighter, self).setFormat(start, count, format)
+        super().setFormat(start, count, format)
 
 
 # -------------------------------------------------------------------------------
@@ -582,7 +580,7 @@ class PyfacePythonWidget(PythonWidget):
         """
         self._pyface_widget = pyface_widget
 
-        super(PyfacePythonWidget, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
     # ---------------------------------------------------------------------------
     # 'QWidget' interface
@@ -612,7 +610,7 @@ class PyfacePythonWidget(PythonWidget):
             event=event,
         )
 
-        super(PyfacePythonWidget, self).keyPressEvent(event)
+        super().keyPressEvent(event)
 
 
 class _DropEventEmitter(QtCore.QObject):

--- a/pyface/ui/qt4/single_choice_dialog.py
+++ b/pyface/ui/qt4/single_choice_dialog.py
@@ -86,7 +86,7 @@ class SingleChoiceDialog(MSingleChoiceDialog, Dialog):
                 self.choice = None
 
         # Let the window close as normal.
-        super(SingleChoiceDialog, self).close()
+        super().close()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/advanced_editor_area_pane.py
@@ -110,7 +110,7 @@ class AdvancedEditorAreaPane(TaskPane, MEditorAreaPane):
             signal, handler = self._connections_to_remove.pop()
             signal.disconnect(handler)
 
-        super(AdvancedEditorAreaPane, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # 'IEditorAreaPane' interface.
@@ -267,7 +267,7 @@ class EditorAreaWidget(QtGui.QMainWindow):
     # ------------------------------------------------------------------------
 
     def __init__(self, editor_area, parent=None):
-        super(EditorAreaWidget, self).__init__(parent)
+        super().__init__(parent)
         self.editor_area = editor_area
         self.reset_drag()
 
@@ -451,7 +451,7 @@ class EditorAreaWidget(QtGui.QMainWindow):
     def childEvent(self, event):
         """ Reimplemented to gain access to the tab bars as they are created.
         """
-        super(EditorAreaWidget, self).childEvent(event)
+        super().childEvent(event)
         if event.polished():
             child = event.child()
             if isinstance(child, QtGui.QTabBar):
@@ -608,7 +608,7 @@ class EditorWidget(QtGui.QDockWidget):
     """
 
     def __init__(self, editor, parent=None):
-        super(EditorWidget, self).__init__(parent)
+        super().__init__(parent)
         self.editor = editor
         self.editor.create(self)
         self.setAllowedAreas(QtCore.Qt.LeftDockWidgetArea)
@@ -672,7 +672,7 @@ class EditorTitleBarWidget(QtGui.QTabBar):
     """
 
     def __init__(self, editor_widget):
-        super(EditorTitleBarWidget, self).__init__(editor_widget)
+        super().__init__(editor_widget)
         self.addTab(editor_widget.windowTitle())
         self.setTabToolTip(0, editor_widget.editor.tooltip)
         self.setDocumentMode(True)

--- a/pyface/ui/qt4/tasks/dock_pane.py
+++ b/pyface/ui/qt4/tasks/dock_pane.py
@@ -98,7 +98,7 @@ class DockPane(TaskPane, MDockPane):
             control.topLevelChanged.disconnect(self._receive_floating)
             control.visibilityChanged.disconnect(self._receive_visible)
 
-        super(DockPane, self).destroy()
+        super().destroy()
 
     def set_focus(self):
         """ Gives focus to the control that represents the pane.

--- a/pyface/ui/qt4/tasks/editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/editor_area_pane.py
@@ -110,7 +110,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
             signal, handler = self._connections_to_remove.pop()
             signal.disconnect(handler)
 
-        super(EditorAreaPane, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # 'IEditorAreaPane' interface.
@@ -223,7 +223,7 @@ class EditorAreaWidget(QtGui.QTabWidget):
     """
 
     def __init__(self, editor_area, parent=None):
-        super(EditorAreaWidget, self).__init__(parent)
+        super().__init__(parent)
         self.editor_area = editor_area
 
         # Configure the QTabWidget.
@@ -248,7 +248,7 @@ class EditorAreaDropFilter(QtCore.QObject):
     """
 
     def __init__(self, editor_area):
-        super(EditorAreaDropFilter, self).__init__()
+        super().__init__()
         self.editor_area = editor_area
 
     def eventFilter(self, object, event):
@@ -275,4 +275,4 @@ class EditorAreaDropFilter(QtCore.QObject):
 
             return True
 
-        return super(EditorAreaDropFilter, self).eventFilter(object, event)
+        return super().eventFilter(object, event)

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -142,7 +142,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         # together with the main control
         self.active_tabwidget = None
 
-        super(SplitEditorAreaPane, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # 'IEditorAreaPane' interface.
@@ -460,7 +460,7 @@ class EditorAreaWidget(QtGui.QSplitter):
         tabwidget : tabwidget object contained by this splitter
 
         """
-        super(EditorAreaWidget, self).__init__(parent=parent)
+        super().__init__(parent=parent)
         self.editor_area = editor_area
 
         if not tabwidget:
@@ -745,7 +745,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
         editor_area : global SplitEditorAreaPane instance
         parent : parent of the tabwidget
         """
-        super(DraggableTabWidget, self).__init__(parent)
+        super().__init__(parent)
         self.editor_area = editor_area
 
         # configure QTabWidget
@@ -948,7 +948,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
                 event.acceptProposedAction()
                 return
 
-        super(DraggableTabWidget, self).dragEnterEvent(event)
+        super().dragEnterEvent(event)
 
     def dropEvent(self, event):
         """ Re-implemented to handle drop events
@@ -964,7 +964,7 @@ class DraggableTabWidget(QtGui.QTabWidget):
         """ Clear widget highlight on leaving
         """
         self.setBackgroundRole(QtGui.QPalette.Window)
-        return super(DraggableTabWidget, self).dragLeaveEvent(event)
+        return super().dragLeaveEvent(event)
 
 
 class DraggableTabBar(QtGui.QTabBar):
@@ -972,7 +972,7 @@ class DraggableTabBar(QtGui.QTabBar):
     """
 
     def __init__(self, editor_area, parent):
-        super(DraggableTabBar, self).__init__(parent)
+        super().__init__(parent)
         self.editor_area = editor_area
         self.setContextMenuPolicy(QtCore.Qt.DefaultContextMenu)
         self.drag_obj = None
@@ -987,7 +987,7 @@ class DraggableTabBar(QtGui.QTabBar):
                 self.drag_obj = TabDragObject(
                     start_pos=event.pos(), tabBar=self
                 )
-        return super(DraggableTabBar, self).mousePressEvent(event)
+        return super().mousePressEvent(event)
 
     def mouseMoveEvent(self, event):
         """ Re-implemented to create a drag event when the mouse is moved for a
@@ -1013,14 +1013,14 @@ class DraggableTabBar(QtGui.QTabBar):
                 drag.exec_()
                 self.drag_obj = None  # deactivate the drag_obj again
                 return
-        return super(DraggableTabBar, self).mouseMoveEvent(event)
+        return super().mouseMoveEvent(event)
 
     def mouseReleaseEvent(self, event):
         """ Re-implemented to deactivate the drag when mouse button is
         released
         """
         self.drag_obj = None
-        return super(DraggableTabBar, self).mouseReleaseEvent(event)
+        return super().mouseReleaseEvent(event)
 
 
 class TabDragObject(object):

--- a/pyface/ui/qt4/tasks/task_window_backend.py
+++ b/pyface/ui/qt4/tasks/task_window_backend.py
@@ -166,7 +166,7 @@ class TaskWindowLayout(MainWindowLayout):
         """ Applies a DockLayout to the window.
         """
         self.consumed = []
-        super(TaskWindowLayout, self).set_layout(layout)
+        super().set_layout(layout)
 
     # ------------------------------------------------------------------------
     # 'MainWindowLayout' abstract interface.

--- a/pyface/ui/qt4/tests/test_gui.py
+++ b/pyface/ui/qt4/tests/test_gui.py
@@ -35,7 +35,7 @@ class SimpleApplication(HasStrictTraits):
     application_running = Event()
 
     def __init__(self):
-        super(HasStrictTraits, self).__init__()
+        super().__init__()
         self.gui = GUI()
 
     def start(self):

--- a/pyface/ui/qt4/timer/timer.py
+++ b/pyface/ui/qt4/timer/timer.py
@@ -23,7 +23,7 @@ class PyfaceTimer(BaseTimer):
 
     def __init__(self, **traits):
         traits.setdefault("_timer", QTimer())
-        super(PyfaceTimer, self).__init__(**traits)
+        super().__init__(**traits)
         self._timer.timeout.connect(self.perform)
 
     def _start(self):

--- a/pyface/ui/qt4/window.py
+++ b/pyface/ui/qt4/window.py
@@ -125,7 +125,7 @@ class Window(MWindow, Widget):
             # hides it), but the close may trigger an application shutdown,
             # which can take a long time and may also attempt to recursively
             # destroy the window again.
-            super(Window, self).destroy()
+            super().destroy()
             control.close()
 
     # -------------------------------------------------------------------------


### PR DESCRIPTION
This PR updates `super` usage in a semi-automated fashion. We used regex-based search and replace to update the `super` usage. Note that there were two instances where a super was being called with the wrong arguments - which got fixed in this PR.

See similar PR https://github.com/enthought/traits/pull/1280