### PR TITLE
Update super usage in the "wx" and "null" backends

### DIFF
--- a/pyface/ui/null/action/tool_bar_manager.py
+++ b/pyface/ui/null/action/tool_bar_manager.py
@@ -49,7 +49,7 @@ class ToolBarManager(ActionManager):
         """ Creates a new tool bar manager. """
 
         # Base class contructor.
-        super(ToolBarManager, self).__init__(*args, **traits)
+        super().__init__(*args, **traits)
 
         # An image cache to make sure that we only load each image used in the
         # tool bar exactly once.

--- a/pyface/ui/null/action/tool_palette.py
+++ b/pyface/ui/null/action/tool_palette.py
@@ -40,7 +40,7 @@ class ToolPalette(Widget):
         """ Creates a new tool palette. """
 
         # Base class constructor.
-        super(ToolPalette, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/null/action/tool_palette_manager.py
+++ b/pyface/ui/null/action/tool_palette_manager.py
@@ -42,7 +42,7 @@ class ToolPaletteManager(ActionManager):
         """ Creates a new tool bar manager. """
 
         # Base class contructor.
-        super(ToolPaletteManager, self).__init__(*args, **traits)
+        super().__init__(*args, **traits)
 
         # An image cache to make sure that we only load each image used in the
         # tool bar exactly once.

--- a/pyface/ui/wx/action/tool_bar_manager.py
+++ b/pyface/ui/wx/action/tool_bar_manager.py
@@ -63,7 +63,7 @@ class ToolBarManager(ActionManager):
         """ Creates a new tool bar manager. """
 
         # Base class contructor.
-        super(ToolBarManager, self).__init__(*args, **traits)
+        super().__init__(*args, **traits)
 
         # An image cache to make sure that we only load each image used in the
         # tool bar exactly once.

--- a/pyface/ui/wx/action/tool_palette.py
+++ b/pyface/ui/wx/action/tool_palette.py
@@ -57,7 +57,7 @@ class ToolPalette(Widget):
         """ Creates a new tool palette. """
 
         # Base class constructor.
-        super(ToolPalette, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/wx/action/tool_palette_manager.py
+++ b/pyface/ui/wx/action/tool_palette_manager.py
@@ -45,7 +45,7 @@ class ToolPaletteManager(ActionManager):
         """ Creates a new tool bar manager. """
 
         # Base class contructor.
-        super(ToolPaletteManager, self).__init__(*args, **traits)
+        super().__init__(*args, **traits)
 
         # An image cache to make sure that we only load each image used in the
         # tool bar exactly once.

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -110,7 +110,7 @@ class ApplicationWindow(MApplicationWindow, Window):
 
     def _create(self):
 
-        super(ApplicationWindow, self)._create()
+        super()._create()
 
         self._aui_manager = PyfaceAuiManager()
         self._aui_manager.SetManagedWindow(self.control)
@@ -152,7 +152,7 @@ class ApplicationWindow(MApplicationWindow, Window):
     def destroy(self):
         if self.control:
             self._aui_manager.UnInit()
-        super(ApplicationWindow, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # Private interface.

--- a/pyface/ui/wx/directory_dialog.py
+++ b/pyface/ui/wx/directory_dialog.py
@@ -56,7 +56,7 @@ class DirectoryDialog(MDirectoryDialog, Dialog):
         self.path = str(self.control.GetPath())
 
         # Let the window close as normal.
-        super(DirectoryDialog, self).close()
+        super().close()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/ui/wx/expandable_header.py
+++ b/pyface/ui/wx/expandable_header.py
@@ -69,7 +69,7 @@ class ExpandableHeader(Widget):
         """ Creates the panel. """
 
         # Base class constructor.
-        super(ExpandableHeader, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/wx/expandable_panel.py
+++ b/pyface/ui/wx/expandable_panel.py
@@ -38,7 +38,7 @@ class ExpandablePanel(Widget):
         """ Creates a new LayeredPanel. """
 
         # Base class constructor.
-        super(ExpandablePanel, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/wx/fields/field.py
+++ b/pyface/ui/wx/fields/field.py
@@ -50,12 +50,12 @@ class Field(MField, Widget):
     # ------------------------------------------------------------------------
 
     def _create(self):
-        super(Field, self)._create()
+        super()._create()
         self._add_event_listeners()
 
     def destroy(self):
         self._remove_event_listeners()
-        super(Field, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # Private interface

--- a/pyface/ui/wx/file_dialog.py
+++ b/pyface/ui/wx/file_dialog.py
@@ -81,7 +81,7 @@ class FileDialog(MFileDialog, Dialog):
         # Get the index of the selected filter.
         self.wildcard_index = self.control.GetFilterIndex()
         # Let the window close as normal.
-        super(FileDialog, self).close()
+        super().close()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/ui/wx/grid/checkbox_image_renderer.py
+++ b/pyface/ui/wx/grid/checkbox_image_renderer.py
@@ -31,8 +31,6 @@ class CheckboxImageRenderer(MappedGridCellImageRenderer):
             text_map = {True: "True", False: "False"}
 
         # Base-class constructor
-        super(CheckboxImageRenderer, self).__init__(
-            checked_image_map, text_map
-        )
+        super().__init__(checked_image_map, text_map)
 
         return

--- a/pyface/ui/wx/grid/checkbox_renderer.py
+++ b/pyface/ui/wx/grid/checkbox_renderer.py
@@ -21,7 +21,7 @@ class CheckboxRenderer(GridCellRenderer):
     def __init__(self, **traits):
 
         # base-class constructor
-        super(CheckboxRenderer, self).__init__(**traits)
+        super().__init__(**traits)
 
         # initialize the renderer, if it hasn't already been initialized
         if self.renderer is None:

--- a/pyface/ui/wx/grid/composite_grid_model.py
+++ b/pyface/ui/wx/grid/composite_grid_model.py
@@ -35,7 +35,7 @@ class CompositeGridModel(GridModel):
         """ Create a CompositeGridModel object. """
 
         # Base class constructor
-        super(CompositeGridModel, self).__init__(**traits)
+        super().__init__(**traits)
 
         self._row_count = None
 

--- a/pyface/ui/wx/grid/edit_image_renderer.py
+++ b/pyface/ui/wx/grid/edit_image_renderer.py
@@ -19,7 +19,7 @@ class EditImageRenderer(GridCellImageRenderer):
     image = ImageResource("table_edit")
 
     def __init__(self, **kw):
-        super(EditImageRenderer, self).__init__(self, **kw)
+        super().__init__(self, **kw)
 
     def get_image_for_cell(self, grid, row, col):
         """ returns the image resource for the table_edit bitmap """

--- a/pyface/ui/wx/grid/edit_renderer.py
+++ b/pyface/ui/wx/grid/edit_renderer.py
@@ -17,7 +17,7 @@ class EditRenderer(GridCellRenderer):
     def __init__(self, **traits):
 
         # base-class constructor
-        super(EditRenderer, self).__init__(**traits)
+        super().__init__(**traits)
 
         # initialize the renderer, if it hasn't already been initialized
         if self.renderer is None:

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -167,7 +167,7 @@ class Grid(Widget):
         """
 
         # Base class constructors.
-        super(Grid, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Flag set when columns are resizing:
         self._user_col_size = False

--- a/pyface/ui/wx/grid/grid_model.py
+++ b/pyface/ui/wx/grid/grid_model.py
@@ -90,17 +90,6 @@ class GridModel(HasPrivateTraits):
     dclick = Event  # = (row, column) that was double-clicked on
 
     # ------------------------------------------------------------------------
-    # 'object' interface.
-    # ------------------------------------------------------------------------
-    def __init__(self, **traits):
-        """ Creates a new grid model. """
-
-        # Base class constructors.
-        super(GridModel, self).__init__(**traits)
-
-        return
-
-    # ------------------------------------------------------------------------
     # 'GridModel' interface -- Subclasses MUST override the following
     # ------------------------------------------------------------------------
 

--- a/pyface/ui/wx/grid/mapped_grid_cell_image_renderer.py
+++ b/pyface/ui/wx/grid/mapped_grid_cell_image_renderer.py
@@ -21,7 +21,7 @@ class MappedGridCellImageRenderer(GridCellImageRenderer):
     def __init__(self, image_map=None, text_map=None):
 
         # Base-class constructor. We pass ourself as the provider
-        super(MappedGridCellImageRenderer, self).__init__(self)
+        super().__init__(self)
 
         self.image_map = image_map
         self.text_map = text_map

--- a/pyface/ui/wx/grid/simple_grid_model.py
+++ b/pyface/ui/wx/grid/simple_grid_model.py
@@ -38,17 +38,6 @@ class SimpleGridModel(GridModel):
     columns = Either(None, List(Instance(GridColumn)))
 
     # ------------------------------------------------------------------------
-    # 'object' interface.
-    # ------------------------------------------------------------------------
-    def __init__(self, **traits):
-        """ Create a SimpleGridModel object. """
-
-        # Base class constructor
-        super(SimpleGridModel, self).__init__(**traits)
-
-        return
-
-    # ------------------------------------------------------------------------
     # 'GridModel' interface.
     # ------------------------------------------------------------------------
 
@@ -282,7 +271,7 @@ class SimpleGridModel(GridModel):
 class _CopyAction(Action):
     def __init__(self, model, row, col, **kw):
 
-        super(_CopyAction, self).__init__(**kw)
+        super().__init__(**kw)
         self._model = model
         self._row = row
         self._col = col

--- a/pyface/ui/wx/grid/trait_grid_model.py
+++ b/pyface/ui/wx/grid/trait_grid_model.py
@@ -102,7 +102,7 @@ class TraitGridModel(GridModel):
         """ Create a TraitGridModel object. """
 
         # Base class constructor
-        super(TraitGridModel, self).__init__(**traits)
+        super().__init__(**traits)
 
         # if no columns are pass in then create the list of names
         # from the first trait in the list. if the list is empty,

--- a/pyface/ui/wx/heading_text.py
+++ b/pyface/ui/wx/heading_text.py
@@ -47,7 +47,7 @@ class HeadingText(MHeadingText, Widget):
         """ Creates the panel. """
 
         # Base class constructor.
-        super(HeadingText, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/wx/image_button.py
+++ b/pyface/ui/wx/image_button.py
@@ -86,7 +86,7 @@ class ImageButton(Widget):
         """
         self._image = None
 
-        super(ImageButton, self).__init__(**traits)
+        super().__init__(**traits)
 
         self._recalc_size()
 

--- a/pyface/ui/wx/image_widget.py
+++ b/pyface/ui/wx/image_widget.py
@@ -66,7 +66,7 @@ class ImageWidget(Widget):
         """ Creates a new widget. """
 
         # Base class constructors.
-        super(ImageWidget, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Add some padding around the image.
         size = (self.bitmap.GetWidth() + 10, self.bitmap.GetHeight() + 10)

--- a/pyface/ui/wx/ipython_widget.py
+++ b/pyface/ui/wx/ipython_widget.py
@@ -60,7 +60,7 @@ class IPython010Controller(IPythonController):
     def execute_command(self, command, hidden=False):
         # XXX: Overriden to fix bug where executing a hidden command still
         # causes the prompt number to increase.
-        super(IPython010Controller, self).execute_command(command, hidden)
+        super().execute_command(command, hidden)
         if hidden:
             self.shell.current_cell_number -= 1
 
@@ -140,9 +140,7 @@ class IPython09Controller(IPythonController):
         """
 
         completion_text = self._get_completion_text(line)
-        suggestion, completions = super(IPython09Controller, self).complete(
-            completion_text
-        )
+        suggestion, completions = super().complete(completion_text)
         new_line = line[: -len(completion_text)] + suggestion
         return new_line, completions
 
@@ -348,7 +346,7 @@ class IPythonWidget(Widget):
         """ Creates a new pager. """
 
         # Base class constructor.
-        super(IPythonWidget, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/wx/layered_panel.py
+++ b/pyface/ui/wx/layered_panel.py
@@ -54,7 +54,7 @@ class LayeredPanel(Widget):
         """ Creates a new LayeredPanel. """
 
         # Base class constructor.
-        super(LayeredPanel, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/wx/list_box.py
+++ b/pyface/ui/wx/list_box.py
@@ -41,7 +41,7 @@ class ListBox(Widget):
         """ Creates a new list box. """
 
         # Base-class constructors.
-        super(ListBox, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the widget!
         self._create_control(parent)

--- a/pyface/ui/wx/mdi_application_window.py
+++ b/pyface/ui/wx/mdi_application_window.py
@@ -103,7 +103,7 @@ class MDIApplicationWindow(ApplicationWindow):
             # Let the AUI manager look after the frame.
             self._aui_manager.SetManagedWindow(self.control)
 
-        contents = super(MDIApplicationWindow, self)._create_contents(parent)
+        contents = super()._create_contents(parent)
 
         return contents
 

--- a/pyface/ui/wx/multi_toolbar_window.py
+++ b/pyface/ui/wx/multi_toolbar_window.py
@@ -41,7 +41,7 @@ class MultiToolbarWindow(ApplicationWindow):
     # Protected 'Window' interface.
     # ------------------------------------------------------------------------
     def _create_contents(self, parent):
-        panel = super(MultiToolbarWindow, self)._create_contents(parent)
+        panel = super()._create_contents(parent)
         self._create_trim_widgets(parent)
 
         return panel

--- a/pyface/ui/wx/progress_dialog.py
+++ b/pyface/ui/wx/progress_dialog.py
@@ -140,7 +140,7 @@ class ProgressDialog(MProgressDialog, Window):
         # before open() is called
         self._start_time = 0
 
-        super(ProgressDialog, self).__init__(*args, **kw)
+        super().__init__(*args, **kw)
 
     # -------------------------------------------------------------------------
     # IWindow Interface
@@ -148,7 +148,7 @@ class ProgressDialog(MProgressDialog, Window):
 
     def open(self):
         """ Opens the window. """
-        super(ProgressDialog, self).open()
+        super().open()
         self._start_time = time.time()
         wx.GetApp().Yield(True)
 
@@ -161,7 +161,7 @@ class ProgressDialog(MProgressDialog, Window):
         if self._message_control is not None:
             self._message_control = None
 
-        super(ProgressDialog, self).close()
+        super().close()
 
     # -------------------------------------------------------------------------
     # IProgressDialog Interface

--- a/pyface/ui/wx/python_editor.py
+++ b/pyface/ui/wx/python_editor.py
@@ -53,7 +53,7 @@ class PythonEditor(MPythonEditor, Widget):
         """ Creates a new pager. """
 
         # Base class constructor.
-        super(PythonEditor, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)

--- a/pyface/ui/wx/python_shell.py
+++ b/pyface/ui/wx/python_shell.py
@@ -56,7 +56,7 @@ class PythonShell(MPythonShell, Widget):
         """ Creates a new pager. """
 
         # Base class constructor.
-        super(PythonShell, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control that represents the widget.
         self.control = self._create_control(parent)
@@ -263,7 +263,7 @@ class PyShell(PyShellBase):
         # wx.py.shell dosent reassign it back to the original on destruction
         self.raw_input = input
 
-        super(PyShell, self).__init__(
+        super().__init__(
             parent,
             id,
             pos,
@@ -309,7 +309,7 @@ class PyShell(PyShellBase):
         self.redirectStdin(False)
         builtins.raw_input = self.raw_input
         self.destroy()
-        super(PyShellBase, self).Destroy()
+        super().Destroy()
 
 
 class _NullIO(object):

--- a/pyface/ui/wx/single_choice_dialog.py
+++ b/pyface/ui/wx/single_choice_dialog.py
@@ -63,7 +63,7 @@ class SingleChoiceDialog(MSingleChoiceDialog, Dialog):
             self.choice = self.choices[self.control.GetSelection()]
 
         # Let the window close as normal.
-        super(SingleChoiceDialog, self).close()
+        super().close()
 
     # ------------------------------------------------------------------------
     # Protected 'IWidget' interface.

--- a/pyface/ui/wx/tasks/editor_area_pane.py
+++ b/pyface/ui/wx/tasks/editor_area_pane.py
@@ -68,7 +68,7 @@ class EditorAreaPane(TaskPane, MEditorAreaPane):
         for editor in self.editors:
             self.remove_editor(editor)
 
-        super(EditorAreaPane, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # 'IEditorAreaPane' interface.

--- a/pyface/ui/wx/timer/timer.py
+++ b/pyface/ui/wx/timer/timer.py
@@ -19,7 +19,7 @@ from pyface.timer.i_timer import BaseTimer
 
 class CallbackTimer(wx.Timer):
     def __init__(self, timer):
-        super(CallbackTimer, self).__init__()
+        super().__init__()
         self.timer = timer
 
     def Notify(self):

--- a/pyface/ui/wx/tree/tree.py
+++ b/pyface/ui/wx/tree/tree.py
@@ -178,7 +178,7 @@ class Tree(Widget):
         """
 
         # Base class constructors.
-        super(Tree, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control.
         self.control = tree = _Tree(

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -61,7 +61,7 @@ class TableViewer(ContentViewer):
         """
 
         # Base-class constructor.
-        super(TableViewer, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control.
         self.control = table = _Table(parent, image_size, self)

--- a/pyface/ui/wx/viewer/tree_viewer.py
+++ b/pyface/ui/wx/viewer/tree_viewer.py
@@ -89,7 +89,7 @@ class TreeViewer(ContentViewer):
         """
 
         # Base class constructor.
-        super(TreeViewer, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the toolkit-specific control.
         self.control = tree = wx.TreeCtrl(parent, -1, style=self._get_style())

--- a/pyface/wx/drag_and_drop.py
+++ b/pyface/wx/drag_and_drop.py
@@ -53,7 +53,7 @@ class FileDropSource(wx.DropSource):
             data_object.AddFile(file)
 
         # Create the drop source and begin the drag and drop operation:
-        super(FileDropSource, self).__init__(source)
+        super().__init__(source)
         self.SetData(data_object)
         self.result = self.DoDragDrop(True)
 
@@ -164,7 +164,7 @@ class PythonDropTarget(wx.DropTarget):
         """
 
         # Base-class constructor.
-        super(PythonDropTarget, self).__init__()
+        super().__init__()
 
         # The handler can either be a function that will be called when
         # any data is dropped onto the target, or an instance that supports


### PR DESCRIPTION
This PR updates `super` usage in a semi-automated fashion. We used regex-based search and replace to update the `super` usage. Note that there was one instance where a `super` was being called with the wrong arguments - which got fixed in this PR and a redundant redefinition of `__init__` which got removed.

See similar PR https://github.com/enthought/pyface/pull/944 and https://github.com/enthought/traits/pull/1280