### PR TITLE
Cleanup super usage in toolkit agnostic code

### DIFF
--- a/pyface/action/action_event.py
+++ b/pyface/action/action_event.py
@@ -34,7 +34,7 @@ class ActionEvent(HasTraits):
         Note: Every keyword argument becomes a public attribute of the event.
         """
         # Base-class constructor.
-        super(ActionEvent, self).__init__(**traits)
+        super().__init__(**traits)
 
         # When the action was performed.
         self.when = time.time()

--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -86,7 +86,7 @@ class ActionManager(HasTraits):
         If a string is passed, a Group is created with id set to the string.
         """
         # Base class constructor.
-        super(ActionManager, self).__init__(**traits)
+        super().__init__(**traits)
 
         # The last group in every manager is the group with Id 'additions'.
         #

--- a/pyface/action/group.py
+++ b/pyface/action/group.py
@@ -70,7 +70,7 @@ class Group(HasTraits):
             Items to add to the group.
         """
         # Base class constructor.
-        super(Group, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Add any specified items.
         for item in items:

--- a/pyface/action/gui_application_action.py
+++ b/pyface/action/gui_application_action.py
@@ -45,7 +45,7 @@ class GUIApplicationAction(ListeningAction):
     def destroy(self):
         # Disconnect listeners to application and dependent properties.
         self.application = None
-        super(GUIApplicationAction, self).destroy()
+        super().destroy()
 
 
 class ActiveWindowAction(GUIApplicationAction):

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -76,7 +76,7 @@ class ListeningAction(Action):
             if method:
                 method()
         else:
-            super(ListeningAction, self).perform(event)
+            super().perform(event)
 
     # -------------------------------------------------------------------------
     # Protected interface.

--- a/pyface/action/traitsui_widget_action.py
+++ b/pyface/action/traitsui_widget_action.py
@@ -69,4 +69,4 @@ class TraitsUIWidgetAction(Action):
         if self.model is not None:
             context = {"object": self.model, "action": self}
             return context
-        return super(TraitsUIWidgetAction, self).trait_context()
+        return super().trait_context()

--- a/pyface/action/window_action.py
+++ b/pyface/action/window_action.py
@@ -42,7 +42,7 @@ class WindowAction(ListeningAction):
     def destroy(self):
         # Disconnect listeners to window and dependent properties.
         self.window = None
-        super(WindowAction, self).destroy()
+        super().destroy()
 
 
 class CloseWindowAction(WindowAction):

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -102,7 +102,7 @@ class Toolkit(HasTraits):
     packages = List(Str)
 
     def __init__(self, package, toolkit, *packages, **traits):
-        super(Toolkit, self).__init__(
+        super().__init__(
             package=package, toolkit=toolkit, packages=list(packages), **traits
         )
 

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -431,9 +431,6 @@ class DockItem(HasPrivateTraits):
     #  Implementation of the 'owner' property:
     # ---------------------------------------------------------------------------
 
-    def __init__(self, **kw):
-        super().__init__(**kw)
-
     @cached_property
     def _get_owner(self):
         if self.parent is None:

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -272,7 +272,7 @@ class DockImages(HasPrivateTraits):
     def __init__(self, **traits):
         """ Initializes the object.
         """
-        super(DockImages, self).__init__(**traits)
+        super().__init__(**traits)
 
         self._lazy_init_done = False
 
@@ -432,7 +432,7 @@ class DockItem(HasPrivateTraits):
     # ---------------------------------------------------------------------------
 
     def __init__(self, **kw):
-        super(DockItem, self).__init__(**kw)
+        super().__init__(**kw)
 
     @cached_property
     def _get_owner(self):
@@ -2604,7 +2604,7 @@ class DockRegion(DockGroup):
     def toggle_lock(self):
         """ Toggles the 'lock' status of every control in the group.
         """
-        super(DockRegion, self).toggle_lock()
+        super().toggle_lock()
         self._is_notebook = None
 
     # ---------------------------------------------------------------------------
@@ -2727,7 +2727,7 @@ class DockRegion(DockGroup):
         """ Gets the DockInfo object for a specified window position.
         """
         # Check to see if the point is in our drag bar:
-        info = super(DockRegion, self).dock_info_at(x, y, tdx, is_control)
+        info = super().dock_info_at(x, y, tdx, is_control)
         if info is not None:
             return info
 
@@ -2869,7 +2869,7 @@ class DockRegion(DockGroup):
         ):
             self.scroll(self._scroll)
         else:
-            super(DockRegion, self).mouse_up(event)
+            super().mouse_up(event)
 
     # ---------------------------------------------------------------------------
     #  Handles the mouse moving while the left mouse button is pressed:
@@ -3530,7 +3530,7 @@ class DockSection(DockGroup):
         """ Gets the DockInfo object for a specified window position.
         """
         # Check to see if the point is in our drag bar:
-        info = super(DockSection, self).dock_info_at(x, y, tdx, is_control)
+        info = super().dock_info_at(x, y, tdx, is_control)
         if info is not None:
             return info
 
@@ -3830,9 +3830,6 @@ class DockInfo(HasPrivateTraits):
     # Dock Control:
     control = Instance(DockItem)
 
-    def __init__(self, **kw):
-        super(DockInfo, self).__init__(**kw)
-
     # ---------------------------------------------------------------------------
     #  Draws the DockInfo on the display:
     # ---------------------------------------------------------------------------
@@ -3987,7 +3984,7 @@ class DockSizer(wx.Sizer):
     # ---------------------------------------------------------------------------
 
     def __init__(self, contents=None):
-        super(DockSizer, self).__init__()
+        super().__init__()
 
         # Make sure the DockImages singleton has been initialized:
         DockImages.init()

--- a/pyface/dock/dock_window.py
+++ b/pyface/dock/dock_window.py
@@ -304,7 +304,7 @@ class DockWindow(HasPrivateTraits):
         style=wx.FULL_REPAINT_ON_RESIZE,
         **traits
     ):
-        super(DockWindow, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the actual window:
         self.control = control = wx.Window(parent, wid, pos, size, style)

--- a/pyface/dock/dock_window_shell.py
+++ b/pyface/dock/dock_window_shell.py
@@ -57,7 +57,7 @@ class DockWindowShell(HasPrivateTraits):
     # ---------------------------------------------------------------------------
 
     def __init__(self, dock_control, use_mouse=False, **traits):
-        super(DockWindowShell, self).__init__(**traits)
+        super().__init__(**traits)
 
         old_control = dock_control.control
         parent = wx.GetTopLevelParent(old_control)

--- a/pyface/fields/i_combo_field.py
+++ b/pyface/fields/i_combo_field.py
@@ -54,7 +54,7 @@ class MComboField(HasTraits):
     def __init__(self, values, **traits):
         value = traits.pop("value", values[0])
         traits["values"] = values
-        super(MComboField, self).__init__(**traits)
+        super().__init__(**traits)
         self.value = value
 
     # ------------------------------------------------------------------------
@@ -62,13 +62,13 @@ class MComboField(HasTraits):
     # ------------------------------------------------------------------------
 
     def _initialize_control(self):
-        super(MComboField, self)._initialize_control()
+        super()._initialize_control()
         self._set_control_values(self.values)
         self._set_control_value(self.value)
 
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
-        super(MComboField, self)._add_event_listeners()
+        super()._add_event_listeners()
         self.observe(
             self._values_updated, "values.items,formatter", dispatch="ui"
         )
@@ -85,7 +85,7 @@ class MComboField(HasTraits):
             dispatch="ui",
             remove=True,
         )
-        super(MComboField, self)._remove_event_listeners()
+        super()._remove_event_listeners()
 
     # Toolkit control interface ---------------------------------------------
 

--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -57,7 +57,7 @@ class MField(HasTraits):
 
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
-        super(MField, self)._add_event_listeners()
+        super()._add_event_listeners()
         self.observe(self._value_updated, "value", dispatch="ui")
         self.observe(self._tooltip_updated, "tooltip", dispatch="ui")
         self.observe(
@@ -82,7 +82,7 @@ class MField(HasTraits):
             dispatch="ui",
             remove=True,
         )
-        super(MField, self)._remove_event_listeners()
+        super()._remove_event_listeners()
 
     # ------------------------------------------------------------------------
     # Private interface

--- a/pyface/fields/i_spin_field.py
+++ b/pyface/fields/i_spin_field.py
@@ -57,7 +57,7 @@ class MSpinField(HasTraits):
         value = traits.pop("value", None)
         if "bounds" in traits:
             traits["value"] = traits["bounds"][0]
-        super(MSpinField, self).__init__(**traits)
+        super().__init__(**traits)
         if value is not None:
             self.value = value
 
@@ -66,13 +66,13 @@ class MSpinField(HasTraits):
     # ------------------------------------------------------------------------
 
     def _initialize_control(self):
-        super(MSpinField, self)._initialize_control()
+        super()._initialize_control()
         self._set_control_bounds(self.bounds)
         self._set_control_value(self.value)
 
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
-        super(MSpinField, self)._add_event_listeners()
+        super()._add_event_listeners()
         self.observe(self._bounds_updated, "bounds", dispatch="ui")
         if self.control is not None:
             self._observe_control_value()
@@ -84,7 +84,7 @@ class MSpinField(HasTraits):
         self.observe(
             self._bounds_updated, "bounds", dispatch="ui", remove=True
         )
-        super(MSpinField, self)._remove_event_listeners()
+        super()._remove_event_listeners()
 
     # Toolkit control interface ---------------------------------------------
 

--- a/pyface/fields/i_text_field.py
+++ b/pyface/fields/i_text_field.py
@@ -63,11 +63,11 @@ class MTextField(HasTraits):
         self._set_control_placeholder(self.placeholder)
         self._set_control_read_only(self.read_only)
 
-        super(MTextField, self)._initialize_control()
+        super()._initialize_control()
 
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """
-        super(MTextField, self)._add_event_listeners()
+        super()._add_event_listeners()
         self.observe(self._update_text_updated, "update_text", dispatch="ui")
         self.observe(self._placeholder_updated, "placeholder", dispatch="ui")
         self.observe(self._echo_updated, "echo", dispatch="ui")
@@ -103,7 +103,7 @@ class MTextField(HasTraits):
         self.observe(
             self._read_only_updated, "read_only", dispatch="ui", remove=True
         )
-        super(MTextField, self)._remove_event_listeners()
+        super()._remove_event_listeners()
 
     def _editing_finished(self):
         if self.control is not None:

--- a/pyface/gui_application.py
+++ b/pyface/gui_application.py
@@ -162,7 +162,7 @@ class GUIApplication(Application):
         """
         from pyface.gui import GUI
 
-        ok = super(GUIApplication, self).start()
+        ok = super().start()
         if ok:
             # create the GUI so that the splash screen comes up first thing
             if self.gui is Undefined:
@@ -214,7 +214,7 @@ class GUIApplication(Application):
         The fires closing events for each window, and returns False if any
         listener vetos.
         """
-        if not super(GUIApplication, self)._can_exit():
+        if not super()._can_exit():
             return False
 
         for window in reversed(self.windows):

--- a/pyface/i_application_window.py
+++ b/pyface/i_application_window.py
@@ -131,7 +131,7 @@ class MApplicationWindow(HasTraits):
         for tool_bar_manager in self.tool_bar_managers:
             tool_bar_manager.destroy()
 
-        super(MApplicationWindow, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # Protected 'IApplicationWindow' interface.

--- a/pyface/i_dialog.py
+++ b/pyface/i_dialog.py
@@ -180,7 +180,7 @@ class MDialog(HasTraits):
     def _create(self):
         """ Creates the window's widget hierarchy. """
 
-        super(MDialog, self)._create()
+        super()._create()
 
         self._create_contents(self.control)
 

--- a/pyface/i_progress_dialog.py
+++ b/pyface/i_progress_dialog.py
@@ -95,7 +95,7 @@ class MProgressDialog(HasTraits):
             msg = "Dialog min ({}) is greater than dialog max ({})."
             raise AttributeError(msg.format(self.min, self.max))
 
-        super(MProgressDialog, self).open()
+        super().open()
 
     # ------------------------------------------------------------------------
     # 'IProgressDialog' interface.

--- a/pyface/i_splash_screen.py
+++ b/pyface/i_splash_screen.py
@@ -72,7 +72,7 @@ class MSplashScreen(HasTraits):
     def open(self):
         """ Creates the toolkit-specific control for the widget. """
 
-        super(MSplashScreen, self).open()
+        super().open()
 
         if self.show_log_messages:
             self._log_handler = SplashScreenLogHandler(self)
@@ -90,4 +90,4 @@ class MSplashScreen(HasTraits):
             logger = logging.getLogger()
             logger.removeHandler(self._log_handler)
 
-        super(MSplashScreen, self).close()
+        super().close()

--- a/pyface/mdi_window_menu.py
+++ b/pyface/mdi_window_menu.py
@@ -165,7 +165,7 @@ class MDIWindowMenu(MenuManager):
         """ Creates a new MDI window menu. """
 
         # Base class constructor.
-        super(MDIWindowMenu, self).__init__(
+        super().__init__(
             Cascade(window=window),
             Tile(window=window),
             Separator(),

--- a/pyface/sizers/flow.py
+++ b/pyface/sizers/flow.py
@@ -24,7 +24,7 @@ class FlowSizer(wx.PySizer):
     # ---------------------------------------------------------------------------
 
     def __init__(self, orient=wx.HORIZONTAL):
-        super(FlowSizer, self).__init__()
+        super().__init__()
         self._orient = orient
         self._frozen = False
         self._needed_size = None

--- a/pyface/splash_screen_log_handler.py
+++ b/pyface/splash_screen_log_handler.py
@@ -26,7 +26,7 @@ class SplashScreenLogHandler(Handler):
             The splash screen being used to display the log messages
         """
         # Base class constructor.
-        super(SplashScreenLogHandler, self).__init__()
+        super().__init__()
 
         # The splash screen that we will display log messages on.
         self._splash_screen = splash_screen

--- a/pyface/split_panel.py
+++ b/pyface/split_panel.py
@@ -26,7 +26,7 @@ class SplitPanel(Widget, SplitWidget):
         """ Creates a new panel. """
 
         # Base class constructor.
-        super(SplitPanel, self).__init__(**traits)
+        super().__init__(**traits)
 
         # Create the widget's toolkit-specific control.
         self.control = self._create_splitter(parent)

--- a/pyface/tasks/action/dock_pane_toggle_group.py
+++ b/pyface/tasks/action/dock_pane_toggle_group.py
@@ -43,7 +43,7 @@ class DockPaneToggleAction(Action):
     # ------------------------------------------------------------------------
 
     def destroy(self):
-        super(DockPaneToggleAction, self).destroy()
+        super().destroy()
 
         # Make sure that we are not listening to changes to the pane anymore.
         # In traits style, we will set the basic object to None and have the

--- a/pyface/tasks/action/schema.py
+++ b/pyface/tasks/action/schema.py
@@ -60,7 +60,7 @@ class Schema(HasTraits):
     def __init__(self, *items, **traits):
         """ Creates a new schema.
         """
-        super(Schema, self).__init__(**traits)
+        super().__init__(**traits)
         self.items.extend(items)
 
     def create(self, children):

--- a/pyface/tasks/action/task_action.py
+++ b/pyface/tasks/action/task_action.py
@@ -42,7 +42,7 @@ class TaskAction(ListeningAction):
     def destroy(self):
         # Disconnect listeners to task and dependent properties.
         self.task = None
-        super(TaskAction, self).destroy()
+        super().destroy()
 
 
 class TaskWindowAction(TaskAction):

--- a/pyface/tasks/action/task_toggle_group.py
+++ b/pyface/tasks/action/task_toggle_group.py
@@ -42,7 +42,7 @@ class TaskToggleAction(Action):
     # ------------------------------------------------------------------------
 
     def destroy(self):
-        super(TaskToggleAction, self).destroy()
+        super().destroy()
 
         # Make sure that we are not listening to changes in the task anymore
         # In traits style, we will set the basic object to None and have the

--- a/pyface/tasks/action/task_window_toggle_group.py
+++ b/pyface/tasks/action/task_window_toggle_group.py
@@ -83,7 +83,7 @@ class TaskWindowToggleGroup(Group):
     def destroy(self):
         """ Called when the group is no longer required.
         """
-        super(TaskWindowToggleGroup, self).destroy()
+        super().destroy()
         if self.application:
             self.application.observe(
                 self._rebuild, "windows.items", remove=True

--- a/pyface/tasks/task_layout.py
+++ b/pyface/tasks/task_layout.py
@@ -91,7 +91,7 @@ class LayoutContainer(LayoutItem):
                 )
             else:
                 traits["items"] = list(items)
-        super(LayoutContainer, self).__init__(**traits)
+        super().__init__(**traits)
 
     def iterleaves(self):
         for item in self.items:
@@ -119,7 +119,7 @@ class PaneItem(LayoutItem):
     height = Int(-1)
 
     def __init__(self, id="", **traits):
-        super(PaneItem, self).__init__(**traits)
+        super().__init__(**traits)
         self.id = id
 
     def pargs(self):

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -98,7 +98,7 @@ class TaskWindow(ApplicationWindow):
         # undesirable animations when the window is being closed.
         for state in self._states:
             self._destroy_state(state)
-        super(TaskWindow, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # 'Window' interface.

--- a/pyface/tasks/tasks_application.py
+++ b/pyface/tasks/tasks_application.py
@@ -131,7 +131,7 @@ class TasksApplication(GUIApplication):
         """
         from pyface.tasks.task_window_layout import TaskWindowLayout
 
-        window = super(TasksApplication, self).create_window(**kwargs)
+        window = super().create_window(**kwargs)
 
         if layout is not None:
             for task_id in layout.get_tasks():
@@ -178,7 +178,7 @@ class TasksApplication(GUIApplication):
         window = event.object
         if getattr(window, "active_task", None) in self.tasks:
             self.tasks.remove(window.active_task)
-        super(TasksApplication, self)._on_window_closed(event)
+        super()._on_window_closed(event)
 
     # Trait initializers and property getters ---------------------------------
 

--- a/pyface/tasks/tests/test_tasks_application.py
+++ b/pyface/tasks/tests/test_tasks_application.py
@@ -65,14 +65,14 @@ class TestingApp(TasksApplication):
     def start(self):
         if not self.start_cleanly:
             return False
-        super(TestingApp, self).start()
+        super().start()
 
         window = self.windows[0]
         window.observe(self._on_window_closing, "closing")
         return True
 
     def stop(self):
-        super(TestingApp, self).stop()
+        super().stop()
         return self.stop_cleanly
 
     def _on_window_closing(self, event):
@@ -90,7 +90,7 @@ class TestingApp(TasksApplication):
             self.exit_prepared = True
         if self.exit_prepared_error:
             raise Exception("Exit preparation failed")
-        super(TestingApp, self)._prepare_exit()
+        super()._prepare_exit()
 
 
 @unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")

--- a/pyface/tasks/tests/test_topological_sort.py
+++ b/pyface/tasks/tests/test_topological_sort.py
@@ -22,7 +22,7 @@ class TestItem(HasTraits):
     after = Int()
 
     def __init__(self, id, **traits):
-        super(TestItem, self).__init__(id=id, **traits)
+        super().__init__(id=id, **traits)
 
     def __hash__(self):
         return hash(self.id)

--- a/pyface/tasks/traits_dock_pane.py
+++ b/pyface/tasks/traits_dock_pane.py
@@ -36,7 +36,7 @@ class TraitsDockPane(DockPane):
         """
         if self.model:
             return {"object": self.model, "pane": self}
-        return super(TraitsDockPane, self).trait_context()
+        return super().trait_context()
 
     # ------------------------------------------------------------------------
     # 'ITaskPane' interface.
@@ -50,7 +50,7 @@ class TraitsDockPane(DockPane):
         self.ui = None
 
         # Destroy the dock control.
-        super(TraitsDockPane, self).destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # 'IDockPane' interface.

--- a/pyface/tasks/traits_editor.py
+++ b/pyface/tasks/traits_editor.py
@@ -36,7 +36,7 @@ class TraitsEditor(Editor):
         """
         if self.model:
             return {"object": self.model, "editor": self}
-        return super(TraitsEditor, self).trait_context()
+        return super().trait_context()
 
     # ------------------------------------------------------------------------
     # 'IEditor' interface.

--- a/pyface/tasks/traits_task_pane.py
+++ b/pyface/tasks/traits_task_pane.py
@@ -36,7 +36,7 @@ class TraitsTaskPane(TaskPane):
         """
         if self.model:
             return {"object": self.model, "pane": self}
-        return super(TraitsTaskPane, self).trait_context()
+        return super().trait_context()
 
     # ------------------------------------------------------------------------
     # 'ITaskPane' interface.

--- a/pyface/tests/test_application.py
+++ b/pyface/tests/test_application.py
@@ -58,15 +58,15 @@ class TestingApp(Application):
     exit_prepared_error = Bool(False)
 
     def start(self):
-        super(TestingApp, self).start()
+        super().start()
         return self.start_cleanly
 
     def stop(self):
-        super(TestingApp, self).stop()
+        super().stop()
         return self.stop_cleanly
 
     def _run(self):
-        super(TestingApp, self)._run()
+        super()._run()
         if self.do_exit:
             if self.error_exit:
                 raise ApplicationExit("error message")

--- a/pyface/tests/test_gui_application.py
+++ b/pyface/tests/test_gui_application.py
@@ -73,14 +73,14 @@ class TestingApp(GUIApplication):
     def start(self):
         if not self.start_cleanly:
             return False
-        super(TestingApp, self).start()
+        super().start()
 
         window = self.windows[0]
         window.observe(self._on_window_closing, "closing")
         return True
 
     def stop(self):
-        super(TestingApp, self).stop()
+        super().stop()
         return self.stop_cleanly
 
     def _on_window_closing(self, event):
@@ -99,7 +99,7 @@ class TestingApp(GUIApplication):
         self.exit_vetoed = self.veto_exit
 
     def _prepare_exit(self):
-        super(TestingApp, self)._prepare_exit()
+        super()._prepare_exit()
         if not self.exit_vetoed:
             self.exit_prepared = True
         if self.exit_prepared_error:

--- a/pyface/timer/do_later.py
+++ b/pyface/timer/do_later.py
@@ -26,9 +26,7 @@ class DoLaterTimer(Timer):
 
     def __init__(self, interval, callable, args, kw_args):
         # Adapt the old DoLaterTimer initializer to the Timer initializer.
-        super(DoLaterTimer, self).__init__(
-            interval, callable, *args, **kw_args
-        )
+        super().__init__(interval, callable, *args, **kw_args)
 
 
 def do_later(callable, *args, **kwargs):

--- a/pyface/timer/timer.py
+++ b/pyface/timer/timer.py
@@ -40,7 +40,7 @@ class Timer(CallbackTimer):
         arguments and keyword args after every `millisecs` (milliseconds).
         """
         interval = millisecs / 1000.0
-        super(Timer, self).__init__(
+        super().__init__(
             interval=interval, callback=callable, args=args, kwargs=kwargs
         )
         self.start()

--- a/pyface/tree/node_manager.py
+++ b/pyface/tree/node_manager.py
@@ -44,7 +44,7 @@ class NodeManager(HasPrivateTraits):
         """ Creates a new tree model. """
 
         # Base class constructor.
-        super(NodeManager, self).__init__(**traits)
+        super().__init__(**traits)
 
         # This saves looking up a node's type every time.  If we ever have
         # nodes that change type dynamically then we will obviously have to

--- a/pyface/ui_traits.py
+++ b/pyface/ui_traits.py
@@ -107,7 +107,7 @@ class Image(TraitType):
             The default value for the Image, either an ImageResource object,
             or a string from which an ImageResource object can be derived.
         """
-        super(Image, self).__init__(convert_image(value), **metadata)
+        super().__init__(convert_image(value), **metadata)
 
     def validate(self, object, name, value):
         """ Validates that a specified value is valid for this trait.
@@ -211,7 +211,7 @@ class BaseMB(ABCHasStrictTraits):
                 {"left": left, "right": right, "top": top, "bottom": bottom}
             )
 
-        super(BaseMB, self).__init__(**traits)
+        super().__init__(**traits)
 
 
 class Margin(BaseMB):
@@ -296,7 +296,7 @@ class HasMargin(TraitType):
                 dv = self.klass(*dv)
 
             if not isinstance(dv, self.klass):
-                return super(HasMargin, self).get_default_value()
+                return super().get_default_value()
 
             self.default_value_type = dvt = DefaultValue.callable_and_args
             dv = (self.klass, (), dv.trait_get())

--- a/pyface/undo/action/abstract_command_stack_action.py
+++ b/pyface/undo/action/abstract_command_stack_action.py
@@ -47,7 +47,7 @@ class AbstractCommandStackAction(Action):
     def __init__(self, **traits):
         """ Initialise the instance. """
 
-        super(AbstractCommandStackAction, self).__init__(**traits)
+        super().__init__(**traits)
 
         self.undo_manager.observe(
             self._on_stack_updated, "stack_updated"

--- a/pyface/wizard/i_wizard.py
+++ b/pyface/wizard/i_wizard.py
@@ -85,7 +85,7 @@ class MWizard(HasTraits):
         """ Creates the window contents. """
 
         # This creates the dialog and button areas.
-        super(MWizard, self)._create_contents(parent)
+        super()._create_contents(parent)
 
         # Wire up the controller.
         self._initialize_controller(self.controller)

--- a/pyface/workbench/action/menu_bar_manager.py
+++ b/pyface/workbench/action/menu_bar_manager.py
@@ -35,8 +35,6 @@ class MenuBarManager(BaseMenuBarManager):
         # The controller handles the invocation of every action.
         controller = ActionController(window=self.window)
 
-        menu_bar = super(MenuBarManager, self).create_menu_bar(
-            parent, controller=controller
-        )
+        menu_bar = super().create_menu_bar(parent, controller=controller)
 
         return menu_bar

--- a/pyface/workbench/action/tool_bar_manager.py
+++ b/pyface/workbench/action/tool_bar_manager.py
@@ -36,7 +36,7 @@ class ToolBarManager(pyface.ToolBarManager):
         if controller is None:
             controller = ActionController(window=self.window)
 
-        tool_bar = super(ToolBarManager, self).create_tool_bar(
+        tool_bar = super().create_tool_bar(
             parent, controller=controller, **kwargs
         )
 

--- a/pyface/workbench/editor_manager.py
+++ b/pyface/workbench/editor_manager.py
@@ -36,7 +36,7 @@ class EditorManager(HasTraits):
     def __init__(self, **traits):
         """ Constructor. """
 
-        super(EditorManager, self).__init__(**traits)
+        super().__init__(**traits)
 
         # A mapping from editor to editor kind (the factory that created them).
         self._editor_to_kind_map = weakref.WeakKeyDictionary()


### PR DESCRIPTION
This PR updates `super` usage in a semi-automated fashion. We used regex-based search and replace to update the `super` usage. Note that there was one unnnecessary redefinition of `__init__` which got removed in this PR.

See similar PR #944, #945 and https://github.com/enthought/traits/pull/1280