### PR TITLE
Update  _*_changed static trait listeners to use traits observe

### DIFF
--- a/examples/tasks/advanced/python_editor_qt4.py
+++ b/examples/tasks/advanced/python_editor_qt4.py
@@ -16,7 +16,9 @@ from os.path import basename
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Bool, Event, Instance, File, Str, Property, provides
+from traits.api import (
+    Bool, Event, File, Instance, observe, Property, provides, Str
+)
 from pyface.tasks.api import Editor
 
 
@@ -104,11 +106,13 @@ class PythonEditor(Editor):
     # Trait handlers.
     # ------------------------------------------------------------------------
 
-    def _path_changed(self):
+    @observe('path')
+    def _path_updated(self, event):
         if self.control is not None:
             self.load()
 
-    def _show_line_numbers_changed(self):
+    @observe('show_line_numbers')
+    def _show_line_numbers_updated(self, event=None):
         if self.control is not None:
             self.control.code.line_number_widget.setVisible(
                 self.show_line_numbers
@@ -125,7 +129,7 @@ class PythonEditor(Editor):
         from pyface.ui.qt4.code_editor.code_widget import AdvancedCodeWidget
 
         self.control = control = AdvancedCodeWidget(parent)
-        self._show_line_numbers_changed()
+        self._show_line_numbers_updated()
 
         # Install event filter to trap key presses.
         event_filter = PythonEditorEventFilter(self, self.control)

--- a/examples/tasks/advanced/python_editor_wx.py
+++ b/examples/tasks/advanced/python_editor_wx.py
@@ -17,7 +17,9 @@ import wx
 import wx.stc
 
 
-from traits.api import Bool, Event, Instance, File, Str, Property, provides
+from traits.api import (
+    Bool, Event, File, Instance, observe, Property, provides, Str
+)
 from pyface.tasks.api import Editor
 from pyface.wx.python_stc import PythonSTC, faces
 
@@ -114,11 +116,13 @@ class PythonEditor(Editor):
     # Trait handlers.
     # ------------------------------------------------------------------------
 
-    def _path_changed(self):
+    @observe('path')
+    def _path_updated(self, event):
         if self.control is not None:
             self.load()
 
-    def _show_line_numbers_changed(self):
+    @observe('show_line_numbers')
+    def _show_line_numbers_updated(self, event=None):
         if self.control is not None:
             c = self.control
             if self.show_line_numbers:
@@ -137,7 +141,7 @@ class PythonEditor(Editor):
         from pyface.ui.qt4.code_editor.code_widget import AdvancedCodeWidget
 
         self.control = control = AdvancedCodeWidget(parent)
-        self._show_line_numbers_changed()
+        self._show_line_numbers_updated()
 
     def _create_control(self, parent):
         """ Creates the toolkit-specific control for the widget. """

--- a/pyface/action/action_item.py
+++ b/pyface/action/action_item.py
@@ -66,11 +66,13 @@ class ActionItem(ActionManagerItem):
 
     # Trait change handlers ------------------------------------------------
 
-    def _enabled_changed(self, trait_name, old, new):
-        self.action.enabled = new
+    @observe('enabled')
+    def _enabled_updated(self, event):
+        self.action.enabled = event.new
 
-    def _visible_changed(self, trait_name, old, new):
-        self.action.visible = new
+    @observe('visible')
+    def _visible_updated(self, event):
+        self.action.visible = event.new
 
     @observe("_wrappers:items:control")
     def _on_destroy(self, event):

--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -11,9 +11,9 @@
 """ Abstract base class for all action managers. """
 
 
-from traits.api import Bool, Constant, Event, HasTraits, Instance
-from traits.api import List, Property, Str
-
+from traits.api import (
+    Bool, Constant, Event, HasTraits, Instance, List, observe, Property, Str
+)
 
 from pyface.action.action_controller import ActionController
 from pyface.action.group import Group
@@ -125,13 +125,15 @@ class ActionManager(HasTraits):
 
     # Trait change handlers ------------------------------------------------
 
-    def _enabled_changed(self, trait_name, old, new):
+    @observe('enabled')
+    def _enabled_updated(self, event):
         for group in self._groups:
-            group.enabled = new
+            group.enabled = event.new
 
-    def _visible_changed(self, trait_name, old, new):
+    @observe('visible')
+    def _visible_updated(self, event):
         for group in self._groups:
-            group.visible = new
+            group.visible = event.new
 
     # Methods -------------------------------------------------------------#
 

--- a/pyface/action/group.py
+++ b/pyface/action/group.py
@@ -13,8 +13,7 @@
 from functools import partial
 
 
-from traits.api import Any, Bool, HasTraits, List, Property
-from traits.api import Str
+from traits.api import Any, Bool, HasTraits, List, observe, Property, Str
 from traits.trait_base import user_name_for
 
 
@@ -87,9 +86,10 @@ class Group(HasTraits):
 
     # Trait change handlers ------------------------------------------------
 
-    def _enabled_changed(self, trait_name, old, new):
+    @observe("enabled")
+    def _enabled_updated(self, event):
         for item in self.items:
-            item.enabled = new
+            item.enabled = event.new
 
     # Methods -------------------------------------------------------------#
 

--- a/pyface/action/listening_action.py
+++ b/pyface/action/listening_action.py
@@ -16,7 +16,7 @@ import logging
 
 
 from pyface.action.action import Action
-from traits.api import Any, Str, Undefined
+from traits.api import Any, Str, observe, Undefined
 
 # Logging.
 logger = logging.getLogger(__name__)
@@ -100,7 +100,9 @@ class ListeningAction(Action):
 
     # Trait change handlers --------------------------------------------------
 
-    def _enabled_name_changed(self, old, new):
+    @observe('enabled_name')
+    def _enabled_name_updated(self, event):
+        old, new = event.old, event.new
         obj = self.object
         if obj is not None:
             if old:
@@ -109,7 +111,9 @@ class ListeningAction(Action):
                 obj.observe(self._enabled_update, new)
         self._enabled_update()
 
-    def _visible_name_changed(self, old, new):
+    @observe('visible_name')
+    def _visible_name_updated(self, event):
+        old, new = event.old, event.new
         obj = self.object
         if obj is not None:
             if old:
@@ -118,7 +122,9 @@ class ListeningAction(Action):
                 obj.observe(self._visible_update, new)
         self._visible_update()
 
-    def _object_changed(self, old, new):
+    @observe('object')
+    def _object_updated(self, event):
+        old, new = event.old, event.new
         for kind in ("enabled", "visible"):
             method = getattr(self, "_%s_update" % kind)
             name = getattr(self, "%s_name" % kind)

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -36,6 +36,7 @@ from traits.api import (
     Undefined,
     Bool,
     cached_property,
+    observe,
 )
 from traitsui.dock_window_theme import dock_window_theme
 from traitsui.wx.helper import BufferDC

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -2008,7 +2008,8 @@ class DockControl(DockItem):
     #  Handles the 'feature_changed' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _feature_changed(self):
+    @observe("feature_changed")
+    def _feature_changed_updated(self, event):
         """ Handles the 'feature_changed' trait being changed
         """
         self.set_feature_mode()

--- a/pyface/dock/dock_sizer.py
+++ b/pyface/dock/dock_sizer.py
@@ -2018,9 +2018,11 @@ class DockControl(DockItem):
     #  Handles the 'control' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _control_changed(self, old, new):
+    @observe("control")
+    def _control_updated(self, event):
         """ Handles the 'control' trait being changed.
         """
+        old, new = event.old, event.new
         self._tab_width = None
 
         if old is not None:
@@ -2034,7 +2036,8 @@ class DockControl(DockItem):
     #  Handles the 'name' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _name_changed(self):
+    @observe("name")
+    def _name_updated(self, event):
         """ Handles the 'name' trait being changed.
         """
         self._tab_width = self._tab_name = None
@@ -2043,7 +2046,8 @@ class DockControl(DockItem):
     #  Handles the 'style' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _style_changed(self):
+    @observe("style")
+    def _style_updated(self, event):
         """ Handles the 'style' trait being changed.
         """
         if self.parent is not None:
@@ -2053,7 +2057,8 @@ class DockControl(DockItem):
     #  Handles the 'image' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _image_changed(self):
+    @observe("image")
+    def _image_updated(self, event):
         """ Handles the 'image' trait being changed.
         """
         self._image = None
@@ -2062,7 +2067,8 @@ class DockControl(DockItem):
     #  Handles the 'visible' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _visible_changed(self):
+    @observe("visible")
+    def _visible_updated(self, event):
         """ Handles the 'visible' trait being changed.
         """
         if self.parent is not None:
@@ -2072,9 +2078,11 @@ class DockControl(DockItem):
     #  Handles the 'dockable' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _dockable_changed(self, dockable):
+    @observe("dockable")
+    def _dockable_updated(self, event):
         """ Handles the 'dockable' trait being changed.
         """
+        dockable = event.new
         if dockable is not None:
             dockable.dockable_bind(self)
 
@@ -2243,7 +2251,8 @@ class DockGroup(DockItem):
     #  Handles 'initialized' being changed:
     # ---------------------------------------------------------------------------
 
-    def _initialized_changed(self):
+    @observe("initialized")
+    def _initialized_updated(self, event):
         """ Handles 'initialized' being changed.
         """
         for item in self.contents:
@@ -3003,7 +3012,9 @@ class DockRegion(DockGroup):
     #  Handles the 'active' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _active_changed(self, old, new):
+    @observe("active")
+    def _active_updated(self, event):
+        old, new = event.old, event.new
         self._set_visibility()
 
         # Set the correct tab state for each tab:
@@ -3031,7 +3042,8 @@ class DockRegion(DockGroup):
     #  Handles the 'contents' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _contents_changed(self):
+    @observe("contents")
+    def _contents_updated(self, event):
         """ Handles the 'contents' trait being changed.
         """
         self._is_notebook = None
@@ -3040,7 +3052,8 @@ class DockRegion(DockGroup):
         self.calc_min(True)
         self.modified = True
 
-    def _contents_items_changed(self, event):
+    @observe("contents:items")
+    def _contents_items_updated(self, event):
         """ Handles the 'contents' trait being changed.
         """
         self._is_notebook = None
@@ -3760,7 +3773,8 @@ class DockSection(DockGroup):
     #  Handles the 'contents' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _contents_changed(self):
+    @observe("contents")
+    def _contents_updated(self, event):
         """ Handles the 'contents' trait being changed.
         """
         for item in self.contents:
@@ -3768,7 +3782,8 @@ class DockSection(DockGroup):
         self.calc_min(True)
         self.modified = True
 
-    def _contents_items_changed(self, event):
+    @observe("contents:items")
+    def _contents_items_updated(self, event):
         """ Handles the 'contents' trait being changed.
         """
         for item in event.added:
@@ -3780,13 +3795,15 @@ class DockSection(DockGroup):
     #  Handles the 'splitters' trait being changed:
     # ---------------------------------------------------------------------------
 
-    def _splitters_changed(self):
+    @observe("splitters")
+    def _splitters_updated(self, event):
         """ Handles the 'splitters' trait being changed.
         """
         for item in self.splitters:
             item.parent = self
 
-    def _splitters_items_changed(self, event):
+    @observe("splitters:items")
+    def _splitters_items_updated(self, event):
         """ Handles the 'splitters' trait being changed.
         """
         for item in event.added:

--- a/pyface/dock/tests/test_dock_sizer.py
+++ b/pyface/dock/tests/test_dock_sizer.py
@@ -1,0 +1,27 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import unittest
+from unittest.mock import MagicMock
+
+from pyface.dock.dock_sizer import DockControl
+from pyface.toolkit import toolkit
+
+not_wx = toolkit.toolkit != "wx"
+
+class TestDockControl(unittest.TestCase):
+
+    @unittest.skipIf(not_wx, "This test is specific to the wx backend")
+    def test_feature_changed(self):
+        dock_control = DockControl()
+        DockControl.set_feature_mode = MagicMock()
+        dock_control.feature_changed = True
+
+        dock_control.set_feature_mode.assert_called_once_with()

--- a/pyface/dock/tests/test_dock_sizer.py
+++ b/pyface/dock/tests/test_dock_sizer.py
@@ -11,15 +11,16 @@
 import unittest
 from unittest.mock import MagicMock
 
-from pyface.dock.dock_sizer import DockControl
 from pyface.toolkit import toolkit
 
 not_wx = toolkit.toolkit != "wx"
+
 
 class TestDockControl(unittest.TestCase):
 
     @unittest.skipIf(not_wx, "This test is specific to the wx backend")
     def test_feature_changed(self):
+        from pyface.dock.dock_sizer import DockControl
         dock_control = DockControl()
         DockControl.set_feature_mode = MagicMock()
         dock_control.feature_changed = True

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -167,11 +167,14 @@ class ApplicationWindow(MApplicationWindow, Window):
     # assignment. For this reason, it is unnecessary to delete the old controls
     # in the following two handlers.
 
-    def _menu_bar_manager_changed(self):
+    @observe("menu_bar_manager")
+    def _menu_bar_manager_updated(self, event):
         if self.control is not None:
             self._create_menu_bar(self.control)
 
-    def _status_bar_manager_changed(self, old, new):
+    @observe("status_bar_manager")
+    def _status_bar_manager_updated(self, event):
+        old, new = event.old, event.new
         if self.control is not None:
             if old is not None:
                 old.destroy_status_bar()
@@ -189,5 +192,6 @@ class ApplicationWindow(MApplicationWindow, Window):
             # Add the new toolbars.
             self._create_tool_bar(self.control)
 
-    def _icon_changed(self):
+    @observe("icon")
+    def _icon_updated(self, event):
         self._set_window_icon()


### PR DESCRIPTION
Part of #899 

This PR replaces some of the instances of `_*_changed` static trait listeners with `observe` from the code base.  There are still plenty more that will need to be addressed in follow up PRs.