### PR TITLE
Address a few deprecation warnings when using python 3.8 and pyqt5

### DIFF
--- a/pyface/data_view/data_models/tests/test_array_data_model.py
+++ b/pyface/data_view/data_models/tests/test_array_data_model.py
@@ -55,7 +55,7 @@ class TestArrayDataModel(UnittestTools, TestCase):
         model = ArrayDataModel(value_type=FloatValue())
         self.assertEqual(model.data.ndim, 2)
         self.assertEqual(model.data.shape, (0, 0))
-        self.assertEqual(model.data.dtype, np.float)
+        self.assertEqual(model.data.dtype, float)
         self.assertEqual(model.get_column_count(), 0)
         self.assertTrue(model.can_have_children(()))
         self.assertEqual(model.get_row_count(()), 0)

--- a/pyface/ui/qt4/console/console_widget.py
+++ b/pyface/ui/qt4/console/console_widget.py
@@ -347,7 +347,7 @@ class ConsoleWidget(QtGui.QWidget):
         if self.paging == "vsplit":
             height = height * 2 + splitwidth
 
-        return QtCore.QSize(width, height)
+        return QtCore.QSize(int(width), int(height))
 
     # ---------------------------------------------------------------------------
     # 'ConsoleWidget' public interface
@@ -1966,7 +1966,7 @@ class ConsoleWidget(QtGui.QWidget):
             step = viewport_height
         diff = maximum - scrollbar.maximum()
         scrollbar.setRange(0, maximum)
-        scrollbar.setPageStep(step)
+        scrollbar.setPageStep(int(step))
         # Compensate for undesirable scrolling that occurs automatically due to
         # maximumBlockCount() text truncation.
         if diff < 0 and document.blockCount() == document.maximumBlockCount():


### PR DESCRIPTION
This PR addresses a few deprecation warnings observed using python 3.8 and pyqt5 on the traitsui and pyface test suites.