### PR TITLE
Toggle Fields (CheckBoxField, RadioButtonField, etc.)

### DIFF
--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -66,7 +66,7 @@ ToggleField and Subclasses
 ==========================
 
 The :py:class:`~pyface.fields.i_toggle_field.IToggleField` interface holds a
-boolean :py:attr:`~pyface.fields.i_spin_field.IToggleField.value` that is
+boolean :py:attr:`~pyface.fields.i_toggle_field.IToggleField.value` that is
 toggled between ``True`` and ``False`` by the widget.  The interface is
 implemented by several different concrete classes with different appearances
 but similar behaviour:
@@ -81,6 +81,6 @@ implementations to toggling behaviour.
 
 All :py:class:`~pyface.fields.i_toggle_field.IToggleField` implementations
 have can have label text set via the
-:py:attr:`~pyface.fields.i_spin_field.IToggleField.text` trait, and in the
+:py:attr:`~pyface.fields.i_toggle_field.IToggleField.text` trait, and in the
 Qt backend they can have an image for an
-:py:attr:`~pyface.fields.i_spin_field.IToggleField.icon`.
+:py:attr:`~pyface.fields.i_toggle_field.IToggleField.icon`.

--- a/docs/source/fields.rst
+++ b/docs/source/fields.rst
@@ -62,4 +62,25 @@ values, a :py:attr:`~pyface.fields.i_spin_field.IComboField.formatter` function
 should be provided - this defaults to either :py:func:`str` (Python 3+) or
 :py:func:`unicode` (Python 2).
 
+ToggleField and Subclasses
+==========================
 
+The :py:class:`~pyface.fields.i_toggle_field.IToggleField` interface holds a
+boolean :py:attr:`~pyface.fields.i_spin_field.IToggleField.value` that is
+toggled between ``True`` and ``False`` by the widget.  The interface is
+implemented by several different concrete classes with different appearances
+but similar behaviour:
+
+- :py:class:`~pyface.fields.toggle_field.CheckBoxField`
+- :py:class:`~pyface.fields.toggle_field.RadioButtonField`
+- :py:class:`~pyface.fields.toggle_field.ToggleButtonField`
+
+There is an abstract class :py:class:`~pyface.fields.toggle_field.ToggleField`
+which implements much of the behaviour and is suitable for use by custom
+implementations to toggling behaviour.
+
+All :py:class:`~pyface.fields.i_toggle_field.IToggleField` implementations
+have can have label text set via the
+:py:attr:`~pyface.fields.i_spin_field.IToggleField.text` trait, and in the
+Qt backend they can have an image for an
+:py:attr:`~pyface.fields.i_spin_field.IToggleField.icon`.

--- a/pyface/fields/api.py
+++ b/pyface/fields/api.py
@@ -15,9 +15,12 @@
 
 API for the ``pyface.fields`` subpackage.
 
+- :class:`~.CheckBoxField`
 - :class:`~.ComboField`
+- :class:`~.RadioButtonField`
 - :class:`~.SpinField`
 - :class:`~.TextField`
+- :class:`~.ToggleButtonField`
 
 Interfaces
 ----------
@@ -25,6 +28,7 @@ Interfaces
 - :class:`~.IField`
 - :class:`~.ISpinField`
 - :class:`~.ITextField`
+- :class:`~.IToggleField`
 
 """
 
@@ -32,7 +36,11 @@ from .i_combo_field import IComboField
 from .i_field import IField
 from .i_spin_field import ISpinField
 from .i_text_field import ITextField
+from .i_toggle_field import IToggleField
 
 from .combo_field import ComboField
 from .spin_field import SpinField
 from .text_field import TextField
+from .toggle_field import (
+    CheckBoxField, RadioButtonField, ToggleButtonField,
+)

--- a/pyface/fields/api.py
+++ b/pyface/fields/api.py
@@ -7,9 +7,6 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-#
-# Author: Enthought, Inc.
-# Description: <Enthought pyface package component>
 
 """
 

--- a/pyface/fields/i_toggle_field.py
+++ b/pyface/fields/i_toggle_field.py
@@ -1,0 +1,98 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" The toggle field interface. """
+
+
+from traits.api import Bool, HasTraits, Str
+
+from pyface.fields.i_field import IField
+from pyface.ui_traits import Image
+
+
+class IToggleField(IField):
+    """ The toggle field interface.
+
+    This is for a toggle between two states.
+    """
+
+    #: The current value of the toggle.
+    value = Bool()
+
+    #: The text to display in the toggle.
+    text = Str()
+
+    #: The icon to display with the toggle.
+    icon = Image()
+
+
+class MToggleField(HasTraits):
+    """ The toggle field mixin class.
+
+    This is for a toggle between two states.
+    """
+
+    #: The current value of the toggle.
+    value = Bool()
+
+    #: The text to display in the toggle.
+    text = Str()
+
+    #: The icon to display with the toggle.
+    icon = Image()
+
+    # ------------------------------------------------------------------------
+    # Private interface
+    # ------------------------------------------------------------------------
+
+    def _initialize_control(self):
+        super()._initialize_control()
+        self._set_control_text(self.text)
+        self._set_control_icon(self.icon)
+
+    def _add_event_listeners(self):
+        """ Set up toolkit-specific bindings for events """
+        super()._add_event_listeners()
+        self.observe(self._text_updated, "text", dispatch="ui")
+        self.observe(self._icon_updated, "icon", dispatch="ui")
+        if self.control is not None:
+            self._observe_control_value()
+
+    def _remove_event_listeners(self):
+        """ Remove toolkit-specific bindings for events """
+        if self.control is not None:
+            self._observe_control_value(remove=True)
+        self.observe(self._text_updated, "text", dispatch="ui", remove=True)
+        self.observe(self._icon_updated, "icon", dispatch="ui", remove=True)
+        super()._remove_event_listeners()
+
+    # Toolkit control interface ---------------------------------------------
+
+    def _get_control_text(self):
+        """ Toolkit specific method to set the control's text. """
+        raise NotImplementedError()
+
+    def _set_control_text(self, text):
+        """ Toolkit specific method to set the control's text. """
+        raise NotImplementedError()
+
+    def _set_control_icon(self, icon):
+        """ Toolkit specific method to set the control's icon. """
+        raise NotImplementedError()
+
+    # Trait change handlers -------------------------------------------------
+
+    def _text_updated(self, event):
+        if self.control is not None:
+            self._set_control_text(self.text)
+
+    def _icon_updated(self, event):
+        if self.control is not None:
+            self._set_control_icon(self.icon)

--- a/pyface/fields/i_toggle_field.py
+++ b/pyface/fields/i_toggle_field.py
@@ -20,7 +20,7 @@ from pyface.ui_traits import Image
 class IToggleField(IField):
     """ The toggle field interface.
 
-    This is for a toggle between two states.
+    This is for a toggle between two states, represented by a boolean value.
     """
 
     #: The current value of the toggle.
@@ -36,7 +36,7 @@ class IToggleField(IField):
 class MToggleField(HasTraits):
     """ The toggle field mixin class.
 
-    This is for a toggle between two states.
+    This is for a toggle between two states, represented by a boolean value.
     """
 
     #: The current value of the toggle.

--- a/pyface/fields/tests/test_toggle_field.py
+++ b/pyface/fields/tests/test_toggle_field.py
@@ -1,0 +1,88 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+import unittest
+
+
+from pyface.image_resource import ImageResource
+from ..toggle_field import (
+    CheckBoxField, RadioButtonField, ToggleButtonField
+)
+from .field_mixin import FieldMixin
+
+
+class ToggleFieldMixin(FieldMixin):
+
+    # Tests ------------------------------------------------------------------
+
+    def test_toggle_field(self):
+        self._create_widget_control()
+
+        self.widget.value = True
+        self.gui.process_events()
+
+        self.assertEqual(self.widget._get_control_value(), True)
+
+    def test_toggle_field_set(self):
+        self._create_widget_control()
+
+        with self.assertTraitChanges(self.widget, "value", count=1):
+            self.widget._set_control_value(True)
+            self.gui.process_events()
+
+        self.assertEqual(self.widget.value, True)
+
+    def test_text_field_text(self):
+        self._create_widget_control()
+        self.assertEqual(self.widget._get_control_text(), "Toggle")
+
+        self.widget.text = "Test"
+        self.gui.process_events()
+
+        self.assertEqual(self.widget._get_control_text(), "Test")
+
+    def test_text_field_image(self):
+        self._create_widget_control()
+        image = ImageResource("question")
+
+        # XXX can't validate icon values currently, so just a smoke test
+        self.widget.image = image
+        self.gui.process_events()
+
+
+class TestCheckboxField(ToggleFieldMixin, unittest.TestCase):
+
+    def _create_widget(self):
+        return CheckBoxField(
+            parent=self.parent.control,
+            text="Toggle",
+            tooltip="Dummy",
+        )
+
+
+class TestRadioButtonField(ToggleFieldMixin, unittest.TestCase):
+
+    def _create_widget(self):
+        return RadioButtonField(
+            parent=self.parent.control,
+            text="Toggle",
+            tooltip="Dummy",
+        )
+
+
+class TestToggleButtonField(ToggleFieldMixin, unittest.TestCase):
+
+    def _create_widget(self):
+        return ToggleButtonField(
+            parent=self.parent.control,
+            text="Toggle",
+            tooltip="Dummy",
+        )

--- a/pyface/fields/toggle_field.py
+++ b/pyface/fields/toggle_field.py
@@ -1,0 +1,22 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+#
+# Author: Enthought, Inc.
+# Description: <Enthought pyface package component>
+
+""" The toggle field widgets. """
+
+# Import the toolkit specific version.
+from pyface.toolkit import toolkit_object
+
+ToggleField = toolkit_object("fields.toggle_field:ToggleField")
+CheckBoxField = toolkit_object("fields.toggle_field:CheckBoxField")
+RadioButtonField = toolkit_object("fields.toggle_field:RadioButtonField")
+ToggleButtonField = toolkit_object("fields.toggle_field:ToggleButtonField")

--- a/pyface/fields/toggle_field.py
+++ b/pyface/fields/toggle_field.py
@@ -7,9 +7,6 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-#
-# Author: Enthought, Inc.
-# Description: <Enthought pyface package component>
 
 """ The toggle field widgets. """
 

--- a/pyface/ui/qt4/fields/toggle_field.py
+++ b/pyface/ui/qt4/fields/toggle_field.py
@@ -1,0 +1,95 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+#
+# Author: Enthought, Inc.
+# Description: <Enthought pyface package component>
+
+""" The Qt-specific implementation of the toggle field class """
+
+
+from traits.api import provides
+
+from pyface.fields.i_toggle_field import IToggleField, MToggleField
+from pyface.qt.QtGui import (
+    QCheckBox, QIcon, QPushButton, QRadioButton, QToolButton,
+)
+from .field import Field
+
+
+@provides(IToggleField)
+class ToggleField(MToggleField, Field):
+    """ The Qt-specific implementation of the toggle field class """
+
+    # ------------------------------------------------------------------------
+    # Private interface
+    # ------------------------------------------------------------------------
+
+    # Toolkit control interface ---------------------------------------------
+
+    def _get_control_value(self):
+        """ Toolkit specific method to get the control's value. """
+        return self.control.isChecked()
+
+    def _get_control_text(self):
+        """ Toolkit specific method to get the control's text. """
+        return self.control.text()
+
+    def _set_control_value(self, value):
+        """ Toolkit specific method to set the control's value. """
+        return self.control.setChecked(value)
+
+    def _set_control_text(self, text):
+        """ Toolkit specific method to set the control's text. """
+        return self.control.setText(text)
+
+    def _set_control_icon(self, icon):
+        """ Toolkit specific method to set the control's icon. """
+        if icon is not None:
+            self.control.setIcon(icon.create_icon())
+        else:
+            self.control.setIcon(QIcon())
+
+    def _observe_control_value(self, remove=False):
+        """ Toolkit specific method to change the control value observer. """
+        if remove:
+            self.control.toggled.disconnect(self._update_value)
+        else:
+            self.control.toggled.connect(self._update_value)
+
+
+class CheckBoxField(ToggleField):
+    """ The Qt-specific implementation of the checkbox class """
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+        control = QCheckBox(parent)
+        return control
+
+
+class RadioButtonField(ToggleField):
+    """ The Qt-specific implementation of the radio button class
+
+    This is intended to be used in groups, and shouldn't be used by itself.
+    """
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+        control = QRadioButton(parent)
+        return control
+
+
+class ToggleButtonField(ToggleField):
+    """ The Qt-specific implementation of the toggle button class """
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+        control = QPushButton(parent)
+        control.setCheckable(True)
+        return control

--- a/pyface/ui/qt4/fields/toggle_field.py
+++ b/pyface/ui/qt4/fields/toggle_field.py
@@ -7,9 +7,6 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-#
-# Author: Enthought, Inc.
-# Description: <Enthought pyface package component>
 
 """ The Qt-specific implementation of the toggle field class """
 

--- a/pyface/ui/wx/fields/toggle_field.py
+++ b/pyface/ui/wx/fields/toggle_field.py
@@ -1,0 +1,128 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+#
+# Author: Enthought, Inc.
+# Description: <Enthought pyface package component>
+
+""" The Wx-specific implementation of the toggle field class """
+
+import wx
+
+from traits.api import provides
+
+from pyface.fields.i_toggle_field import IToggleField, MToggleField
+from .field import Field
+
+
+@provides(IToggleField)
+class ToggleField(MToggleField, Field):
+    """ The Wx-specific implementation of the toggle field class """
+
+    # ------------------------------------------------------------------------
+    # Private interface
+    # ------------------------------------------------------------------------
+
+    # Toolkit control interface ---------------------------------------------
+
+    def _get_control_value(self):
+        """ Toolkit specific method to get the control's value. """
+        return self.control.GetValue()
+
+    def _get_control_text(self):
+        """ Toolkit specific method to get the control's text. """
+        return self.control.GetLabel()
+
+    def _set_control_value(self, value):
+        """ Toolkit specific method to set the control's value. """
+        self.control.SetValue(value)
+
+    def _set_control_text(self, text):
+        """ Toolkit specific method to set the control's text. """
+        self.control.SetLabel(text)
+
+    def _set_control_icon(self, icon):
+        """ Toolkit specific method to set the control's icon. """
+        # don't support icons on Wx for now
+        pass
+
+
+class CheckBoxField(ToggleField):
+    """ The Wx-specific implementation of the checkbox class """
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+        control = wx.CheckBox(parent)
+        return control
+
+    def _set_control_value(self, value):
+        """ Toolkit specific method to set the control's value. """
+        super()._set_control_value(value)
+        event = wx.CommandEvent(wx.EVT_CHECKBOX.typeId, self.control.GetId())
+        event.SetInt(value)
+        wx.PostEvent(self.control.GetEventHandler(), event)
+
+    def _observe_control_value(self, remove=False):
+        """ Toolkit specific method to change the control value observer. """
+        if remove:
+            self.control.Unbind(wx.EVT_CHECKBOX, handler=self._update_value)
+        else:
+            self.control.Bind(wx.EVT_CHECKBOX, self._update_value)
+
+
+class RadioButtonField(ToggleField):
+    """ The Wx-specific implementation of the radio button class
+
+    This is intended to be used in groups, and shouldn't be used by itself.
+    """
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+        control = wx.RadioButton(parent)
+        return control
+
+    def _set_control_value(self, value):
+        """ Toolkit specific method to set the control's value. """
+        super()._set_control_value(value)
+        event = wx.CommandEvent(wx.EVT_RADIOBUTTON.typeId, self.control.GetId())
+        event.SetInt(value)
+        wx.PostEvent(self.control.GetEventHandler(), event)
+
+    def _observe_control_value(self, remove=False):
+        """ Toolkit specific method to change the control value observer. """
+        if remove:
+            self.control.Unbind(wx.EVT_RADIOBUTTON, handler=self._update_value)
+        else:
+            self.control.Bind(wx.EVT_RADIOBUTTON, self._update_value)
+
+
+class ToggleButtonField(ToggleField):
+    """ The Wx-specific implementation of the toggle button class """
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+        control = wx.ToggleButton(parent)
+        return control
+
+    def _set_control_value(self, value):
+        """ Toolkit specific method to set the control's value. """
+        super()._set_control_value(value)
+        event = wx.CommandEvent(wx.EVT_TOGGLEBUTTON.typeId, self.control.GetId())
+        event.SetInt(value)
+        wx.PostEvent(self.control.GetEventHandler(), event)
+
+    def _observe_control_value(self, remove=False):
+        """ Toolkit specific method to change the control value observer. """
+        if remove:
+            self.control.Unbind(
+                wx.EVT_TOGGLEBUTTON,
+                handler=self._update_value,
+            )
+        else:
+            self.control.Bind(wx.EVT_TOGGLEBUTTON, self._update_value)

--- a/pyface/ui/wx/fields/toggle_field.py
+++ b/pyface/ui/wx/fields/toggle_field.py
@@ -7,9 +7,6 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-#
-# Author: Enthought, Inc.
-# Description: <Enthought pyface package component>
 
 """ The Wx-specific implementation of the toggle field class """
 


### PR DESCRIPTION
This PR adds additional fields with toggling behaviour: check boxes, radio buttons, and toggle buttons.

The purpose of this functionality is to abstract the common API to permit an eventual refactor of the TraitsUI `BooleanEditor` to allow styles other than checkboxes.