### PR TITLE
Catch deprecation warning thrown by QtScript import in testsuite

### DIFF
--- a/pyface/ui/qt4/tests/test_qt_imports.py
+++ b/pyface/ui/qt4/tests/test_qt_imports.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 import unittest
+import warnings
 
 
 class TestPyfaceQtImports(unittest.TestCase):
@@ -18,9 +19,21 @@ class TestPyfaceQtImports(unittest.TestCase):
         import pyface.qt.QtGui
         import pyface.qt.QtNetwork
         import pyface.qt.QtOpenGL
-        import pyface.qt.QtScript
         import pyface.qt.QtSvg
         import pyface.qt.QtTest
         import pyface.qt.QtWebKit
         import pyface.qt.QtMultimedia
         import pyface.qt.QtMultimediaWidgets
+
+    def test_import_QtScript(self):
+        # QtScript is not supported on PyQt5/PySide2 and
+        # this import will raise a deprecation warning.
+        with warnings.catch_warnings(record=True) as w:
+            # Cause all warnings to always be triggered.
+            warnings.simplefilter("always", category=DeprecationWarning)
+
+            import pyface.qt.QtScript
+
+        self.assertTrue(len(w) == 1)
+        for warn in w:
+            self.assertEqual(warn.category, DeprecationWarning)


### PR DESCRIPTION
`pyface.qt.QtScript` is expected to throw a deprecation warning on `PyQt5`/`PySide2`. We refactored the existing test to create a new test that checks for the deprecation warning  while also swallowing the deprecation warning thereby making the test output cleaner.

fixes #582 (the last open item)