### PR TITLE
Use "ubuntu-latest" in GitHub Actions CI

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -13,7 +13,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2']
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -15,7 +15,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2']
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
This PR updates GitHub Actions CI to use `ubuntu-latest` instead of using an older version of ubuntu. I'm not entirely sure why we were pinning CI to use an older version of ubuntu in the first place - we might just have copied over existing CI configuration from another ETS repository.