### PR TITLE
Make it possible to manually trigger cron job

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -3,6 +3,8 @@ name: Test with EDM using ETS packages from source
 on:
   schedule:
     - cron:  '0 0 * * 5'
+  # Make it possible to manually trigger the workflow
+  workflow_dispatch:
 
 env:
   INSTALL_EDM_VERSION: 3.2.3


### PR DESCRIPTION
This PR makes it possible to manually trigger the cron job - using `workflow_dispatch`. Ref https://github.com/enthought/ets/issues/68