### PR TITLE
HeadingText fixes

### DIFF
--- a/pyface/i_heading_text.py
+++ b/pyface/i_heading_text.py
@@ -10,11 +10,9 @@
 
 """ Heading text. """
 
+import warnings
 
-from traits.api import HasTraits, Instance, Int, Interface, Str
-
-
-from pyface.i_image_resource import IImageResource
+from traits.api import HasTraits, Int, Interface, Str
 
 
 class IHeadingText(Interface):
@@ -31,11 +29,30 @@ class IHeadingText(Interface):
     #: The heading text.
     text = Str("Default")
 
-    #: The background image.
-    image = Instance(IImageResource)
-
 
 class MHeadingText(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the IHeadingText interface.
     """
+
+    level = Int(1)
+
+    text = Str("Default")
+
+    def __init__(self, parent=None, **traits):
+        """ Creates the heading text. """
+
+        create = traits.pop("create", True)
+
+        # Base class constructor.
+        super().__init__(parent=parent, **traits)
+
+        if create:
+            # Create the widget's toolkit-specific control.
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -68,8 +68,8 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
         with self.event_loop():
             self.widget.destroy()
 
-    def test_message(self):
-        # test that create works with message
+    def test_text(self):
+        # test that create works with text
         with self.event_loop():
             self.widget = HeadingText(
                 self.window.control,
@@ -78,24 +78,19 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
             )
             self.widget.create()
 
+        self.assertEqual(self.widget.text, "Hello")
+        self.assertEqual(self.widget._get_control_text(), "Hello")
+
         with self.event_loop():
             self.widget.destroy()
 
     @unittest.skipUnless(is_wx, "Only Wx supports background images")
     def test_image(self):
-        # test that image works
-        # XXX this image doesn't make sense here, but that's fine
-        # XXX this isn't implemented in qt4 backend, but shouldn't fail
+        # test that image raises a deprecation warning
         with self.event_loop():
-            self.widget = HeadingText(
-                self.window.control, image=ImageResource("core.png")
-            )
-        with self.event_loop():
-            self.widget.destroy()
-
-    def test_level(self):
-        # test that create works with level
-        with self.event_loop():
-            self.widget = HeadingText(self.window.control, level=2)
-        with self.event_loop():
-            self.widget.destroy()
+            with self.assertWarns(PendingDeprecationWarning):
+                self.widget = HeadingText(
+                    self.window.control,
+                    create=False,
+                    image=ImageResource("core.png"),
+                )

--- a/pyface/ui/qt4/heading_text.py
+++ b/pyface/ui/qt4/heading_text.py
@@ -44,7 +44,6 @@ class HeadingText(MHeadingText, Widget):
         """ Set the text on the toolkit specific widget. """
         # Bold the text. Qt supports a limited subset of HTML for rich text.
         text = f"<b>{text}</b>"
-        print(text)
         self.control.setText(text)
 
     def _get_control_text(self):

--- a/pyface/ui/qt4/heading_text.py
+++ b/pyface/ui/qt4/heading_text.py
@@ -13,7 +13,7 @@
 
 from pyface.qt import QtGui
 
-from traits.api import observe, provides
+from traits.api import provides
 
 from pyface.i_heading_text import IHeadingText, MHeadingText
 from .widget import Widget
@@ -21,37 +21,35 @@ from .widget import Widget
 
 @provides(IHeadingText)
 class HeadingText(MHeadingText, Widget):
-    """ The toolkit specific implementation of a HeadingText.  See the
-    IHeadingText interface for the API documentation.
+    """ The Qt-specific implementation of a HeadingText.
     """
 
     # ------------------------------------------------------------------------
-    # Private interface.
+    # 'IWidget' interface.
     # ------------------------------------------------------------------------
 
     def _create_control(self, parent):
         """ Create the toolkit-specific control that represents the widget. """
-
         control = QtGui.QLabel(parent)
-        control.setText(self.text)
         control.setSizePolicy(
             QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed
         )
         return control
 
-    def _set_text(self, text):
+    # ------------------------------------------------------------------------
+    # Private interface.
+    # ------------------------------------------------------------------------
+
+    def _set_control_text(self, text):
         """ Set the text on the toolkit specific widget. """
-
         # Bold the text. Qt supports a limited subset of HTML for rich text.
-        text = "<b>" + text + "</b>"
-
+        text = f"<b>{text}</b>"
+        print(text)
         self.control.setText(text)
 
-    # Trait event handlers -------------------------------------------------
-
-    @observe("text")
-    def _update_text(self, event):
-        """ Called when the text is changed. """
-        new = event.new
-        if self.control is not None:
-            self._set_text(new)
+    def _get_control_text(self):
+        """ Get the text on the toolkit specific widget. """
+        text = self.control.text()
+        # remove the bolding from the text
+        text = text[3:-4]
+        return text

--- a/pyface/ui/qt4/heading_text.py
+++ b/pyface/ui/qt4/heading_text.py
@@ -11,12 +11,9 @@
 # This software is provided without warranty under the terms of the BSD license.
 # However, when used with the GPL version of PyQt the additional terms described in the PyQt GPL exception also apply
 
-
 from pyface.qt import QtGui
 
-
-from traits.api import Int, observe, provides, Str
-
+from traits.api import observe, provides
 
 from pyface.i_heading_text import IHeadingText, MHeadingText
 from .widget import Widget
@@ -28,25 +25,6 @@ class HeadingText(MHeadingText, Widget):
     IHeadingText interface for the API documentation.
     """
 
-    # 'IHeadingText' interface ---------------------------------------------
-
-    level = Int(1)
-
-    text = Str("Default")
-
-    # ------------------------------------------------------------------------
-    # 'object' interface.
-    # ------------------------------------------------------------------------
-
-    def __init__(self, parent, **traits):
-        """ Creates the panel. """
-
-        # Base class constructor.
-        super().__init__(**traits)
-
-        # Create the toolkit-specific control that represents the widget.
-        self._create_control(parent)
-
     # ------------------------------------------------------------------------
     # Private interface.
     # ------------------------------------------------------------------------
@@ -54,12 +32,12 @@ class HeadingText(MHeadingText, Widget):
     def _create_control(self, parent):
         """ Create the toolkit-specific control that represents the widget. """
 
-        self.control = QtGui.QLabel(parent)
-        self._set_text(self.text)
-
-        self.control.setSizePolicy(
+        control = QtGui.QLabel(parent)
+        control.setText(self.text)
+        control.setSizePolicy(
             QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Fixed
         )
+        return control
 
     def _set_text(self, text):
         """ Set the text on the toolkit specific widget. """

--- a/pyface/ui/wx/heading_text.py
+++ b/pyface/ui/wx/heading_text.py
@@ -12,12 +12,9 @@
 """ Enthought pyface package component
 """
 
-
 import wx
 
-
-from traits.api import Instance, Int, provides, Str
-
+from traits.api import Instance, provides
 
 from pyface.i_heading_text import IHeadingText, MHeadingText
 from pyface.image_resource import ImageResource
@@ -31,28 +28,9 @@ class HeadingText(MHeadingText, Widget):
     IHeadingText interface for the API documentation.
     """
 
-    # 'IHeadingText' interface ---------------------------------------------
-
-    level = Int(1)
-
-    text = Str("Default")
+    # 'HeadingText' interface ---------------------------------------------
 
     image = Instance(ImageResource, ImageResource("heading_level_1"))
-
-    # ------------------------------------------------------------------------
-    # 'object' interface.
-    # ------------------------------------------------------------------------
-
-    def __init__(self, parent, **traits):
-        """ Creates the panel. """
-
-        # Base class constructor.
-        super().__init__(**traits)
-
-        # Create the toolkit-specific control that represents the widget.
-        self.control = self._create_control(parent)
-
-        return
 
     # ------------------------------------------------------------------------
     # Private interface.
@@ -106,8 +84,6 @@ class HeadingText(MHeadingText, Widget):
 
             x = x + w
 
-        return
-
     # Trait event handlers -------------------------------------------------
 
     def _text_changed(self, new):
@@ -115,8 +91,6 @@ class HeadingText(MHeadingText, Widget):
 
         if self.control is not None:
             self.control.Refresh()
-
-        return
 
     # wx event handlers ----------------------------------------------------
 
@@ -145,5 +119,3 @@ class HeadingText(MHeadingText, Widget):
         # Render the text.
         dc.SetFont(self._font)
         dc.DrawText(self.text, 5, 4)
-
-        return

--- a/pyface/ui/wx/heading_text.py
+++ b/pyface/ui/wx/heading_text.py
@@ -18,104 +18,36 @@ from traits.api import Instance, provides
 
 from pyface.i_heading_text import IHeadingText, MHeadingText
 from pyface.image_resource import ImageResource
-from pyface.wx.util.font_helper import new_font_like
 from .widget import Widget
 
 
 @provides(IHeadingText)
 class HeadingText(MHeadingText, Widget):
-    """ The toolkit specific implementation of a HeadingText.  See the
-    IHeadingText interface for the API documentation.
+    """ The Wx-specific implementation of a HeadingText.
     """
 
-    # 'HeadingText' interface ---------------------------------------------
-
+    #: Background image.  This is deprecated and no-longer used.
     image = Instance(ImageResource, ImageResource("heading_level_1"))
+
+    # ------------------------------------------------------------------------
+    # 'IWidget' interface.
+    # ------------------------------------------------------------------------
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+        control = wx.StaticText(parent)
+        return control
 
     # ------------------------------------------------------------------------
     # Private interface.
     # ------------------------------------------------------------------------
 
-    def _create_control(self, parent):
-        """ Create the toolkit-specific control that represents the widget. """
+    def _set_control_text(self, text):
+        """ Set the text on the toolkit specific widget. """
+        # Bold the text. Wx supports a limited subset of HTML for rich text.
+        text = f"<b>{text}</b>"
+        self.control.SetLabelMarkup(text)
 
-        # The background image (it is tiled).
-        image = self.image.create_image()
-        self._bmp = image.ConvertToBitmap()
-
-        sizer = wx.BoxSizer(wx.VERTICAL)
-        panel = wx.Panel(parent, -1, style=wx.CLIP_CHILDREN | wx.SIMPLE_BORDER)
-        panel.SetSizer(sizer)
-        panel.SetAutoLayout(True)
-
-        # Create a suitable font.
-        self._font = new_font_like(wx.NORMAL_FONT, family=wx.SWISS)
-
-        width, height = self._get_preferred_size(self.text, self._font)
-        panel.SetMinSize((width, height))
-
-        panel.Bind(wx.EVT_PAINT, self._on_paint_background)
-        panel.Bind(wx.EVT_ERASE_BACKGROUND, self._on_erase_background)
-
-        return panel
-
-    def _get_preferred_size(self, text, font):
-        """ Calculates the preferred size of the widget. """
-
-        dc = wx.ScreenDC()
-
-        dc.SetFont(font)
-        width, height = dc.GetTextExtent(text)
-
-        return (width + 10, height + 10)
-
-    def _tile_background_image(self, dc, width, height):
-        """ Tiles the background image. """
-
-        w = self._bmp.GetWidth()
-        h = self._bmp.GetHeight()
-
-        x = 0
-        while x < width:
-            y = 0
-            while y < height:
-                dc.DrawBitmap(self._bmp, x, y)
-                y = y + h
-
-            x = x + w
-
-    # Trait event handlers -------------------------------------------------
-
-    def _text_changed(self, new):
-        """ Called when the text is changed. """
-
-        if self.control is not None:
-            self.control.Refresh()
-
-    # wx event handlers ----------------------------------------------------
-
-    def _on_paint_background(self, event):
-        """ Called when the background of the panel is painted. """
-
-        dc = wx.PaintDC(self.control)
-        size = self.control.GetClientSize()
-
-        # Tile the background image.
-        self._tile_background_image(dc, size.width, size.height)
-
-        # Render the text.
-        dc.SetFont(self._font)
-        dc.DrawText(self.text, 5, 4)
-
-    def _on_erase_background(self, event):
-        """ Called when the background of the panel is erased. """
-
-        dc = event.GetDC()
-        size = self.control.GetClientSize()
-
-        # Tile the background image.
-        self._tile_background_image(dc, size.width, size.height)
-
-        # Render the text.
-        dc.SetFont(self._font)
-        dc.DrawText(self.text, 5, 4)
+    def _get_control_text(self):
+        """ Get the text on the toolkit specific widget. """
+        return self.control.GetLabelText()


### PR DESCRIPTION
Improvements and fixes for HeadingText:

- aligns Qt _create_control with standard API
- routes creation through create() call
- makes widget creation in init() optional
- deprecates automatic widget creation
- makes appearance of Qt and Wx similar (deprecates background image for wx)
- changes to text are dispatched on the ui thread
- general clean-up and standardization
- better testing
- various other small fixes