### PR TITLE
SplitWidget fixes

### DIFF
--- a/pyface/i_split_widget.py
+++ b/pyface/i_split_widget.py
@@ -11,7 +11,9 @@
 """ Mix-in class for split widgets. """
 
 
-from traits.api import Callable, Enum, Float, HasTraits, Interface
+from traits.api import Callable, Float, HasTraits, Interface
+
+from pyface.ui_traits import Orientation
 
 
 class ISplitWidget(Interface):
@@ -28,7 +30,7 @@ class ISplitWidget(Interface):
     #: Splitting vertically means there will be a left hand panel and a right
     #: hand panel, splitting horizontally means there will be a top panel and
     #: a bottom panel.
-    direction = Enum("vertical", "vertical", "horizontal")
+    direction = Orientation()
 
     #: The ratio of the size of the left/top pane to the right/bottom pane.
     ratio = Float(0.5)
@@ -90,3 +92,49 @@ class MSplitWidget(HasTraits):
     """ The mixin class that contains common code for toolkit specific
     implementations of the ISplitWidget interface.
     """
+
+    # 'ISplitWidget' interface ---------------------------------------------
+
+    #: The direction in which the widget is split.
+    #
+    #: Splitting vertically means there will be a left hand panel and a right
+    #: hand panel, splitting horizontally means there will be a top panel and
+    #: a bottom panel.
+    direction = Orientation()
+
+    #: The ratio of the size of the left/top pane to the right/bottom pane.
+    ratio = Float(0.5)
+
+    #: An optional callable that provides the left hand/top panel.
+    lhs = Callable
+
+    #: An optional callable that provides the right hand/bottom panel.
+    rhs = Callable
+
+    def _create_lhs(self, parent):
+        """ Creates the left hand/top panel depending on the direction.
+
+        Parameters
+        ----------
+        parent : toolkit control
+            The splitter's toolkit control.
+
+        Returns
+        -------
+        lhs : toolkit control
+            The toolkit control for the lhs.
+        """
+
+    def _create_rhs(self, parent):
+        """ Creates the right hand/bottom panel depending on the direction.
+
+        Parameters
+        ----------
+        parent : toolkit control
+            The splitter's toolkit control.
+
+        Returns
+        -------
+        rhs : toolkit control
+            The toolkit control for the rhs.
+        """

--- a/pyface/i_split_widget.py
+++ b/pyface/i_split_widget.py
@@ -124,6 +124,7 @@ class MSplitWidget(HasTraits):
         lhs : toolkit control
             The toolkit control for the lhs.
         """
+        raise NotImplementedError()
 
     def _create_rhs(self, parent):
         """ Creates the right hand/bottom panel depending on the direction.
@@ -138,3 +139,4 @@ class MSplitWidget(HasTraits):
         rhs : toolkit control
             The toolkit control for the rhs.
         """
+        raise NotImplementedError()

--- a/pyface/split_panel.py
+++ b/pyface/split_panel.py
@@ -10,6 +10,7 @@
 
 """ A panel that is split in two either horizontally or vertically. """
 
+import warnings
 
 from pyface.split_widget import SplitWidget
 from pyface.widget import Widget
@@ -22,11 +23,24 @@ class SplitPanel(Widget, SplitWidget):
     # 'object' interface.
     # ------------------------------------------------------------------------
 
-    def __init__(self, parent, **traits):
+    def __init__(self, parent=None, **traits):
         """ Creates a new panel. """
 
-        # Base class constructor.
-        super().__init__(**traits)
+        create = traits.pop("create", True)
 
-        # Create the widget's toolkit-specific control.
-        self.control = self._create_splitter(parent)
+        # Base class constructor.
+        super().__init__(parent=parent, **traits)
+
+        if create:
+            # Create the widget's toolkit-specific control.
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
+
+    def _create_control(self, parent):
+        """ Create the toolkit control """
+        return self._create_splitter(parent)

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -43,7 +43,26 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
     def test_lifecycle(self):
         # test that destroy works
         with self.event_loop():
-            self.widget = SplitPanel(self.window.control)
+            with self.assertWarns(PendingDeprecationWarning):
+                self.widget = SplitPanel(self.window.control)
+
+        self.assertIsNotNone(self.widget.control)
+
+        with self.event_loop():
+            self.widget.destroy()
+
+    def test_two_stage_create(self):
+        # test that create=False works
+        self.widget = SplitPanel(create=False)
+
+        self.assertIsNone(self.widget.control)
+
+        with self.event_loop():
+            self.widget.parent = self.window.control
+            self.widget.create()
+
+        self.assertIsNotNone(self.widget.control)
+
         with self.event_loop():
             self.widget.destroy()
 

--- a/pyface/ui/qt4/split_widget.py
+++ b/pyface/ui/qt4/split_widget.py
@@ -11,34 +11,20 @@
 # This software is provided without warranty under the terms of the BSD license.
 # However, when used with the GPL version of PyQt the additional terms described in the PyQt GPL exception also apply
 
-
 """ Mix-in class for split widgets. """
-
 
 from pyface.qt import QtCore, QtGui
 
-
-from traits.api import Callable, Enum, Float, HasTraits, provides
-
+from traits.api import provides
 
 from pyface.i_split_widget import ISplitWidget, MSplitWidget
 
 
 @provides(ISplitWidget)
-class SplitWidget(MSplitWidget, HasTraits):
+class SplitWidget(MSplitWidget):
     """ The toolkit specific implementation of a SplitWidget.  See the
     ISPlitWidget interface for the API documentation.
     """
-
-    # 'ISplitWidget' interface ---------------------------------------------
-
-    direction = Enum("vertical", "vertical", "horizontal")
-
-    ratio = Float(0.5)
-
-    lhs = Callable
-
-    rhs = Callable
 
     # ------------------------------------------------------------------------
     # Protected 'ISplitWidget' interface.

--- a/pyface/ui/wx/image_button.py
+++ b/pyface/ui/wx/image_button.py
@@ -20,6 +20,7 @@ from numpy import array, frombuffer, reshape, ravel, dtype
 
 from traits.api import Bool, Str, Range, Enum, Instance, Event
 
+from pyface.ui_traits import Orientation
 from .widget import Widget
 from .image_resource import ImageResource
 
@@ -69,7 +70,7 @@ class ImageButton(Widget):
     style = Enum("button", "radio", "toolbar", "checkbox")
 
     # Orientation of the text relative to the image:
-    orientation = Enum("vertical", "horizontal")
+    orientation = Orientation()
 
     # Is the control selected ('radio' or 'checkbox' style)?
     selected = Bool(False)

--- a/pyface/ui/wx/split_widget.py
+++ b/pyface/ui/wx/split_widget.py
@@ -12,31 +12,18 @@
 """ Mix-in class for split widgets.
 """
 
-
 import wx
 
-
-from traits.api import Callable, Enum, Float, HasTraits, provides
-
+from traits.api import provides
 
 from pyface.i_split_widget import ISplitWidget, MSplitWidget
 
 
 @provides(ISplitWidget)
-class SplitWidget(MSplitWidget, HasTraits):
+class SplitWidget(MSplitWidget):
     """ The toolkit specific implementation of a SplitWidget.  See the
     ISPlitWidget interface for the API documentation.
     """
-
-    # 'ISplitWidget' interface ---------------------------------------------
-
-    direction = Enum("vertical", "vertical", "horizontal")
-
-    ratio = Float(0.5)
-
-    lhs = Callable
-
-    rhs = Callable
 
     # ------------------------------------------------------------------------
     # Protected 'ISplitWidget' interface.

--- a/pyface/ui_traits.py
+++ b/pyface/ui_traits.py
@@ -334,3 +334,6 @@ Position = Enum("left", "right", "above", "below")
 
 #: The alignment of text within a control.
 Alignment = Enum("default", "left", "center", "right")
+
+#: Whether the orientation of a widget's contents is horizontal or vertical.
+Orientation = Enum("vertical", "horizontal")


### PR DESCRIPTION
Some improvements to the `SplitWidget` class and related classes (particularly `SplitPanel`)

- clean up of traits (including adding an "Orientation" trait)
- deprecate automatic creation of widgets in `SplitPanel.__init__` (part of #729)
- add an `Orientation` trait and use it where applicable