### PR TITLE
Fixes for `PythonEditor` and `PythonWidget`

### DIFF
--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -45,8 +45,26 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
     def test_lifecycle(self):
         # test that destroy works
         with self.event_loop():
-            self.widget = PythonEditor(self.window.control)
+            with self.assertWarns(PendingDeprecationWarning):
+                self.widget = PythonEditor(self.window.control)
 
+        self.assertIsNotNone(self.widget.control)
+        self.assertFalse(self.widget.dirty)
+
+        with self.event_loop():
+            self.widget.destroy()
+
+    def test_two_stage_create(self):
+        # test that create and destroy work
+        self.widget = PythonEditor(create=False)
+
+        self.assertIsNone(self.widget.control)
+
+        with self.event_loop():
+            self.widget.parent = self.window.control
+            self.widget.create()
+
+        self.assertIsNotNone(self.widget.control)
         self.assertFalse(self.widget.dirty)
 
         with self.event_loop():

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -46,7 +46,26 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
     def test_lifecycle(self):
         # test that destroy works
         with self.event_loop():
-            self.widget = PythonShell(self.window.control)
+            with self.assertWarns(PendingDeprecationWarning):
+                self.widget = PythonShell(self.window.control)
+
+        self.assertIsNotNone(self.widget.control)
+
+        with self.event_loop():
+            self.widget.destroy()
+
+    def test_two_stage_create(self):
+        # test that create=False works
+        self.widget = PythonShell(create=False)
+
+        self.assertIsNone(self.widget.control)
+
+        with self.event_loop():
+            self.widget.parent = self.window.control
+            self.widget.create()
+
+        self.assertIsNotNone(self.widget.control)
+
         with self.event_loop():
             self.widget.destroy()
 

--- a/pyface/ui/qt4/python_editor.py
+++ b/pyface/ui/qt4/python_editor.py
@@ -9,6 +9,7 @@
 #
 # Thanks for using Enthought open source!
 
+import warnings
 
 from pyface.qt import QtCore, QtGui
 
@@ -46,9 +47,20 @@ class PythonEditor(MPythonEditor, Widget):
     # 'object' interface.
     # ------------------------------------------------------------------------
 
-    def __init__(self, parent, **traits):
+    def __init__(self, parent=None, **traits):
+
+        create = traits.pop("create", True)
+
         super().__init__(parent=parent, **traits)
-        self._create()
+
+        if create:
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
 
     # ------------------------------------------------------------------------
     # 'PythonEditor' interface.

--- a/pyface/ui/qt4/python_shell.py
+++ b/pyface/ui/qt4/python_shell.py
@@ -16,6 +16,7 @@ from code import compile_command, InteractiveInterpreter
 from io import StringIO
 import sys
 from time import time
+import warnings
 
 
 from pyface.qt import QtCore, QtGui
@@ -56,11 +57,21 @@ class PythonShell(MPythonShell, Widget):
 
     # FIXME v3: Either make this API consistent with other Widget sub-classes
     # or make it a sub-class of HasTraits.
-    def __init__(self, parent, **traits):
+    def __init__(self, parent=None, **traits):
+
+        create = traits.pop("create", True)
+
         super().__init__(parent=parent, **traits)
 
-        # Create the toolkit-specific control that represents the widget.
-        self._create()
+        if create:
+            # Create the toolkit-specific control that represents the widget.
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
 
     # --------------------------------------------------------------------------
     # 'IPythonShell' interface

--- a/pyface/ui/wx/ipython_widget.py
+++ b/pyface/ui/wx/ipython_widget.py
@@ -17,6 +17,7 @@ import builtins
 import codeop
 import re
 import sys
+import warnings
 
 
 import IPython
@@ -344,6 +345,12 @@ class IPythonWidget(Widget):
     # or make it a sub-class of HasTraits.
     def __init__(self, parent, **traits):
         """ Creates a new pager. """
+
+        warnings.warn(
+            "the Wx IPython widget us deprecated and will be removed in a "
+            "future Pyface version",
+            PendingDeprecationWarning,
+        )
 
         # Base class constructor.
         super().__init__(**traits)

--- a/pyface/ui/wx/python_editor.py
+++ b/pyface/ui/wx/python_editor.py
@@ -12,6 +12,7 @@
 """ Enthought pyface package component
 """
 
+import warnings
 
 import wx.stc
 
@@ -49,14 +50,23 @@ class PythonEditor(MPythonEditor, Widget):
     # 'object' interface.
     # ------------------------------------------------------------------------
 
-    def __init__(self, parent, **traits):
+    def __init__(self, parent=None, **traits):
         """ Creates a new pager. """
 
-        # Base class constructor.
-        super().__init__(**traits)
+        create = traits.pop("create", True)
 
-        # Create the toolkit-specific control that represents the widget.
-        self.control = self._create_control(parent)
+        # Base class constructor.
+        super().__init__(parent=parent, **traits)
+
+        if create:
+            # Create the widget's toolkit-specific control.
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
 
         return
 

--- a/pyface/ui/wx/python_shell.py
+++ b/pyface/ui/wx/python_shell.py
@@ -16,6 +16,7 @@ import builtins
 import os
 import sys
 import types
+import warnings
 
 
 from wx.py.shell import Shell as PyShellBase
@@ -52,17 +53,23 @@ class PythonShell(MPythonShell, Widget):
 
     # FIXME v3: Either make this API consistent with other Widget sub-classes
     # or make it a sub-class of HasTraits.
-    def __init__(self, parent, **traits):
+    def __init__(self, parent=None, **traits):
         """ Creates a new pager. """
 
+        create = traits.pop("create", True)
+
         # Base class constructor.
-        super().__init__(**traits)
+        super().__init__(parent=parent, **traits)
 
-        # Create the toolkit-specific control that represents the widget.
-        self.control = self._create_control(parent)
-
-        # Set up to be notified whenever a Python statement is executed:
-        self.control.handlers.append(self._on_command_executed)
+        if create:
+            # Create the toolkit-specific control that represents the widget.
+            self.control = self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
 
     # ------------------------------------------------------------------------
     # 'IPythonShell' interface.
@@ -171,6 +178,9 @@ class PythonShell(MPythonShell, Widget):
 
         # Enable the shell as a drag and drop target.
         shell.SetDropTarget(PythonDropTarget(self))
+
+        # Set up to be notified whenever a Python statement is executed:
+        shell.handlers.append(self._on_command_executed)
 
         return shell
 


### PR DESCRIPTION
This mainly kicks-off the deprecation of automatic creation of the widgets in the `__init__` method.

This also deprecates the very old wx IPython widget - see #979.