### PR TITLE
Implement ILayeredPanel.

### DIFF
--- a/pyface/api.py
+++ b/pyface/api.py
@@ -109,6 +109,7 @@ from .heading_text import HeadingText
 from .image_cache import ImageCache
 from .image_resource import ImageResource
 from .key_pressed_event import KeyPressedEvent
+from .layered_panel import LayeredPanel
 from .message_dialog import error, information, warning, MessageDialog
 from .progress_dialog import ProgressDialog
 
@@ -147,7 +148,6 @@ from .widget import Widget
 
 from .expandable_panel import ExpandablePanel
 from .image_widget import ImageWidget
-from .layered_panel import LayeredPanel
 from .mdi_application_window import MDIApplicationWindow
 from .mdi_window_menu import MDIWindowMenu
 from .multi_toolbar_window import MultiToolbarWindow

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -70,9 +70,10 @@ Miscellaneous
 - :class:`~.Filter`
 - :class:`~.HeadingText`
 - :class:`~.ImageCache`
-- :class:`~.Sorter`
+- :class:`~.LayeredPanel`
 - :class:`~.PythonEditor`
 - :class:`~.PythonShell`
+- :class:`~.Sorter`
 
 Note that the :class:`~.PythonEditor` and :class:`~.PythonShell` classes are
 only available if the ``pygments`` package is available in the Python
@@ -83,7 +84,6 @@ Wx-specific classes
 
 - :class:`~.ExpandablePanel`
 - :class:`~.ImageWidget`
-- :class:`~.LayeredPanel`
 - :class:`~.MDIApplicationWindow`
 - :class:`~.MDIWindowMenu`
 - :class:`~.MultiToolbarWindow`

--- a/pyface/i_layered_panel.py
+++ b/pyface/i_layered_panel.py
@@ -14,6 +14,8 @@ A layered panel contains one or more named layers, with only one layer
 visible at any one time (think of a 'tab' control minus the tabs!).
 """
 
+import warnings
+
 from traits.api import Any, Dict, HasTraits, Interface, Str
 
 
@@ -97,3 +99,9 @@ class MLayeredPanel(HasTraits):
         if create:
             # Create the toolkit-specific control that represents the widget.
             self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )

--- a/pyface/i_layered_panel.py
+++ b/pyface/i_layered_panel.py
@@ -1,0 +1,99 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Interace and mixins for layered panels.
+
+A layered panel contains one or more named layers, with only one layer
+visible at any one time (think of a 'tab' control minus the tabs!).
+"""
+
+from traits.api import Any, Dict, HasTraits, Interface, Str
+
+
+class ILayeredPanel(Interface):
+    """ A Layered panel.
+
+    A layered panel contains one or more named layers, with only one layer
+    visible at any one time (think of a 'tab' control minus the tabs!).  Each
+    layer is a toolkit-specific control.
+
+    """
+
+    # "ILayeredPanel' interface --------------------------------------------
+
+    # The toolkit-specific control of the currently displayed layer.
+    current_layer = Any()
+
+    # The name of the currently displayed layer.
+    current_layer_name = Str()
+
+    # ------------------------------------------------------------------------
+    # 'ILayeredPanel' interface.
+    # ------------------------------------------------------------------------
+
+    def add_layer(self, name, layer):
+        """ Adds a layer with the specified name.
+
+        All layers are hidden when they are added.  Use 'show_layer' to make a
+        layer visible.
+
+        """
+
+    def show_layer(self, name):
+        """ Shows the layer with the specified name. """
+
+    def has_layer(self, name):
+        """ Does the panel contain a layer with the specified name? """
+
+
+class MLayeredPanel(HasTraits):
+    """ A Layered panel mixin.
+
+    A layered panel contains one or more named layers, with only one layer
+    visible at any one time (think of a 'tab' control minus the tabs!).  Each
+    layer is a toolkit-specific control.
+    """
+
+    # "ILayeredPanel' interface --------------------------------------------
+
+    # The toolkit-specific control of the currently displayed layer.
+    current_layer = Any()
+
+    # The name of the currently displayed layer.
+    current_layer_name = Str()
+
+    # Private traits -------------------------------------------------------
+
+    # The a map of layer names to toolkit controls in the panel.
+    _layers = Dict(Str)
+
+    # ------------------------------------------------------------------------
+    # 'ILayeredPanel' interface.
+    # ------------------------------------------------------------------------
+
+    def has_layer(self, name):
+        """ Does the panel contain a layer with the specified name? """
+        return name in self._layers
+
+    # ------------------------------------------------------------------------
+    # 'object' interface.
+    # ------------------------------------------------------------------------
+
+    def __init__(self, parent=None, **traits):
+        """ Creates a new LayeredPanel. """
+
+        create = traits.pop("create", True)
+
+        # Base class constructor.
+        super().__init__(parent=parent, **traits)
+
+        if create:
+            # Create the toolkit-specific control that represents the widget.
+            self.create()

--- a/pyface/tests/test_layered_panel.py
+++ b/pyface/tests/test_layered_panel.py
@@ -1,0 +1,143 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+import unittest
+
+from ..heading_text import HeadingText
+from ..layered_panel import LayeredPanel
+from ..toolkit import toolkit_object
+from ..window import Window
+
+GuiTestAssistant = toolkit_object("util.gui_test_assistant:GuiTestAssistant")
+no_gui_test_assistant = GuiTestAssistant.__name__ == "Unimplemented"
+
+
+@unittest.skipIf(no_gui_test_assistant, "No GuiTestAssistant")
+class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
+    def setUp(self):
+        GuiTestAssistant.setUp(self)
+        self.window = Window()
+        self.window._create()
+
+    def tearDown(self):
+        if self.widget.control is not None:
+            with self.delete_widget(self.widget.control):
+                self.widget.destroy()
+
+        if self.window.control is not None:
+            with self.delete_widget(self.window.control):
+                self.window.destroy()
+
+        del self.widget
+        del self.window
+        GuiTestAssistant.tearDown(self)
+
+    def test_lifecycle(self):
+        # test that create and destory work
+        self.widget = LayeredPanel(create=False)
+
+        self.assertIsNone(self.widget.control)
+
+        with self.event_loop():
+            self.widget.parent = self.window.control
+            self.widget.create()
+
+        self.assertIsNotNone(self.widget.control)
+
+        with self.event_loop():
+            self.widget.destroy()
+
+        self.assertIsNone(self.widget.control)
+
+    def test_add_layer(self):
+        # test that a layer can be added
+        self.widget = LayeredPanel(create=False)
+        with self.event_loop():
+            self.widget.parent = self.window.control
+            self.widget.create()
+
+        layer_widget = HeadingText(parent=self.window.control, create=False)
+        with self.event_loop():
+            layer_widget.create()
+
+        try:
+            with self.event_loop():
+                self.widget.add_layer("test 1", layer_widget.control)
+
+            self.assertIn("test 1", self.widget._layers)
+            self.assertIs(self.widget._layers["test 1"], layer_widget.control)
+        finally:
+            with self.event_loop():
+                layer_widget.destroy()
+
+        with self.event_loop():
+            self.widget.destroy()
+
+    def test_show_layer(self):
+        # test that a layer can be shown
+        self.widget = LayeredPanel(create=False)
+        with self.event_loop():
+            self.widget.parent = self.window.control
+            self.widget.create()
+
+        layer_widget_1 = HeadingText(parent=self.window.control, create=False)
+        layer_widget_2 = HeadingText(parent=self.window.control, create=False)
+        with self.event_loop():
+            layer_widget_1.create()
+            layer_widget_2.create()
+            self.widget.add_layer("test 1", layer_widget_1.control)
+            self.widget.add_layer("test 2", layer_widget_2.control)
+
+        try:
+            with self.event_loop():
+                self.widget.show_layer("test 1")
+
+            self.assertEqual(self.widget.current_layer_name, "test 1")
+            self.assertIs(self.widget.current_layer, layer_widget_1.control)
+
+            with self.event_loop():
+                self.widget.show_layer("test 2")
+
+            self.assertEqual(self.widget.current_layer_name, "test 2")
+            self.assertIs(self.widget.current_layer, layer_widget_2.control)
+        finally:
+            with self.event_loop():
+                layer_widget_1.destroy()
+                layer_widget_2.destroy()
+
+        with self.event_loop():
+            self.widget.destroy()
+
+    def test_has_layer(self):
+        # test that a has_layer works
+        self.widget = LayeredPanel(create=False)
+        with self.event_loop():
+            self.widget.parent = self.window.control
+            self.widget.create()
+
+        layer_widget_1 = HeadingText(parent=self.window.control, create=False)
+        layer_widget_2 = HeadingText(parent=self.window.control, create=False)
+        with self.event_loop():
+            layer_widget_1.create()
+            layer_widget_2.create()
+            self.widget.add_layer("test 1", layer_widget_1.control)
+            self.widget.add_layer("test 2", layer_widget_2.control)
+
+        try:
+            self.assertTrue(self.widget.has_layer("test 1"))
+            self.assertTrue(self.widget.has_layer("test 2"))
+        finally:
+            with self.event_loop():
+                layer_widget_1.destroy()
+                layer_widget_2.destroy()
+
+        with self.event_loop():
+            self.widget.destroy()

--- a/pyface/ui/qt4/layered_panel.py
+++ b/pyface/ui/qt4/layered_panel.py
@@ -1,0 +1,65 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" A Layered panel. """
+
+from traits.api import Int, provides
+
+from pyface.qt.QtGui import QStackedWidget
+from pyface.i_layered_panel import ILayeredPanel, MLayeredPanel
+from .widget import Widget
+
+
+@provides(ILayeredPanel)
+class LayeredPanel(MLayeredPanel, Widget):
+    """ A Layered panel.
+
+    A layered panel contains one or more named layers, with only one layer
+    visible at any one time (think of a 'tab' control minus the tabs!).  Each
+    layer is a toolkit-specific control.
+
+    """
+
+    # The minimum sizes of the panel.  Ignored in Qt.
+    min_width = Int(0)
+    min_height = Int(0)
+
+    # ------------------------------------------------------------------------
+    # 'ILayeredPanel' interface.
+    # ------------------------------------------------------------------------
+
+    def add_layer(self, name, layer):
+        """ Adds a layer with the specified name.
+
+        All layers are hidden when they are added.  Use 'show_layer' to make a
+        layer visible.
+        """
+        self.control.addWidget(layer)
+        self._layers[name] = layer
+        return layer
+
+    def show_layer(self, name):
+        """ Shows the layer with the specified name. """
+        layer = self._layers[name]
+        layer_index = self.control.indexOf(layer)
+        self.control.setCurrentIndex(layer_index)
+        self.current_layer = layer
+        self.current_layer_name = name
+        return layer
+
+    # ------------------------------------------------------------------------
+    # "IWidget" interface.
+    # ------------------------------------------------------------------------
+
+    def _create_control(self, parent):
+        """ Create the toolkit-specific control that represents the widget. """
+
+        control = QStackedWidget(parent)
+        return control

--- a/pyface/ui/wx/layered_panel.py
+++ b/pyface/ui/wx/layered_panel.py
@@ -14,14 +14,14 @@
 import wx
 from wx.lib.scrolledpanel import ScrolledPanel
 
+from traits.api import Int, provides
 
-from traits.api import Any, Str, Int
-
-
+from pyface.i_layered_panel import ILayeredPanel, MLayeredPanel
 from .widget import Widget
 
 
-class LayeredPanel(Widget):
+@provides(ILayeredPanel)
+class LayeredPanel(MLayeredPanel, Widget):
     """ A Layered panel.
 
     A layered panel contains one or more named layers, with only one layer
@@ -33,38 +33,10 @@ class LayeredPanel(Widget):
     # The default style.
     STYLE = wx.CLIP_CHILDREN
 
-    # "Layered Panel' interface --------------------------------------------
-
-    # The toolkit-specific control of the currently displayed layer.
-    current_layer = Any()
-
-    # The name of the currently displayed layer.
-    current_layer_name = Str()
-
     # The minimum for the panel, which is the maximum of the minimum
     # sizes of the layers
     min_width = Int(0)
     min_height = Int(0)
-
-    # ------------------------------------------------------------------------
-    # 'object' interface.
-    # ------------------------------------------------------------------------
-
-    def __init__(self, parent, **traits):
-        """ Creates a new LayeredPanel. """
-
-        # Base class constructor.
-        super().__init__(**traits)
-
-        # Create the toolkit-specific control that represents the widget.
-        self.control = self._create_control(parent)
-
-        # The layers in the panel.
-        #
-        # { str name : wx.Window layer }
-        self._layers = {}
-
-        return
 
     # ------------------------------------------------------------------------
     # 'LayeredPanel' interface.
@@ -130,11 +102,6 @@ class LayeredPanel(Widget):
         layer = self._show_layer(name, self._layers[name])
 
         return layer
-
-    def has_layer(self, name):
-        """ Does the panel contain a layer with the specified name? """
-
-        return name in self._layers
 
     # ------------------------------------------------------------------------
     # Private interface.

--- a/pyface/ui/wx/preference/preference_dialog.py
+++ b/pyface/ui/wx/preference/preference_dialog.py
@@ -88,7 +88,8 @@ class PreferenceDialog(SplitDialog):
         panel.SetAutoLayout(True)
 
         # The 'pretty' title bar ;^)
-        self.__title = HeadingText(panel)
+        self.__title = HeadingText(parent=panel, create=False)
+        self.__title.create()
         sizer.Add(
             self.__title.control,
             0,
@@ -97,7 +98,13 @@ class PreferenceDialog(SplitDialog):
         )
 
         # The preference page of the node currently selected in the tree.
-        self._layered_panel = LayeredPanel(panel, min_width=-1, min_height=-1)
+        self._layered_panel = LayeredPanel(
+            parent=panel,
+            create=False,
+            min_width=-1,
+            min_height=-1,
+        )
+        self._layered_panel.create()
         sizer.Add(
             self._layered_panel.control,
             1,

--- a/pyface/ui/wx/wizard/wizard.py
+++ b/pyface/ui/wx/wizard/wizard.py
@@ -29,7 +29,7 @@ class Wizard(MWizard, Dialog):
 
     """
 
-    # 'IWizard' interface -------------------------------------------------#
+    # 'IWizard' interface --------------------------------------------------
 
     pages = Property(List(IWizardPage))
 
@@ -37,9 +37,13 @@ class Wizard(MWizard, Dialog):
 
     show_cancel = Bool(True)
 
-    # 'IWindow' interface -------------------------------------------------#
+    # 'IWindow' interface --------------------------------------------------
 
     title = Str("Wizard")
+
+    # private traits -------------------------------------------------------
+
+    _layered_panel = Instance(LayeredPanel)
 
     # ------------------------------------------------------------------------
     # Protected 'IDialog' interface.
@@ -48,7 +52,8 @@ class Wizard(MWizard, Dialog):
     def _create_dialog_area(self, parent):
         """ Creates the main content of the dialog. """
 
-        self._layered_panel = panel = LayeredPanel(parent)
+        self._layered_panel = panel = LayeredPanel(parent=parent, create=False)
+        panel.create()
         # fixme: Specific size?
         panel.control.SetSize((100, 200))
 
@@ -145,8 +150,6 @@ class Wizard(MWizard, Dialog):
             if self._next is not None:
                 self._next.SetDefault()
 
-        return
-
     # Trait handlers -------------------------------------------------------
 
     def _controller_default(self):
@@ -177,5 +180,3 @@ class Wizard(MWizard, Dialog):
         """ Called when the 'Back' button is pressed. """
 
         self.previous()
-
-        return


### PR DESCRIPTION
This takes the existing wx-only `LayeredPanel` and:

- adds an `ILayeredPanel` interface
- implements the Qt version of it
- adds tests for it
- deprecates autocreation in the `__init__` method
- updates the usage of `LayeredPanel` in `Wizard` and `PreferencesDialog`

It does not attempt to improve the `LayeredPanel` API (eg. by allowing removal of layers, etc.)