### PR TITLE
Fix generic observers for TraitGridModel

### DIFF
--- a/pyface/ui/wx/expandable_panel.py
+++ b/pyface/ui/wx/expandable_panel.py
@@ -13,7 +13,7 @@
 
 import wx
 
-from traits.api import Instance
+from traits.api import Dict, Instance, Str
 
 
 from .expandable_header import ExpandableHeader
@@ -30,26 +30,27 @@ class ExpandablePanel(Widget):
     collapsed_image = Instance(ImageResource, ImageResource("mycarat1"))
     expanded_image = Instance(ImageResource, ImageResource("mycarat2"))
 
+    #: A mapping from panel names to toolkit controls.
+    _layers = Dict(Str)
+
+    #: A mapping from panel names to header text.
+    _headers = Dict(Str)
+
     # ------------------------------------------------------------------------
     # 'object' interface.
     # ------------------------------------------------------------------------
 
-    def __init__(self, parent, **traits):
+    def __init__(self, parent=None, **traits):
         """ Creates a new LayeredPanel. """
 
+        create = traits.pop('create', True)
+
         # Base class constructor.
-        super().__init__(**traits)
+        super().__init__(parent=parent, **traits)
 
-        # Create the toolkit-specific control that represents the widget.
-        self.control = self._create_control(parent)
-
-        # The layers in the panel.
-        #
-        # { str name : wx.Window layer }
-        self._layers = {}
-        self._headers = {}
-
-        return
+        if create:
+            # Create the toolkit-specific control that represents the widget.
+            self.create()
 
     # ------------------------------------------------------------------------
     # 'Expandale' interface.

--- a/pyface/ui/wx/grid/trait_grid_model.py
+++ b/pyface/ui/wx/grid/trait_grid_model.py
@@ -31,6 +31,7 @@ from traits.api import (
     Type,
     Union,
 )
+from traits.observation.api import match
 
 
 from .grid_model import GridColumn, GridModel, GridSortEvent
@@ -686,7 +687,9 @@ class TraitGridModel(GridModel):
         if list is not None:
             for item in list:
                 item.observe(
-                    self._on_contained_trait_changed, remove=remove
+                    self._on_contained_trait_changed,
+                    match(lambda name, trait: True),
+                    remove=remove
                 )
 
     def __manage_column_listeners(self, collist, remove=False):
@@ -695,5 +698,7 @@ class TraitGridModel(GridModel):
             for col in collist:
                 if isinstance(col, TraitGridColumn):
                     col.observe(
-                        self._on_columns_changed, remove=remove
+                        self._on_columns_changed,
+                        match(lambda name, trait: True),
+                        remove=remove,
                     )


### PR DESCRIPTION
This is a quick-fix for a place where `on_trait_change` -> `observe` didn't take into account the lack of a matcher.  For `on_trait_change` this matches everything, for `observer` it is an error.

To validate the fix run the `examples/grid.py` with the Wx toolkit.  It will fail without this fix, but run correctly after it.