### PR TITLE
Deprecate `__init__` methods which create the widget

### DIFF
--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -10,8 +10,9 @@
 
 """ A grid control with a model/ui architecture. """
 
-
 import sys
+import warnings
+
 import wx
 import wx.lib.gridmovers as grid_movers
 from os.path import abspath, exists
@@ -165,15 +166,26 @@ class Grid(Widget):
         'parent' is the toolkit-specific control that is the grid's parent.
 
         """
+        create = traits.pop('create', True)
 
         # Base class constructors.
-        super().__init__(**traits)
+        super().__init__(parent=parent, **traits)
+        if create:
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
+
+    def _create_control(self, parent):
 
         # Flag set when columns are resizing:
         self._user_col_size = False
 
         # Create the toolkit-specific control.
-        self.control = self._grid = grid = wxGrid(parent, -1)
+        self._grid = grid = wxGrid(parent, -1)
         grid.grid = self
 
         self._moveTo = None
@@ -328,6 +340,7 @@ class Grid(Widget):
 
         self._edit = False
         grid.Bind(wx.EVT_IDLE, self._on_idle)
+        return grid
 
     def dispose(self):
         # Remove all wx handlers:

--- a/pyface/ui/wx/image_button.py
+++ b/pyface/ui/wx/image_button.py
@@ -14,11 +14,12 @@
     toolbar button.
 """
 
-
+import warnings
 import wx
+
 from numpy import array, frombuffer, reshape, ravel, dtype
 
-from traits.api import Bool, Str, Range, Enum, Instance, Event
+from traits.api import Any, Bool, Str, Range, Enum, Instance, Event
 
 from pyface.ui_traits import Orientation
 from .widget import Widget
@@ -78,6 +79,8 @@ class ImageButton(Widget):
     # Fired when a 'button' or 'toolbar' style control is clicked:
     clicked = Event()
 
+    _image = Any()
+
     # ---------------------------------------------------------------------------
     #  Initializes the object:
     # ---------------------------------------------------------------------------
@@ -85,11 +88,18 @@ class ImageButton(Widget):
     def __init__(self, parent, **traits):
         """ Creates a new image control.
         """
-        self._image = None
+        create = traits.pop("create", True)
 
-        super().__init__(**traits)
+        super().__init__(parent=parent, **traits)
 
-        self._create_control(parent)
+        if create:
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
 
     def _create_control(self, parent):
         self._recalc_size()

--- a/pyface/ui/wx/image_button.py
+++ b/pyface/ui/wx/image_button.py
@@ -89,18 +89,23 @@ class ImageButton(Widget):
 
         super().__init__(**traits)
 
+        self._create_control(parent)
+
+    def _create_control(self, parent):
         self._recalc_size()
 
-        self.control = wx.Window(parent, -1, size=wx.Size(self._dx, self._dy))
-        self.control._owner = self
+        control = wx.Window(parent, -1, size=wx.Size(self._dx, self._dy))
+        control._owner = self
         self._mouse_over = self._button_down = False
 
         # Set up mouse event handlers:
-        self.control.Bind(wx.EVT_ENTER_WINDOW, self._on_enter_window)
-        self.control.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave_window)
-        self.control.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
-        self.control.Bind(wx.EVT_LEFT_UP, self._on_left_up)
-        self.control.Bind(wx.EVT_PAINT, self._on_paint)
+        control.Bind(wx.EVT_ENTER_WINDOW, self._on_enter_window)
+        control.Bind(wx.EVT_LEAVE_WINDOW, self._on_leave_window)
+        control.Bind(wx.EVT_LEFT_DOWN, self._on_left_down)
+        control.Bind(wx.EVT_LEFT_UP, self._on_left_up)
+        control.Bind(wx.EVT_PAINT, self._on_paint)
+
+        return control
 
     def _recalc_size(self):
         # Calculate the size of the button:

--- a/pyface/ui/wx/image_widget.py
+++ b/pyface/ui/wx/image_widget.py
@@ -10,12 +10,11 @@
 
 """ A clickable/draggable widget containing an image. """
 
+import warnings
 
 import wx
 
-
 from traits.api import Any, Bool, Event
-
 
 from .widget import Widget
 
@@ -64,10 +63,24 @@ class ImageWidget(Widget):
 
     def __init__(self, parent, **traits):
         """ Creates a new widget. """
-
         # Base class constructors.
-        super().__init__(**traits)
 
+        create = traits.pop('create', True)
+
+        # Base-class constructors.
+        super().__init__(parent=parent, **traits)
+
+        # Create the widget!
+        if create:
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
+
+    def _create_control(self, parent):
         # Add some padding around the image.
         size = (self.bitmap.GetWidth() + 10, self.bitmap.GetHeight() + 10)
 
@@ -96,7 +109,7 @@ class ImageWidget(Widget):
             wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DHIGHLIGHT), 1, wx.SOLID
         )
 
-        return
+        return self.control
 
     # ------------------------------------------------------------------------
     # Private interface.

--- a/pyface/ui/wx/list_box.py
+++ b/pyface/ui/wx/list_box.py
@@ -9,12 +9,11 @@
 # Thanks for using Enthought open source!
 """ A simple list box widget with a model-view architecture. """
 
+import warnings
 
 import wx
 
-
 from traits.api import Event, Instance, Int
-
 
 from pyface.list_box_model import ListBoxModel
 from .widget import Widget
@@ -37,14 +36,28 @@ class ListBox(Widget):
     # Default style.
     STYLE = wx.LB_SINGLE | wx.LB_HSCROLL | wx.LB_NEEDED_SB
 
-    def __init__(self, parent, **traits):
+    def __init__(self, parent=None, **traits):
         """ Creates a new list box. """
 
+        create = traits.pop('create', True)
+
         # Base-class constructors.
-        super().__init__(**traits)
+        super().__init__(parent=parent, **traits)
 
         # Create the widget!
-        self._create_control(parent)
+        if create:
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
+
+    def _create(self):
+        super()._create()
+
+        self._populate()
 
         # Listen for changes to the model.
         self.model.observe(self._on_model_changed, "list_changed")
@@ -54,7 +67,6 @@ class ListBox(Widget):
             self._on_model_changed, "list_changed", remove=True
         )
         self.model.dispose()
-        return
 
     # ------------------------------------------------------------------------
     # 'ListBox' interface.
@@ -68,8 +80,6 @@ class ListBox(Widget):
 
         # Populate the list.
         self._populate()
-
-        return
 
     # ------------------------------------------------------------------------
     # wx event handlers.
@@ -91,8 +101,6 @@ class ListBox(Widget):
         # Trait event notification.
         self.item_activated = index
 
-        return
-
     # ------------------------------------------------------------------------
     # Trait handlers.
     # ------------------------------------------------------------------------
@@ -105,8 +113,6 @@ class ListBox(Widget):
         if index != -1:
             self.control.SetSelection(index)
 
-        return
-
     # Dynamic -------------------------------------------------------------#
 
     def _on_model_changed(self, event):
@@ -115,8 +121,6 @@ class ListBox(Widget):
         # For now we just clear out the entire list.
         self.refresh()
 
-        return
-
     # ------------------------------------------------------------------------
     # Private interface.
     # ------------------------------------------------------------------------
@@ -124,20 +128,20 @@ class ListBox(Widget):
     def _create_control(self, parent):
         """ Creates the widget. """
 
-        self.control = wx.ListBox(parent, -1, style=self.STYLE)
+        control = wx.ListBox(parent, -1, style=self.STYLE)
 
         # Wire it up!
-        self.control.Bind(
+        control.Bind(
             wx.EVT_LISTBOX, self._on_item_selected, id=self.control.GetId()
         )
-        self.control.Bind(
+        control.Bind(
             wx.EVT_LISTBOX_DCLICK,
             self._on_item_activated,
             id=self.control.GetId(),
         )
 
         # Populate the list.
-        self._populate()
+        return control
 
     def _populate(self):
         """ Populates the list box. """
@@ -145,5 +149,3 @@ class ListBox(Widget):
         for index in range(self.model.get_item_count()):
             label, item = self.model.get_item_at(index)
             self.control.Append(label, item)
-
-        return

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -10,11 +10,11 @@
 
 """ A viewer for tabular data. """
 
+import warnings
 
 import wx
 
-from traits.api import Color, Event, Instance
-
+from traits.api import Color, Event, Instance, Int, Tuple
 
 from pyface.ui.wx.image_list import ImageList
 from pyface.viewer.content_viewer import ContentViewer
@@ -53,6 +53,9 @@ class TableViewer(ContentViewer):
     # A drag operation was started on a node.
     row_begin_drag = Event()
 
+    # The size of the icons in the table.
+    _image_size = Tuple(Int, Int)
+
     def __init__(self, parent, image_size=(16, 16), **traits):
         """ Creates a new table viewer.
 
@@ -62,12 +65,23 @@ class TableViewer(ContentViewer):
         specifies the size of the images (if any) displayed in the table.
 
         """
+        create = traits.pop('create', True)
 
-        # Base-class constructor.
-        super().__init__(**traits)
+        # Base class constructors.
+        super().__init__(parent=parent, _image_size=image_size, **traits)
 
+        if create:
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
+
+    def _create_control(self, parent):
         # Create the toolkit-specific control.
-        self.control = table = _Table(parent, image_size, self)
+        self.control = table = _Table(parent, self._image_size, self)
 
         # Table events.
         table.Bind(wx.EVT_LIST_ITEM_SELECTED, self._on_item_selected)
@@ -93,7 +107,7 @@ class TableViewer(ContentViewer):
         # don't want to react if the input is set in the constructor.
         self.observe(self._on_input_changed, "input")
 
-        return
+        return table
 
     # ------------------------------------------------------------------------
     # 'TableViewer' interface.

--- a/pyface/ui/wx/viewer/tree_viewer.py
+++ b/pyface/ui/wx/viewer/tree_viewer.py
@@ -10,12 +10,11 @@
 
 """ A viewer based on a tree control. """
 
+import warnings
 
 import wx
 
-
-from traits.api import Bool, Enum, Event, Instance, List
-
+from traits.api import Bool, Enum, Event, Instance, Int, List, Tuple
 
 from pyface.ui.wx.image_list import ImageList
 from pyface.viewer.content_viewer import ContentViewer
@@ -74,6 +73,9 @@ class TreeViewer(ContentViewer):
     # A key was pressed while the tree is in focus.
     key_pressed = Event()
 
+    # The size of the icons in the tree.
+    _image_size = Tuple(Int, Int)
+
     # ------------------------------------------------------------------------
     # 'object' interface.
     # ------------------------------------------------------------------------
@@ -87,9 +89,21 @@ class TreeViewer(ContentViewer):
         specifies the size of the label images (if any) displayed in the tree.
 
         """
+        create = traits.pop('create', True)
 
-        # Base class constructor.
-        super().__init__(**traits)
+        # Base class constructors.
+        super().__init__(parent=parent, _image_size=image_size, **traits)
+
+        if create:
+            self.create()
+            warnings.warn(
+                "automatic widget creation is deprecated and will be removed "
+                "in a future Pyface version, use create=False and explicitly "
+                "call create() for future behaviour",
+                PendingDeprecationWarning,
+            )
+
+    def _create_control(self, parent):
 
         # Create the toolkit-specific control.
         self.control = tree = wx.TreeCtrl(parent, -1, style=self._get_style())
@@ -110,7 +124,7 @@ class TreeViewer(ContentViewer):
 
         # The image list is a wxPython-ism that caches all images used in the
         # control.
-        self._image_list = ImageList(image_size[0], image_size[1])
+        self._image_list = ImageList(*self._image_size)
         if self.show_images:
             tree.AssignImageList(self._image_list)
 
@@ -121,7 +135,7 @@ class TreeViewer(ContentViewer):
         if self.input is not None:
             self._add_element(None, self.input)
 
-        return
+        return tree
 
     # ------------------------------------------------------------------------
     # 'TreeViewer' interface.


### PR DESCRIPTION
As discussed in #729 this does the discussed deprecation transforms in the remaining Wx widgets that use that approach.

Most of these widgets have not tests, but they are exercised by the examples.