### PR TITLE
Use the select interface when using entry points

### DIFF
--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -33,7 +33,7 @@ class TestToolkit(unittest.TestCase):
 
     def test_core_plugins(self):
         # test that we can see appropriate core entrypoints
-        plugins = {ep.name for ep in entry_points()['pyface.toolkits']}
+        plugins = {ep.name for ep in entry_points().select(group='pyface.toolkits'}
         self.assertLessEqual({"qt4", "wx", "qt", "null"}, plugins)
 
     def test_toolkit_object(self):

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -33,7 +33,7 @@ class TestToolkit(unittest.TestCase):
 
     def test_core_plugins(self):
         # test that we can see appropriate core entrypoints
-        plugins = {ep.name for ep in entry_points().select(group='pyface.toolkits'}
+        plugins = {ep.name for ep in entry_points().select(group='pyface.toolkits')}
         self.assertLessEqual({"qt4", "wx", "qt", "null"}, plugins)
 
     def test_toolkit_object(self):


### PR DESCRIPTION
This was missed in #991 and is needed to fully resolve #952 . The change introduced in this PR removes the deprecation warning raised by `importlib_metadata` from the test run as well.

```
2021-07-16T05:11:29.3287021Z test_core_plugins (pyface.tests.test_toolkit.TestToolkit) ... /home/runner/work/pyface/pyface/.edm/envs/pyface-test-3.6-pyqt5/lib/python3.6/site-packages/pyface/tests/test_toolkit.py:36: DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.
2021-07-16T05:11:29.3290051Z   plugins = {ep.name for ep in entry_points()['pyface.toolkits']}
2021-07-16T05:11:29.3290882Z ok
```