### PR TITLE
Dont rely on the existence of "select" on entry points

### DIFF
--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 __requires__ = [
-    'importlib-metadata>=3.6.0; python_version<"3.10"',
+    'importlib-metadata>=3.6.0; python_version<"3.8"',
     'importlib-resources>=1.1.0; python_version<"3.9"',
     "traits>=6.2"
 ]

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -68,11 +68,14 @@ import os
 import sys
 
 try:
-    # Starting Python 3.8, importlib.metadata is available in the Python
-    # standard library.
-    import importlib.metadata as importlib_metadata
-except ImportError:
     import importlib_metadata
+except ImportError:
+    # Starting Python 3.8, importlib.metadata is available in the Python
+    # standard library and starting Python 3.10, the "select" interface is
+    # available on EntryPoints.
+    # Note that we require importlib_metadata as a dependency for all Python
+    # version < 3.10.
+    import importlib.metadata as importlib_metadata
 
 from traits.api import HasTraits, List, ReadOnly, Str, TraitError
 from traits.etsconfig.api import ETSConfig
@@ -187,7 +190,15 @@ def import_toolkit(toolkit_name, entry_point="pyface.toolkits"):
         If no toolkit is found, or if the toolkit cannot be loaded for some
         reason.
     """
-    entry_point_group = importlib_metadata.entry_points().select(group=entry_point)
+
+    # This compatibility layer can be removed when we drop support for
+    # Python < 3.10. Ref https://github.com/enthought/pyface/issues/999.
+    all_entry_points = importlib_metadata.entry_points()
+    if hasattr(all_entry_points, "select"):
+        entry_point_group = all_entry_points.select(group=entry_point)
+    else:
+        entry_point_group = all_entry_points[entry_point]
+
     plugins = [
         plugin for plugin in entry_point_group if plugin.name == toolkit_name
     ]
@@ -255,10 +266,20 @@ def find_toolkit(entry_point, toolkits=None, priorities=default_priorities):
     if ETSConfig.toolkit:
         return import_toolkit(ETSConfig.toolkit, entry_point)
 
-    entry_points = [
-        plugin for plugin in importlib_metadata.entry_points().select(group=entry_point)
-        if toolkits is None or plugin.name in toolkits
-    ]
+    # This compatibility layer can be removed when we drop support for
+    # Python < 3.10. Ref https://github.com/enthought/pyface/issues/999.
+    all_entry_points = importlib_metadata.entry_points()
+    if hasattr(all_entry_points, "select"):
+        entry_points = [
+            plugin for plugin in all_entry_points.select(group=entry_point)
+            if toolkits is None or plugin.name in toolkits
+        ]
+    else:
+        entry_points = [
+            plugin for plugin in all_entry_points[entry_point]
+            if toolkits is None or plugin.name in toolkits
+        ]
+
     for plugin in sorted(entry_points, key=priorities):
         try:
             with ETSConfig.provisional_toolkit(plugin.name):

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -68,14 +68,12 @@ import os
 import sys
 
 try:
-    import importlib_metadata
-except ImportError:
     # Starting Python 3.8, importlib.metadata is available in the Python
     # standard library and starting Python 3.10, the "select" interface is
     # available on EntryPoints.
-    # Note that we require importlib_metadata as a dependency for all Python
-    # version < 3.10.
     import importlib.metadata as importlib_metadata
+except ImportError:
+    import importlib_metadata
 
 from traits.api import HasTraits, List, ReadOnly, Str, TraitError
 from traits.etsconfig.api import ETSConfig

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -10,11 +10,14 @@
 import unittest
 
 try:
-    # Starting Python 3.8, importlib.metadata is available in the Python
-    # standard library.
-    from importlib.metadata import entry_points
-except ImportError:
     from importlib_metadata import entry_points
+except ImportError:
+    # Starting Python 3.8, importlib.metadata is available in the Python
+    # standard library and starting Python 3.10, the "select" interface is
+    # available on EntryPoints.
+    # Note that we require importlib_metadata as a dependency for all Python
+    # version <= 3.10.
+    from importlib.metadata import entry_points
 
 import pyface.toolkit
 
@@ -33,7 +36,19 @@ class TestToolkit(unittest.TestCase):
 
     def test_core_plugins(self):
         # test that we can see appropriate core entrypoints
-        plugins = {ep.name for ep in entry_points().select(group='pyface.toolkits')}
+
+        # This compatibility layer can be removed when we drop support for
+        # Python < 3.10. Ref https://github.com/enthought/pyface/issues/999.
+        all_entry_points = entry_points()
+        if hasattr(all_entry_points, "select"):
+            plugins = {
+                ep.name
+                for ep in entry_points().select(group='pyface.toolkits')
+            }
+        else:
+            plugins = {
+                ep.name for ep in entry_points()['pyface.toolkits']
+            }
         self.assertLessEqual({"qt4", "wx", "qt", "null"}, plugins)
 
     def test_toolkit_object(self):

--- a/pyface/tests/test_toolkit.py
+++ b/pyface/tests/test_toolkit.py
@@ -10,14 +10,12 @@
 import unittest
 
 try:
-    from importlib_metadata import entry_points
-except ImportError:
     # Starting Python 3.8, importlib.metadata is available in the Python
     # standard library and starting Python 3.10, the "select" interface is
     # available on EntryPoints.
-    # Note that we require importlib_metadata as a dependency for all Python
-    # version <= 3.10.
     from importlib.metadata import entry_points
+except ImportError:
+    from importlib_metadata import entry_points
 
 import pyface.toolkit
 


### PR DESCRIPTION
This PR adds a compatibility layer to the entry point code to handle the absence of the `select` method on entry points. Additionally, we now rely on the external `importlib_metadata` first and only if that is absent do we rely on `importlib.metadata` from the standard library.

fixes #998 

Note to reviewer : I tested this locally by creating a python 3.9 virtual environment, installing pyface and relevent test dependencies and running the testsuite. On this branch, I don't see the `select`-related test errors that we see on the `master` branch.