### PR TITLE
Remove unnecessary if name/main code blocks

### DIFF
--- a/pyface/tasks/tests/test_action_manager_builder.py
+++ b/pyface/tasks/tests/test_action_manager_builder.py
@@ -444,7 +444,3 @@ class ActionManagerBuilderTestCase(unittest.TestCase):
             id="MenuBar",
         )
         self.assertActionElementsEqual(actual, desired)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/tasks/tests/test_dock_pane_toggle_group.py
+++ b/pyface/tasks/tests/test_dock_pane_toggle_group.py
@@ -137,7 +137,3 @@ class DockPaneToggleGroupTestCase(unittest.TestCase):
         names = self.get_dock_pane_toggle_action_names()
         expected_names = ["Dock Pane 1"]
         self.assertEqual(list(sorted(expected_names)), list(sorted(names)))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/tasks/tests/test_editor_area_pane.py
+++ b/pyface/tasks/tests/test_editor_area_pane.py
@@ -61,7 +61,3 @@ class TestEditorAreaPane(unittest.TestCase, GuiTestAssistant):
             self.area_pane.create(None)
         with self.event_loop():
             self.area_pane.destroy()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/tasks/tests/test_task_layout.py
+++ b/pyface/tasks/tests/test_task_layout.py
@@ -54,7 +54,3 @@ class LayoutItemsTestCase(unittest.TestCase):
         items = self.items
         with self.assertRaises(ValueError):
             LayoutContainer(*items, items=items)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/tasks/tests/test_topological_sort.py
+++ b/pyface/tasks/tests/test_topological_sort.py
@@ -98,7 +98,3 @@ class TopologicalSortTestCase(unittest.TestCase):
         pairs = [(1, 2), (2, 3), (3, 1)]
         result, has_cycles = topological_sort(pairs)
         self.assertTrue(has_cycles)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/ui/qt4/code_editor/tests/test_code_widget.py
+++ b/pyface/ui/qt4/code_editor/tests/test_code_widget.py
@@ -108,7 +108,3 @@ class TestCodeWidget(unittest.TestCase):
             self.assertTrue(acw.replace.isVisible())
         acw.replace.hide()
         self.assertFalse(acw.replace.isVisible())
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
@@ -517,7 +517,3 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         with event_loop():
             window.close()
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/ui/qt4/tests/test_mimedata.py
+++ b/pyface/ui/qt4/tests/test_mimedata.py
@@ -161,7 +161,3 @@ class PyMimeDataTestCase(unittest.TestCase):
         # remove local instance to simulate cross-process
         md._local_instance = None
         self.assertEqual(md.instanceType(), None)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
+++ b/pyface/ui/qt4/util/tests/test_modal_dialog_tester.py
@@ -171,7 +171,3 @@ class TestModalDialogTester(GuiTestAssistant, unittest.TestCase):
                 tester.close()
 
         tester.open_and_run(when_opened=check_and_close)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/pyface/util/tests/test_id_helper.py
+++ b/pyface/util/tests/test_id_helper.py
@@ -48,7 +48,3 @@ class IDHelperTestCase(unittest.TestCase):
 
         self.assertEqual(get_unique_id(bogus_1), "Bogus_1")
         self.assertEqual(get_unique_id(bogus_2), "Bogus_2")
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This PR removes unnecessary `if __name__ == "__main__"` code blocks. Specifically, this commit removes the `unittest.main()` calls.