### PR TITLE
 Default branch has been renamed from "master" to "main"

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_template.md
+++ b/.github/ISSUE_TEMPLATE/release_template.md
@@ -12,8 +12,8 @@ Release by YYYY-MM-DD
 
 Release candidate
 -------------------
-- [ ] Verify that all relevant PRs have been merged to master.
-- [ ] Create a PR against master to bump version number, merge that PR
+- [ ] Verify that all relevant PRs have been merged to ``main``.
+- [ ] Create a PR against ``main`` to bump version number, merge that PR
 - [ ] From the commit just before bumping the version, create a new branch `maint/<release version number>`
 - [ ] Update changelog and open PR targeting a new `maint/<release version number>` branch
 - [ ] Update `ci-src-requirements.txt` if needed
@@ -36,7 +36,7 @@ Release blockers
 
 Pre-release
 ---
-- [ ] Backport PRs that have been merged to master to the maintenance branch. Use the "need backport ..." tag if there is one (but don't rely 100% on it)
+- [ ] Backport PRs that have been merged to ``main`` to the maintenance branch. Use the "need backport ..." tag if there is one (but don't rely 100% on it)
 - [ ] Verify that no other open issue needs to be addressed before the release.
 - [ ] Test against other ETS packages and other ETS-using projects
 - [ ] Check MANIFEST, requirements, changelog are still up to date.
@@ -60,6 +60,6 @@ Release
 Post-release
 -------------
 - [ ] Package update for `enthought/free` repository (for EDM)
-- [ ] Backport release note and change log to master, and possibly `maint/<release version number>` branch.
+- [ ] Backport release note and change log to ``main``, and possibly `maint/<release version number>` branch.
 - [ ] Update GitHub Release pages https://github.com/enthought/pyface/releases
 - [ ] Announcement (e.g. Google Group)

--- a/README.rst
+++ b/README.rst
@@ -2,9 +2,6 @@
 Pyface: Traits-capable Windowing Framework
 ==========================================
 
-.. image:: https://ci.appveyor.com/api/projects/status/68nfb049cdq9wqd1/branch/master?svg=true
-    :target: https://ci.appveyor.com/project/EnthoughtOSS/pyface/branch/master
-
 The Pyface project contains a toolkit-independent GUI abstraction layer,
 which is used to support the "visualization" features of the Traits package.
 Thus, you can write code in terms of the Traits API (views, items, editors,

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -165,7 +165,7 @@ except ImportError as exc:
 # Useful aliases to avoid repeating long URLs.
 extlinks = {
     'github-examples': (
-        'https://github.com/enthought/pyface/tree/master/examples/%s',
+        'https://github.com/enthought/pyface/tree/main/examples/%s',
         'github-examples'
     )
 }


### PR DESCRIPTION
This PR replaces the use of ``master`` in the repo with ``main`` as the default branch name has been updated.