### PR TITLE
Remove unused "extlinks" in sphinx configuration

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -162,14 +162,6 @@ except ImportError as exc:
     html_favicon = "et.png"
     html_style = 'default.css'
 
-# Useful aliases to avoid repeating long URLs.
-extlinks = {
-    'github-examples': (
-        'https://github.com/enthought/pyface/tree/main/examples/%s',
-        'github-examples'
-    )
-}
-
 # Options for LaTeX output
 # ------------------------
 


### PR DESCRIPTION
This PR removes the unused `extlinks` variable from the sphinx configuration.