### PR TITLE
Add an `_initialize_control()` method to `IWidget`

### DIFF
--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -237,6 +237,7 @@ class MDataViewWidget(HasStrictTraits):
         """ Initializes the toolkit specific control.
         """
         logger.debug('Initializing DataViewWidget')
+        super()._initialize_control()
         self._set_control_header_visible(self.header_visible)
         self._set_control_selection_mode(self.selection_mode)
         self._set_control_selection_type(self.selection_type)

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -228,9 +228,7 @@ class MDataViewWidget(HasStrictTraits):
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
         """
-        self.control = self._create_control(self.parent)
-        self._initialize_control()
-        self._add_event_listeners()
+        super()._create()
 
         self.show(self.visible)
         self.enable(self.enabled)

--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -94,9 +94,7 @@ class MField(HasTraits):
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
         """
-        self.control = self._create_control(self.parent)
-        self._initialize_control()
-        self._add_event_listeners()
+        super()._create()
 
         self.show(self.visible)
         self.enable(self.enabled)
@@ -171,7 +169,7 @@ class MField(HasTraits):
             self._set_control_tooltip(tooltip)
 
     def _context_menu_updated(self, event):
-        
+
         if self.control is not None:
             if event.new is None:
                 self._observe_control_context_menu(remove=True)

--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -101,6 +101,7 @@ class MField(HasTraits):
 
     def _initialize_control(self):
         """ Perform any toolkit-specific initialization for the control. """
+        super()._initialize_control()
         self._set_control_tooltip(self.tooltip)
 
     def _update_value(self, value):

--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -126,6 +126,7 @@ class MWidget(HasTraits):
         :py:attr:``control`` trait.
         """
         self.control = self._create_control(self.parent)
+        self._initialize_control()
         self._add_event_listeners()
 
     def _create_control(self, parent):
@@ -143,6 +144,11 @@ class MWidget(HasTraits):
             A control for the widget.
         """
         raise NotImplementedError()
+
+    def _initialize_control(self):
+        """ Perform any post-creation initialization for the control.
+        """
+        pass
 
     def _add_event_listeners(self):
         """ Set up toolkit-specific bindings for events """


### PR DESCRIPTION
Initially this does nothing, but it allows `super()` calls in `_create()` methods for widgets which want to do post-creation initialization that respects inheritance.

Updates `IField` and `IDataViewWidget` to take advantage of this.

This is a minor change that permits a number of other things to move forward more naturally.