### PR TITLE
Add `LayoutWidget` class and use it for newer widget classes

### DIFF
--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -228,9 +228,7 @@ class MDataViewWidget(HasStrictTraits):
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
         """
-        self.control = self._create_control(self.parent)
-        self._initialize_control()
-        self._add_event_listeners()
+        super()._create()
 
         self.show(self.visible)
         self.enable(self.enabled)
@@ -239,6 +237,7 @@ class MDataViewWidget(HasStrictTraits):
         """ Initializes the toolkit specific control.
         """
         logger.debug('Initializing DataViewWidget')
+        super()._initialize_control()
         self._set_control_header_visible(self.header_visible)
         self._set_control_selection_mode(self.selection_mode)
         self._set_control_selection_type(self.selection_type)

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -17,6 +17,7 @@ from traits.testing.api import UnittestTools
 
 from pyface.gui import GUI
 from pyface.toolkit import toolkit
+from pyface.testing.layout_widget_mixin import LayoutWidgetMixin
 from pyface.window import Window
 
 # This import results in an error without numpy installed
@@ -37,20 +38,7 @@ selection_types = DataViewWidget().trait("selection_type").trait_type.values
 
 
 @requires_numpy
-class TestWidget(unittest.TestCase, UnittestTools):
-
-    def setUp(self):
-        self.gui = GUI()
-
-        self.parent = Window()
-        self.parent._create()
-        self.addCleanup(self._destroy_parent)
-        self.gui.process_events()
-
-        self.widget = self._create_widget()
-
-        self.parent.open()
-        self.gui.process_events()
+class TestWidget(LayoutWidgetMixin, unittest.TestCase):
 
     def _create_widget(self):
         self.data = np.arange(120.0).reshape(4, 5, 6)
@@ -59,22 +47,6 @@ class TestWidget(unittest.TestCase, UnittestTools):
             parent=self.parent.control,
             data_model=self.model
         )
-
-    def _create_widget_control(self):
-        self.widget._create()
-        self.addCleanup(self._destroy_widget)
-        self.parent.show(True)
-        self.gui.process_events()
-
-    def _destroy_parent(self):
-        self.parent.destroy()
-        self.gui.process_events()
-        self.parent = None
-
-    def _destroy_widget(self):
-        self.widget.destroy()
-        self.gui.process_events()
-        self.widget = None
 
     def test_defaults(self):
         self.assertTrue(self.widget.header_visible)

--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -13,10 +13,10 @@
 
 from traits.api import Any, HasTraits, Instance, Str
 
-from pyface.i_widget import IWidget
+from pyface.i_layout_widget import ILayoutWidget
 
 
-class IField(IWidget):
+class IField(ILayoutWidget):
     """ The field interface.
 
     A field is a widget that displays a value and (potentially) allows a user
@@ -94,15 +94,14 @@ class MField(HasTraits):
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
         """
-        self.control = self._create_control(self.parent)
-        self._initialize_control()
-        self._add_event_listeners()
+        super()._create()
 
         self.show(self.visible)
         self.enable(self.enabled)
 
     def _initialize_control(self):
         """ Perform any toolkit-specific initialization for the control. """
+        super()._initialize_control()
         self._set_control_tooltip(self.tooltip)
 
     def _update_value(self, value):
@@ -171,7 +170,7 @@ class MField(HasTraits):
             self._set_control_tooltip(tooltip)
 
     def _context_menu_updated(self, event):
-        
+
         if self.control is not None:
             if event.new is None:
                 self._observe_control_context_menu(remove=True)

--- a/pyface/fields/tests/field_mixin.py
+++ b/pyface/fields/tests/field_mixin.py
@@ -9,49 +9,15 @@
 # Thanks for using Enthought open source!
 
 
-from traits.testing.api import UnittestTools
+from pyface.testing.layout_widget_mixin import LayoutWidgetMixin
 
 from pyface.action.api import Action, MenuManager
 from pyface.gui import GUI
 from pyface.window import Window
 
 
-class FieldMixin(UnittestTools):
+class FieldMixin(LayoutWidgetMixin):
     """ Mixin which provides standard methods for all fields. """
-
-    def setUp(self):
-        self.gui = GUI()
-
-        self.parent = Window()
-        self.parent._create()
-        self.addCleanup(self._destroy_parent)
-        self.gui.process_events()
-
-        self.widget = self._create_widget()
-
-        self.parent.open()
-        self.gui.process_events()
-
-    def _create_widget(self):
-        raise NotImplementedError()
-
-    def _create_widget_control(self):
-        self.widget._create()
-        self.addCleanup(self._destroy_widget)
-        self.widget.show(True)
-        self.gui.process_events()
-
-    def _destroy_parent(self):
-        self.parent.destroy()
-        self.gui.process_events()
-        self.parent = None
-
-    def _destroy_widget(self):
-        self.widget.destroy()
-        self.gui.process_events()
-        self.widget = None
-
-    # Tests ------------------------------------------------------------------
 
     def test_field_tooltip(self):
         self._create_widget_control()

--- a/pyface/i_layout_item.py
+++ b/pyface/i_layout_item.py
@@ -1,0 +1,36 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traits.api import Enum, Int, Interface, Tuple
+
+#: Value that indicates the default size values should be used.
+DEFAULT_SIZE = -1
+
+#: Trait for sizes of widgets.
+Size = Tuple(Int(DEFAULT_SIZE), Int(DEFAULT_SIZE))
+
+#: Trait for size policy values.
+SizePolicy = Enum("default", "fixed", "preferred", "expand")
+
+
+class ILayoutItem(Interface):
+    """ An item that can participate in layout. """
+
+    #: The minimum size that the item can take.
+    minimum_size = Size
+
+    #: The maximum size that the item can take.
+    maximum_size = Size
+
+    #: Weight factor used to distribute extra space between widgets.
+    stretch = Tuple(Int, Int)
+
+    #: How the item should behave when more space is available.
+    size_policy = Tuple(SizePolicy, SizePolicy)

--- a/pyface/i_layout_widget.py
+++ b/pyface/i_layout_widget.py
@@ -158,7 +158,7 @@ class MLayoutWidget(HasTraits):
         """
         raise NotImplementedError()
 
-    def _set_control_stretch(self, size_policy):
+    def _set_control_stretch(self, stretch):
         """ Set the stretch factor of the control.
 
         Toolkit implementations will need to override this method.

--- a/pyface/i_layout_widget.py
+++ b/pyface/i_layout_widget.py
@@ -1,0 +1,189 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traits.api import HasTraits, Int, Tuple, observe
+
+from pyface.i_layout_item import ILayoutItem, Size, SizePolicy
+from pyface.i_widget import IWidget
+
+
+class ILayoutWidget(IWidget, ILayoutItem):
+    """ Interface for widgets that can participate in layout.
+
+    Most widgets implement ILayoutWidget, but widgets like top-level windows,
+    menus, toolbars, etc. do not.
+    """
+    pass
+
+
+class MLayoutWidget(HasTraits):
+    """ A mixin for Widgets that can participate in layouts.
+
+    Most widgets implement ILayoutWidget, but widgets like top-level windows,
+    menus, toolbars, etc. do not.
+    """
+
+    #: The minimum size that the widget can take.
+    minimum_size = Size
+
+    #: The maximum size that the widget can take.
+    maximum_size = Size
+
+    #: Weight factor used to distribute extra space between widgets.
+    stretch = Tuple(Int, Int)
+
+    #: How the widget should behave when more space is available.
+    size_policy = Tuple(SizePolicy, SizePolicy)
+
+    def _create(self):
+        """ Create and initialize the toolkit control. """
+        # XXX remove once #1013 is merged.
+        self.control = self._create_control(self.parent)
+        self._initialize_control()
+        self._add_event_listeners()
+
+    def _initialize_control(self):
+        """ Initialize the toolkit control. """
+        self._set_control_minimum_size(self.minimum_size)
+        self._set_control_maximum_size(self.maximum_size)
+        self._set_control_stretch(self.stretch)
+        self._set_control_size_policy(self.size_policy)
+
+    def _add_event_listeners(self):
+        """ Add trait observers and toolkit binding. """
+        super()._add_event_listeners()
+        self.observe(
+            self._minimum_size_updated,
+            "minimum_size",
+            dispatch="ui",
+        )
+        self.observe(
+            self._maximum_size_updated,
+            "maximum_size",
+            dispatch="ui",
+        )
+        self.observe(
+            self._stretch_updated,
+            "stretch",
+            dispatch="ui",
+        )
+        self.observe(
+            self._size_policy_updated,
+            "size_policy",
+            dispatch="ui",
+        )
+
+    def _remove_event_listeners(self):
+        """ Remove trait observers and toolkit binding. """
+        self.observe(
+            self._minimum_size_updated,
+            "minimum_size",
+            dispatch="ui",
+            remove=True,
+        )
+        self.observe(
+            self._maximum_size_updated,
+            "maximum_size",
+            dispatch="ui",
+            remove=True,
+        )
+        self.observe(
+            self._stretch_updated,
+            "stretch",
+            dispatch="ui",
+            remove=True,
+        )
+        self.observe(
+            self._size_policy_updated,
+            "size_policy",
+            dispatch="ui",
+            remove=True,
+        )
+        super()._remove_event_listeners()
+
+    def _minimum_size_updated(self, event):
+        """ Trait observer for minimum size. """
+        if self.control is not None:
+            self._set_control_minimum_size(event.new)
+
+    def _maximum_size_updated(self, event):
+        """ Trait observer for maximum size. """
+        if self.control is not None:
+            self._set_control_maximum_size(event.new)
+
+    def _stretch_updated(self, event):
+        """ Trait observer for stretch. """
+        if self.control is not None:
+            self._set_control_stretch(event.new)
+
+    def _size_policy_updated(self, event):
+        """ Trait observer for size policy. """
+        if self.control is not None:
+            self._set_control_size_policy(event.new)
+
+    def _set_control_minimum_size(self, size):
+        """ Set the minimum size of the control.
+
+        Toolkit implementations will need to override this method.
+        """
+        raise NotImplementedError()
+
+    def _get_control_minimum_size(self):
+        """ Get the minimum size of the control.
+
+        Toolkit implementations will need to override this method.
+        This method is only used for testing.
+        """
+        raise NotImplementedError()
+
+    def _set_control_maximum_size(self, size):
+        """ Set the maximum size of the control.
+
+        Toolkit implementations will need to override this method.
+        """
+        raise NotImplementedError()
+
+    def _get_control_maximum_size(self):
+        """ Get the maximum size of the control.
+
+        Toolkit implementations will need to override this method.
+        This method is only used for testing.
+        """
+        raise NotImplementedError()
+
+    def _set_control_stretch(self, size_policy):
+        """ Set the stretch factor of the control.
+
+        Toolkit implementations will need to override this method.
+        """
+        raise NotImplementedError()
+
+    def _get_control_stretch(self):
+        """ Get the stretch factor of the control.
+
+        Toolkit implementations will need to override this method.
+        This method is only used for testing.
+        """
+        raise NotImplementedError()
+
+    def _set_control_size_policy(self, size_policy):
+        """ Set the size policy of the control.
+
+        Toolkit implementations will need to override this method.
+        """
+        raise NotImplementedError()
+
+    def _get_control_size_policy(self):
+        """ Get the size policy of the control.
+
+        Toolkit implementations will need to override this method.
+        This method is only used for testing.
+        """
+        raise NotImplementedError()

--- a/pyface/i_layout_widget.py
+++ b/pyface/i_layout_widget.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import HasTraits, Int, Tuple, observe
+from traits.api import HasTraits, Int, Tuple
 
 from pyface.i_layout_item import ILayoutItem, Size, SizePolicy
 from pyface.i_widget import IWidget
@@ -42,15 +42,9 @@ class MLayoutWidget(HasTraits):
     #: How the widget should behave when more space is available.
     size_policy = Tuple(SizePolicy, SizePolicy)
 
-    def _create(self):
-        """ Create and initialize the toolkit control. """
-        # XXX remove once #1013 is merged.
-        self.control = self._create_control(self.parent)
-        self._initialize_control()
-        self._add_event_listeners()
-
     def _initialize_control(self):
         """ Initialize the toolkit control. """
+        super().initialize_control()
         self._set_control_minimum_size(self.minimum_size)
         self._set_control_maximum_size(self.maximum_size)
         self._set_control_stretch(self.stretch)

--- a/pyface/i_layout_widget.py
+++ b/pyface/i_layout_widget.py
@@ -44,7 +44,7 @@ class MLayoutWidget(HasTraits):
 
     def _initialize_control(self):
         """ Initialize the toolkit control. """
-        super().initialize_control()
+        super()._initialize_control()
         self._set_control_minimum_size(self.minimum_size)
         self._set_control_maximum_size(self.maximum_size)
         self._set_control_stretch(self.stretch)

--- a/pyface/layout_widget.py
+++ b/pyface/layout_widget.py
@@ -1,0 +1,15 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Multi-pane splitter widget. """
+
+from .toolkit import toolkit_object
+
+layout_widget = toolkit_object("layout_widget:LayoutWidget")

--- a/pyface/testing/layout_widget_mixin.py
+++ b/pyface/testing/layout_widget_mixin.py
@@ -1,0 +1,78 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from pyface.testing.widget_mixin import WidgetMixin
+
+
+class LayoutWidgetMixin(WidgetMixin):
+    """ Test mixin for classes which inherit LayoutWidget. """
+
+    def test_minimum_size(self):
+        # create a widget with a minimum size
+        self.widget.minimum_size = (100, 100)
+        self.widget.create()
+        minimum_size = self.widget._get_control_minimum_size()
+        self.gui.process_events()
+        self.assertEqual(minimum_size, (100, 100))
+
+        # change the minimum size
+        self.widget.minimum_size = (50, 50)
+        self.gui.process_events()
+        minimum_size = self.widget._get_control_minimum_size()
+
+        self.assertEqual(minimum_size, (50, 50))
+
+    def test_maximum_size(self):
+        # create a widget with a maximum size
+        self.widget.maximum_size = (1000, 1000)
+        self.widget.create()
+        maximum_size = self.widget._get_control_maximum_size()
+        self.gui.process_events()
+        self.assertEqual(maximum_size, (1000, 1000))
+
+        # change the maximum size
+        self.widget.maximum_size = (50, 50)
+        self.gui.process_events()
+        maximum_size = self.widget._get_control_maximum_size()
+
+        self.assertEqual(maximum_size, (50, 50))
+
+    def test_stretch(self):
+        # create a widget with a maximum size
+        self.widget.stretch = (2, 3)
+        self.widget.create()
+        stretch = self.widget._get_control_stretch()
+        self.gui.process_events()
+        self.assertEqual(stretch, (2, 3))
+
+        # change the maximum size
+        self.widget.stretch = (5, 0)
+        self.gui.process_events()
+        maximum_size = self.widget._get_control_stretch()
+
+        self.assertEqual(maximum_size, (5, 0))
+
+    def test_size_policy(self):
+        # create a widget with a maximum size
+        self.widget.create()
+        self.assertEqual(
+            self.widget._get_control_size_policy(),
+            ("default", "default"),
+        )
+
+        for horizontal in ["fixed", "preferred", "expand"]:
+            for vertical in ["fixed", "preferred", "expand"]:
+                with self.subTest(horizontal=horizontal, vertical=vertical):
+                    self.widget.size_policy = (horizontal, vertical)
+                    self.gui.process_events()
+                    self.assertEqual(
+                        self.widget._get_control_size_policy(),
+                        (horizontal, vertical),
+                    )

--- a/pyface/testing/widget_mixin.py
+++ b/pyface/testing/widget_mixin.py
@@ -11,7 +11,6 @@
 
 from traits.testing.api import UnittestTools
 
-from pyface.action.api import Action, MenuManager
 from pyface.gui import GUI
 from pyface.window import Window
 

--- a/pyface/testing/widget_mixin.py
+++ b/pyface/testing/widget_mixin.py
@@ -1,0 +1,55 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+from traits.testing.api import UnittestTools
+
+from pyface.action.api import Action, MenuManager
+from pyface.gui import GUI
+from pyface.window import Window
+
+
+class WidgetMixin(UnittestTools):
+    """ Mixin which provides standard methods for all widgets. """
+
+    def setUp(self):
+        self.gui = GUI()
+
+        self.parent = self._create_parent()
+        self.parent._create()
+        self.addCleanup(self._destroy_parent)
+        self.gui.process_events()
+
+        self.widget = self._create_widget()
+
+        self.parent.open()
+        self.gui.process_events()
+
+    def _create_parent(self):
+        return Window()
+
+    def _create_widget(self):
+        raise NotImplementedError()
+
+    def _create_widget_control(self):
+        self.widget._create()
+        self.addCleanup(self._destroy_widget)
+        self.widget.show(True)
+        self.gui.process_events()
+
+    def _destroy_parent(self):
+        self.parent.destroy()
+        self.gui.process_events()
+        self.parent = None
+
+    def _destroy_widget(self):
+        self.widget.destroy()
+        self.gui.process_events()
+        self.widget = None

--- a/pyface/ui/qt4/data_view/data_view_widget.py
+++ b/pyface/ui/qt4/data_view/data_view_widget.py
@@ -19,7 +19,7 @@ from pyface.qt.QtGui import (
 from pyface.data_view.i_data_view_widget import (
     IDataViewWidget, MDataViewWidget
 )
-from pyface.ui.qt4.widget import Widget
+from pyface.ui.qt4.layout_widget import LayoutWidget
 from .data_view_item_model import DataViewItemModel
 
 # XXX This file is scaffolding and may need to be rewritten
@@ -88,7 +88,7 @@ class DataViewTreeView(QTreeView):
 
 
 @provides(IDataViewWidget)
-class DataViewWidget(MDataViewWidget, Widget):
+class DataViewWidget(MDataViewWidget, LayoutWidget):
     """ The Qt implementation of the DataViewWidget. """
 
     #: Factory for the underlying Qt control, to facilitate replacement

--- a/pyface/ui/qt4/fields/field.py
+++ b/pyface/ui/qt4/fields/field.py
@@ -15,11 +15,11 @@ from traits.api import Any, Instance, Str, provides
 
 from pyface.qt.QtCore import Qt
 from pyface.fields.i_field import IField, MField
-from pyface.ui.qt4.widget import Widget
+from pyface.ui.qt4.layout_widget import LayoutWidget
 
 
 @provides(IField)
-class Field(MField, Widget):
+class Field(MField, LayoutWidget):
     """ The Qt-specific implementation of the field class
 
     This is an abstract class which is not meant to be instantiated.

--- a/pyface/ui/qt4/layout_widget.py
+++ b/pyface/ui/qt4/layout_widget.py
@@ -8,7 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
-from enum import IntEnum
+from enum import Enum
 
 from traits.api import provides
 
@@ -22,7 +22,7 @@ from pyface.ui.qt4.widget import Widget
 QWIDGETSIZE_MAX = getattr(QtGui, "QWIDGETSIZE_MAX", 1 << 24 - 1)
 
 
-class SizePolicies(IntEnum):
+class SizePolicies(Enum):
     """ Qt values for size policies
 
     Note that Qt has additional values that are not mapped to Pyface size
@@ -81,9 +81,13 @@ class LayoutWidget(MLayoutWidget, Widget):
     def _set_control_size_policy(self, size_policy):
         new_size_policy = _clone_size_policy(self.control.sizePolicy())
         if size_policy[0] != "default":
-            new_size_policy.setHorizontalPolicy(SizePolicies[size_policy[0]])
+            new_size_policy.setHorizontalPolicy(
+                SizePolicies[size_policy[0]].value
+            )
         if size_policy[1] != "default":
-            new_size_policy.setVerticalPolicy(SizePolicies[size_policy[1]])
+            new_size_policy.setVerticalPolicy(
+                SizePolicies[size_policy[1]].value
+            )
         self.control.setSizePolicy(new_size_policy)
 
     def _get_control_size_policy(self):

--- a/pyface/ui/qt4/layout_widget.py
+++ b/pyface/ui/qt4/layout_widget.py
@@ -1,0 +1,129 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from enum import IntEnum
+
+from traits.api import provides
+
+from pyface.qt import QtGui
+from pyface.i_layout_item import DEFAULT_SIZE, SizePolicy
+from pyface.i_layout_widget import ILayoutWidget, MLayoutWidget
+from pyface.ui.qt4.widget import Widget
+
+
+#: Maximum widget size (some versions of PyQt don't export it)
+QWIDGETSIZE_MAX = getattr(QtGui, "QWIDGETSIZE_MAX", 1 << 24 - 1)
+
+
+class SizePolicies(IntEnum):
+    """ Qt values for size policies
+
+    Note that Qt has additional values that are not mapped to Pyface size
+    policies.
+    """
+    fixed = QtGui.QSizePolicy.Fixed
+    preferred = QtGui.QSizePolicy.Preferred
+    expand = QtGui.QSizePolicy.Expanding
+
+
+@provides(ILayoutWidget)
+class LayoutWidget(MLayoutWidget, Widget):
+    """ A widget which can participate as part of a layout. """
+
+    def _set_control_minimum_size(self, size):
+        size = tuple(
+            x if x != DEFAULT_SIZE else 0
+            for x in size
+        )
+        self.control.setMinimumSize(*size)
+
+    def _get_control_minimum_size(self):
+        size = self.control.minimumSize()
+        return (size.width(), size.height())
+
+    def _set_control_maximum_size(self, size):
+        size = tuple(
+            x if x != DEFAULT_SIZE else QWIDGETSIZE_MAX
+            for x in size
+        )
+        self.control.setMaximumSize(*size)
+
+    def _get_control_maximum_size(self):
+        size = self.control.maximumSize()
+        return (size.width(), size.height())
+
+    def _set_control_stretch(self, stretch):
+        """ Set the stretch factor of the control.
+        """
+        new_size_policy = _clone_size_policy(self.control.sizePolicy())
+        new_size_policy.setHorizontalStretch(stretch[0])
+        new_size_policy.setVerticalStretch(stretch[1])
+        self.control.setSizePolicy(new_size_policy)
+
+    def _get_control_stretch(self):
+        """ Get the stretch factor of the control.
+
+        This method is only used for testing.
+        """
+        size_policy = self.control.sizePolicy()
+        return (
+            size_policy.horizontalStretch(),
+            size_policy.verticalStretch(),
+        )
+
+    def _set_control_size_policy(self, size_policy):
+        new_size_policy = _clone_size_policy(self.control.sizePolicy())
+        if size_policy[0] != "default":
+            new_size_policy.setHorizontalPolicy(SizePolicies[size_policy[0]])
+        if size_policy[1] != "default":
+            new_size_policy.setVerticalPolicy(SizePolicies[size_policy[1]])
+        self.control.setSizePolicy(new_size_policy)
+
+    def _get_control_size_policy(self):
+        size_policy = self.control.sizePolicy()
+        if self.size_policy[0] != "default":
+            horizontal_policy = SizePolicies(
+                size_policy.horizontalPolicy()).name
+        else:
+            horizontal_policy = "default"
+        if self.size_policy[1] != "default":
+            vertical_policy = SizePolicies(
+                size_policy.verticalPolicy()).name
+        else:
+            vertical_policy = "default"
+        return (horizontal_policy, vertical_policy)
+
+
+def _clone_size_policy(size_policy):
+    """ Clone the state of an existing QSizePolicy object
+
+    This is required because there is no standard Qt copy or clone
+    method.
+    """
+    new_size_policy = QtGui.QSizePolicy()
+    new_size_policy.setHorizontalPolicy(
+        size_policy.horizontalPolicy()
+    )
+    new_size_policy.setVerticalPolicy(
+        size_policy.verticalPolicy()
+    )
+    new_size_policy.setHorizontalStretch(
+        size_policy.horizontalStretch()
+    )
+    new_size_policy.setVerticalStretch(
+        size_policy.verticalStretch()
+    )
+    new_size_policy.setHeightForWidth(
+        size_policy.hasHeightForWidth()
+    )
+    new_size_policy.setWidthForHeight(
+        size_policy.hasWidthForHeight()
+    )
+    return new_size_policy

--- a/pyface/ui/wx/data_view/data_view_widget.py
+++ b/pyface/ui/wx/data_view/data_view_widget.py
@@ -26,7 +26,7 @@ from pyface.data_view.i_data_view_widget import (
     IDataViewWidget, MDataViewWidget
 )
 from pyface.data_view.data_view_errors import DataViewGetError
-from pyface.ui.wx.widget import Widget
+from pyface.ui.wx.layout_widget import LayoutWidget
 from .data_view_model import DataViewModel
 
 
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # XXX This file is scaffolding and may need to be rewritten
 
 @provides(IDataViewWidget)
-class DataViewWidget(MDataViewWidget, Widget):
+class DataViewWidget(MDataViewWidget, LayoutWidget):
     """ The Wx implementation of the DataViewWidget. """
 
     #: What can be selected.

--- a/pyface/ui/wx/fields/field.py
+++ b/pyface/ui/wx/fields/field.py
@@ -16,12 +16,12 @@ from traits.api import Any, Instance, Str, provides
 import wx
 
 from pyface.fields.i_field import IField, MField
-from pyface.ui.wx.widget import Widget
+from pyface.ui.wx.layout_widget import LayoutWidget
 
 
 @provides(IField)
-class Field(MField, Widget):
-    """ The Wxspecific implementation of the field class
+class Field(MField, LayoutWidget):
+    """ The Wx-specific implementation of the field class
 
     This is an abstract class which is not meant to be instantiated.
     """
@@ -34,28 +34,6 @@ class Field(MField, Widget):
 
     #: An optional context menu for the field.
     context_menu = Instance("pyface.action.menu_manager.MenuManager")
-
-    # ------------------------------------------------------------------------
-    # IField interface
-    # ------------------------------------------------------------------------
-
-    def _initialize_control(self):
-        """ Perform any toolkit-specific initialization for the control. """
-        self.control.SetToolTip(self.tooltip)
-        self.control.Enable(self.enabled)
-        self.control.Show(self.visible)
-
-    # ------------------------------------------------------------------------
-    # IWidget interface
-    # ------------------------------------------------------------------------
-
-    def _create(self):
-        super()._create()
-        self._add_event_listeners()
-
-    def destroy(self):
-        self._remove_event_listeners()
-        super().destroy()
 
     # ------------------------------------------------------------------------
     # Private interface

--- a/pyface/ui/wx/layout_widget.py
+++ b/pyface/ui/wx/layout_widget.py
@@ -1,0 +1,121 @@
+# (C) Copyright 2005-2021 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+import typing as t
+
+import wx
+
+from traits.api import provides
+
+from pyface.i_layout_item import DEFAULT_SIZE
+from pyface.i_layout_widget import ILayoutWidget, MLayoutWidget
+from pyface.ui.wx.widget import Widget
+
+
+#: The special "default" size for Wx Size objects.
+WX_DEFAULT_SIZE = -1
+
+
+@provides(ILayoutWidget)
+class LayoutWidget(MLayoutWidget, Widget):
+    """ A widget which can participate as part of a layout.
+
+    This is an abstract class, as Widget._create_control needs to be
+    implemented at a minimum.
+    """
+
+    def _set_control_minimum_size(self, size):
+        """ Set the minimum size of the control. """
+        wx_size = _size_to_wx_size(size)
+        self.control.SetMinSize(wx_size)
+
+    def _get_control_minimum_size(self):
+        """ Get the minimum size of the control. """
+        wx_size = self.control.GetMinSize()
+        return _wx_size_to_size(wx_size)
+
+    def _set_control_maximum_size(self, size):
+        """ Set the maximum size of the control. """
+        wx_size = _size_to_wx_size(size)
+        self.control.SetMaxSize(wx_size)
+
+    def _get_control_maximum_size(self):
+        """ Get the maximum size of the control. """
+        wx_size = self.control.GetMaxSize()
+        return _wx_size_to_size(wx_size)
+
+    def _set_control_stretch(self, size_policy):
+        """ Set the stretch factor of the control.
+
+        In Wx the stretch factor is set at layout time and can't be changed
+        without removing and adding the widget back into a layout.
+        """
+        pass
+
+    def _get_control_stretch(self):
+        """ Get the stretch factor of the control.
+
+        In Wx the stretch factor is set at layout time and can't be obtained
+        from the widget itself.  As a result, this method simply returns the
+        current trait value.  This method is only used for testing.
+        """
+        return self.stretch
+
+    def _set_control_size_policy(self, size_policy):
+        """ Set the size policy of the control
+
+        In Wx the size policy is set at layout time and can't be changed
+        without removing and adding the widget back into a layout.
+        """
+        pass
+
+    def _get_control_size_policy(self):
+        """ Get the size policy of the control
+
+        In Wx the size policy is set at layout time and can't be obtained from
+        the widget itself.  As a result, this method simply returns the
+        current trait value.  This method is only used for testing.
+        """
+        return self.size_policy
+
+
+def _size_to_wx_size(size: t.Tuple[int, int]) -> wx.Size:
+    """ Convert a size tuple to a wx.Size instance.
+
+    Parameters
+    ----------
+    size : tuple of (width, height)
+        The width and height as a tuple of ints.
+
+    Returns
+    -------
+    wx_size : wx.Size instance
+        A corresponding wx Size instance.
+    """
+    return wx.Size(*(
+        x if x != DEFAULT_SIZE else WX_DEFAULT_SIZE
+        for x in size
+    ))
+
+
+def _wx_size_to_size(wx_size: wx.Size) -> t.Tuple[int, int]:
+    """ Convert a wx.Size instance to a size tuple.
+
+    Parameters
+    ----------
+    wx_size : wx.Size instance
+        A wx Size instance.
+
+    Returns
+    -------
+    size : tuple of (width, height)
+        The corresponding width and height as a tuple of ints.
+    """
+    return (wx_size.GetWidth(), wx_size.GetHeight())

--- a/pyface/ui/wx/layout_widget.py
+++ b/pyface/ui/wx/layout_widget.py
@@ -8,8 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-import typing as t
-
 import wx
 
 from traits.api import provides
@@ -86,7 +84,7 @@ class LayoutWidget(MLayoutWidget, Widget):
         return self.size_policy
 
 
-def _size_to_wx_size(size: t.Tuple[int, int]) -> wx.Size:
+def _size_to_wx_size(size):
     """ Convert a size tuple to a wx.Size instance.
 
     Parameters
@@ -105,7 +103,7 @@ def _size_to_wx_size(size: t.Tuple[int, int]) -> wx.Size:
     ))
 
 
-def _wx_size_to_size(wx_size: wx.Size) -> t.Tuple[int, int]:
+def _wx_size_to_size(wx_size):
     """ Convert a wx.Size instance to a size tuple.
 
     Parameters


### PR DESCRIPTION
This adds infrastructure below `IWidget` for widgets that have opinions about sizing; in particular should they be allowed to expand, what weight should they have compared to other widgets when expanding, and are there bounds on how big they can get?  This is useful for widgets which are embedded in layouts and containers.

The PR provides an interface for this, an implementation for both toolkits, and makes this a superclass for `IField` and `IDataViewWidget` for concreteness.  Other widgets will be added tot he system in a separate PR.

This PR is working towards #738 (in that `LayoutWidget` instances are the contents of `IContainers`) and a general layout system for Pyface.  It also is a requirement for being able to directly use Pyface widgets in TraitsUI editors without needing any toolkit-specific code.