### PR TITLE
Widget context menus

### DIFF
--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -11,7 +11,7 @@
 """ The field interface. """
 
 
-from traits.api import Any, HasTraits, Instance, Str
+from traits.api import Any, HasTraits
 
 from pyface.i_layout_widget import ILayoutWidget
 
@@ -26,21 +26,12 @@ class IField(ILayoutWidget):
     #: The value held by the field.
     value = Any()
 
-    #: An optional context menu for the field.
-    context_menu = Instance("pyface.action.menu_manager.MenuManager")
-
-    def show_context_menu(self, x, y):
-        """ Create and show the context menu at a position. """
-
 
 class MField(HasTraits):
     """ The field mix-in. """
 
     #: The value held by the field.
     value = Any()
-
-    #: An optional context menu for the field.
-    context_menu = Instance("pyface.action.menu_manager.MenuManager")
 
     # ------------------------------------------------------------------------
     # IWidget interface
@@ -50,11 +41,6 @@ class MField(HasTraits):
         """ Set up toolkit-specific bindings for events """
         super()._add_event_listeners()
         self.observe(self._value_updated, "value", dispatch="ui")
-        self.observe(
-            self._context_menu_updated, "context_menu", dispatch="ui"
-        )
-        if self.control is not None and self.context_menu is not None:
-            self._observe_control_context_menu()
 
     def _remove_event_listeners(self):
         """ Remove toolkit-specific bindings for events """
@@ -114,34 +100,9 @@ class MField(HasTraits):
         """ Toolkit specific method to change the control value observer. """
         raise NotImplementedError()
 
-    def _observe_control_context_menu(self, remove=False):
-        """ Toolkit specific method to change the control menu observer.
-
-        This should use _handle_control_context_menu as the event handler.
-        """
-        raise NotImplementedError()
-
-    def _handle_control_context_menu(self, event):
-        """ Handle a context menu event.
-
-        This should call show_context_menu with appropriate position x and y
-        arguments.
-
-        The function signature will likely vary from toolkit to toolkit.
-        """
-        raise NotImplementedError()
-
     # Trait change handlers -------------------------------------------------
 
     def _value_updated(self, event):
         value = event.new
         if self.control is not None:
             self._set_control_value(value)
-
-    def _context_menu_updated(self, event):
-
-        if self.control is not None:
-            if event.new is None:
-                self._observe_control_context_menu(remove=True)
-            if event.old is None:
-                self._observe_control_context_menu()

--- a/pyface/fields/tests/field_mixin.py
+++ b/pyface/fields/tests/field_mixin.py
@@ -11,15 +11,7 @@
 
 from pyface.testing.layout_widget_mixin import LayoutWidgetMixin
 
-from pyface.action.api import Action, MenuManager
-from pyface.gui import GUI
-from pyface.window import Window
-
 
 class FieldMixin(LayoutWidgetMixin):
     """ Mixin which provides standard methods for all fields. """
-
-    def test_field_menu(self):
-        self._create_widget_control()
-        self.widget.menu = MenuManager(Action(name="Test"), name="Test")
-        self.gui.process_events()
+    pass

--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -117,7 +117,7 @@ class MWidget(HasTraits):
     #: A tooltip for the widget.
     tooltip = Str()
 
-    #: An optional context menu for the window.
+    #: An optional context menu for the widget.
     context_menu = Instance("pyface.action.menu_manager.MenuManager")
 
     def create(self):

--- a/pyface/testing/widget_mixin.py
+++ b/pyface/testing/widget_mixin.py
@@ -63,5 +63,5 @@ class WidgetMixin(UnittestTools):
 
     def test_field_menu(self):
         self._create_widget_control()
-        self.widget.menu = MenuManager(Action(name="Test"), name="Test")
+        self.widget.context_menu = MenuManager(Action(name="Test"), name="Test")
         self.gui.process_events()

--- a/pyface/testing/widget_mixin.py
+++ b/pyface/testing/widget_mixin.py
@@ -54,14 +54,14 @@ class WidgetMixin(UnittestTools):
         self.gui.process_events()
         self.widget = None
 
-    def test_field_tooltip(self):
+    def test_widget_tooltip(self):
         self._create_widget_control()
         self.widget.tooltip = "New tooltip."
         self.gui.process_events()
 
         self.assertEqual(self.widget._get_control_tooltip(), "New tooltip.")
 
-    def test_field_menu(self):
+    def test_widget_menu(self):
         self._create_widget_control()
         self.widget.context_menu = MenuManager(Action(name="Test"), name="Test")
         self.gui.process_events()

--- a/pyface/testing/widget_mixin.py
+++ b/pyface/testing/widget_mixin.py
@@ -11,6 +11,7 @@
 
 from traits.testing.api import UnittestTools
 
+from pyface.action.api import Action, MenuManager
 from pyface.gui import GUI
 from pyface.window import Window
 
@@ -59,3 +60,8 @@ class WidgetMixin(UnittestTools):
         self.gui.process_events()
 
         self.assertEqual(self.widget._get_control_tooltip(), "New tooltip.")
+
+    def test_field_menu(self):
+        self._create_widget_control()
+        self.widget.menu = MenuManager(Action(name="Test"), name="Test")
+        self.gui.process_events()

--- a/pyface/ui/qt4/fields/field.py
+++ b/pyface/ui/qt4/fields/field.py
@@ -11,9 +11,8 @@
 """ The Qt-specific implementation of the text field class """
 
 
-from traits.api import Any, Instance, Str, provides
+from traits.api import Any, provides
 
-from pyface.qt.QtCore import Qt
 from pyface.fields.i_field import IField, MField
 from pyface.ui.qt4.layout_widget import LayoutWidget
 
@@ -27,29 +26,3 @@ class Field(MField, LayoutWidget):
 
     #: The value held by the field.
     value = Any()
-
-    #: An optional context menu for the field.
-    context_menu = Instance("pyface.action.menu_manager.MenuManager")
-
-    # ------------------------------------------------------------------------
-    # Private interface
-    # ------------------------------------------------------------------------
-
-    def _observe_control_context_menu(self, remove=False):
-        """ Toolkit specific method to change the control menu observer. """
-        if remove:
-            self.control.setContextMenuPolicy(Qt.DefaultContextMenu)
-            self.control.customContextMenuRequested.disconnect(
-                self._handle_control_context_menu
-            )
-        else:
-            self.control.customContextMenuRequested.connect(
-                self._handle_control_context_menu
-            )
-            self.control.setContextMenuPolicy(Qt.CustomContextMenu)
-
-    def _handle_control_context_menu(self, pos):
-        """ Signal handler for displaying context menu. """
-        if self.control is not None and self.context_menu is not None:
-            menu = self.context_menu.create_menu(self.control)
-            menu.show(pos.x(), pos.y())

--- a/pyface/ui/qt4/widget.py
+++ b/pyface/ui/qt4/widget.py
@@ -11,10 +11,9 @@
 
 
 from pyface.qt import QtCore
-
+from pyface.qt.QtCore import Qt
 
 from traits.api import Any, Bool, HasTraits, Instance, Str, provides
-
 
 from pyface.i_widget import IWidget, MWidget
 
@@ -41,6 +40,9 @@ class Widget(MWidget, HasTraits):
 
     #: A tooltip for the field.
     tooltip = Str()
+
+    #: An optional context menu for the widget.
+    context_menu = Instance("pyface.action.menu_manager.MenuManager")
 
     # Private interface ----------------------------------------------------
 
@@ -122,6 +124,25 @@ class Widget(MWidget, HasTraits):
     def _set_control_tooltip(self, tooltip):
         """ Toolkit specific method to set the control's tooltip. """
         self.control.setToolTip(tooltip)
+
+    def _observe_control_context_menu(self, remove=False):
+        """ Toolkit specific method to change the control menu observer. """
+        if remove:
+            self.control.setContextMenuPolicy(Qt.DefaultContextMenu)
+            self.control.customContextMenuRequested.disconnect(
+                self._handle_control_context_menu
+            )
+        else:
+            self.control.customContextMenuRequested.connect(
+                self._handle_control_context_menu
+            )
+            self.control.setContextMenuPolicy(Qt.CustomContextMenu)
+
+    def _handle_control_context_menu(self, pos):
+        """ Signal handler for displaying context menu. """
+        if self.control is not None and self.context_menu is not None:
+            menu = self.context_menu.create_menu(self.control)
+            menu.show(pos.x(), pos.y())
 
     # Trait change handlers --------------------------------------------------
 

--- a/pyface/ui/qt4/widget.py
+++ b/pyface/ui/qt4/widget.py
@@ -38,7 +38,7 @@ class Widget(MWidget, HasTraits):
     #: Whether or not the control is enabled
     enabled = Bool(True)
 
-    #: A tooltip for the field.
+    #: A tooltip for the widget.
     tooltip = Str()
 
     #: An optional context menu for the widget.

--- a/pyface/ui/wx/fields/field.py
+++ b/pyface/ui/wx/fields/field.py
@@ -11,9 +11,7 @@
 """ The Wx-specific implementation of the text field class """
 
 
-from traits.api import Any, Instance, Str, provides
-
-import wx
+from traits.api import Any, provides
 
 from pyface.fields.i_field import IField, MField
 from pyface.ui.wx.layout_widget import LayoutWidget
@@ -28,25 +26,3 @@ class Field(MField, LayoutWidget):
 
     #: The value held by the field.
     value = Any()
-
-    #: An optional context menu for the field.
-    context_menu = Instance("pyface.action.menu_manager.MenuManager")
-
-    # ------------------------------------------------------------------------
-    # Private interface
-    # ------------------------------------------------------------------------
-
-    def _observe_control_context_menu(self, remove=False):
-        """ Toolkit specific method to change the control menu observer. """
-        if remove:
-            self.control.Unbind(
-                wx.EVT_CONTEXT_MENU, handler=self._handle_context_menu
-            )
-        else:
-            self.control.Bind(wx.EVT_CONTEXT_MENU, self._handle_context_menu)
-
-    def _handle_control_context_menu(self, event):
-        """ Signal handler for displaying context menu. """
-        if self.control is not None and self.context_menu is not None:
-            menu = self.context_menu.create_menu(self.control)
-            self.control.PopupMenu(menu)

--- a/pyface/ui/wx/widget.py
+++ b/pyface/ui/wx/widget.py
@@ -12,9 +12,9 @@
 """ Enthought pyface package component
 """
 
+import wx
 
-from traits.api import Any, Bool, HasTraits, Str, provides
-
+from traits.api import Any, Bool, HasTraits, Instance, Str, provides
 
 from pyface.i_widget import IWidget, MWidget
 
@@ -41,6 +41,9 @@ class Widget(MWidget, HasTraits):
 
     #: A tooltip for the widget.
     tooltip = Str()
+
+    #: An optional context menu for the widget.
+    context_menu = Instance("pyface.action.menu_manager.MenuManager")
 
     # ------------------------------------------------------------------------
     # 'IWidget' interface.
@@ -106,3 +109,18 @@ class Widget(MWidget, HasTraits):
     def _set_control_tooltip(self, tooltip):
         """ Toolkit specific method to set the control's tooltip. """
         self.control.SetToolTip(tooltip)
+
+    def _observe_control_context_menu(self, remove=False):
+        """ Toolkit specific method to change the control menu observer. """
+        if remove:
+            self.control.Unbind(
+                wx.EVT_CONTEXT_MENU, handler=self._handle_context_menu
+            )
+        else:
+            self.control.Bind(wx.EVT_CONTEXT_MENU, self._handle_context_menu)
+
+    def _handle_control_context_menu(self, event):
+        """ Signal handler for displaying context menu. """
+        if self.control is not None and self.context_menu is not None:
+            menu = self.context_menu.create_menu(self.control)
+            self.control.PopupMenu(menu)

--- a/pyface/ui/wx/widget.py
+++ b/pyface/ui/wx/widget.py
@@ -114,10 +114,12 @@ class Widget(MWidget, HasTraits):
         """ Toolkit specific method to change the control menu observer. """
         if remove:
             self.control.Unbind(
-                wx.EVT_CONTEXT_MENU, handler=self._handle_context_menu
+                wx.EVT_CONTEXT_MENU, handler=self._handle_control_context_menu
             )
         else:
-            self.control.Bind(wx.EVT_CONTEXT_MENU, self._handle_context_menu)
+            self.control.Bind(
+                wx.EVT_CONTEXT_MENU, self._handle_control_context_menu
+            )
 
     def _handle_control_context_menu(self, event):
         """ Signal handler for displaying context menu. """


### PR DESCRIPTION
This is doing essentially the same as #1019 but for context menus, so that now any widget can have a context menu attached to it.

One consequence of this is that `Field` and the testing code for field have become very thin with no toolkit-specific code at all.  This PR is leaving them in that state, but I will open an issue to either do a clean-up or add some meat to them.