### PR TITLE
ENH: Provides control on item enability and selectability for DataView

### DIFF
--- a/pyface/data_view/abstract_data_model.py
+++ b/pyface/data_view/abstract_data_model.py
@@ -235,6 +235,44 @@ class AbstractDataModel(ABCHasStrictTraits):
         """
         raise NotImplementedError()
 
+    def is_enabled(self, row, column):
+        """ Whether the item located at row and column is enabled.
+
+        The default method returns True.
+
+        Parameters
+        ----------
+        row : sequence of int
+            The indices of the row as a sequence from root to leaf.
+        column : sequence of int
+            The indices of the column as a sequence of length 0 or 1.
+
+        Returns
+        -------
+        can_set_value : bool
+            Whether or not the item is enabled.
+        """
+        return True
+
+    def is_selectable(self, row, column):
+        """ Whether the item located at row and column is selectable.
+
+        The default method returns True.
+
+        Parameters
+        ----------
+        row : sequence of int
+            The indices of the row as a sequence from root to leaf.
+        column : sequence of int
+            The indices of the column as a sequence of length 0 or 1.
+
+        Returns
+        -------
+        can_set_value : bool
+            Whether or not the item is selectable.
+        """
+        return True
+
     # Convenience methods
 
     def is_row_valid(self, row):

--- a/pyface/ui/qt4/data_view/data_view_item_model.py
+++ b/pyface/ui/qt4/data_view/data_view_item_model.py
@@ -142,14 +142,18 @@ class DataViewItemModel(QAbstractItemModel):
         row = self._to_row_index(index)
         column = self._to_column_index(index)
         value_type = self.model.get_value_type(row, column)
-        if row == () and column == ():
-            return Qt.ItemIsEnabled
 
-        flags = Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsDragEnabled
-        if is_qt5 and not self.model.can_have_children(row):
-            flags |= Qt.ItemNeverHasChildren
-
+        flags = Qt.ItemIsDragEnabled
         try:
+            if self.model.is_enabled(row, column):
+                flags |= Qt.ItemIsEnabled
+
+            if self.model.is_selectable(row, column):
+                flags |= Qt.ItemIsSelectable
+
+            if is_qt5 and not self.model.can_have_children(row):
+                flags |= Qt.ItemNeverHasChildren
+
             if value_type:
                 if value_type.has_editor_value(self.model, row, column):
                     flags |= Qt.ItemIsEditable


### PR DESCRIPTION
Hi there! This microscopic PR is intended to provide ways to control if cells in a table rendered with `DataView` can be selected or disabled., via new methods added to `data_view.AbstractDataModel`.

The primary need I'd like to answer with this PR is to offer the possibility to disable cells, or make them non-selectable, depending on some conditions in the underlying data. This is useful, for instance, to prevent interactions with some data items while they are used elsewhere. Feel free to close this PR if you have a better idea to tackle this!

## Example

In `pyface.examples.data_view.row_table_example`, if you subclass the data model to implement `is_enabled` like this:
```Python3
class ExampleDataModel(RowTableDataModel):

    def is_enabled(self, row, column):
        if len(row) == 0:
            return True

        obj = self.data[row[0]]
        return column_data.get_value(obj) > 30
```
and pass it to the data view widget, you should see this:

![Screenshot 2021-09-17 at 00 20 01](https://user-images.githubusercontent.com/24434420/133697658-602bfc99-3400-4057-9f8d-7018c948e461.png)

