### PR TITLE
MAINT/DOC: add 'open files' action to IFileDialog

### DIFF
--- a/pyface/i_file_dialog.py
+++ b/pyface/i_file_dialog.py
@@ -14,7 +14,7 @@
 import sys
 
 
-from traits.api import Enum, HasTraits, Int, Str
+from traits.api import Enum, HasTraits, Int, List, Str
 
 
 from pyface.i_dialog import IDialog
@@ -26,8 +26,9 @@ class IFileDialog(IDialog):
 
     # 'IFileDialog' interface ---------------------------------------------#
 
-    #: The 'action' that the user is peforming on the directory.
-    action = Enum("open", "save as")
+    #: The 'action' that the user is peforming on the directory ("open files"
+    #: differs from "open" in that the former supports multiple selections).
+    action = Enum("open", "open files", "save as")
 
     #: The default directory.
     default_directory = Str()
@@ -43,11 +44,16 @@ class IFileDialog(IDialog):
     #: The directory containing the chosen file.
     directory = Str()
 
-    #: The name of the chosen file.
+    #: The name (basename only) of the chosen file.
     filename = Str()
 
-    #: The path (directory and filename) of the chosen file.
+    #: The path (directory and filename) of the chosen file. To be used when only
+    #: single selection is allowed: if *action* is "open files", use *paths* instead.
     path = Str()
+
+    #: The paths (directory and filename) of the chosen files. To be used when
+    #: multiple selection is allowed.
+    paths = List(Str())
 
     #: The wildcard used to restrict the set of files.
     wildcard = Str()


### PR DESCRIPTION
Closes #874 

Adds class attributes to the `IFileDialog` interface that are shared by both implementations (and the third option is already tested on all toolkits).

I didn't try to document what `file_dialog.path` contains when multiple selection is enabled, since on wx it's not defined: the pyface implementation uses `GetPath()`, which [wx's documentation](https://wxpython.org/Phoenix/docs/html/wx.FileDialog.html#wx.FileDialog.GetPath) says shouldn't be used when multiple selection is active. On qt, we just return the first path in `paths`: understandable, but also rather meaningless to the user.

In principle, we could also add a warning to `directory` and `filename`'s apidocs: they are arbitrarily chosen with "open files". But that seemed to become overly detailed.