### PR TITLE
Fix SplitEditorAreaPane tab label and tooltip updates

### DIFF
--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -151,7 +151,7 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     def activate_editor(self, editor):
         """ Activates the specified editor in the pane.
         """
-        active_tabwidget = editor.control.parent().parent()
+        active_tabwidget = self._get_editor_tabwidget(editor)
         active_tabwidget.setCurrentWidget(editor.control)
         self.active_tabwidget = active_tabwidget
         editor_widget = editor.control.parent()
@@ -184,8 +184,8 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
     def remove_editor(self, editor):
         """ Removes an editor from the associated tabwidget
         """
-        tabwidget = editor.control.parent().parent()
-        tabwidget.removeTab(tabwidget.indexOf(editor.control))
+        tabwidget, index = self._get_editor_tabwidget_index(editor)
+        tabwidget.removeTab(index)
         self.editors.remove(editor)
         editor.destroy()
         editor.editor_area = None
@@ -377,19 +377,29 @@ class SplitEditorAreaPane(TaskPane, MEditorAreaPane):
         """
         return self.control.tabwidgets()
 
+    def _get_editor_tabwidget(self, editor):
+        """ Given an editor, return its tabwidget. """
+        return editor.control.parent().parent()
+
+    def _get_editor_tabwidget_index(self, editor):
+        """ Given an editor, return its tabwidget and index. """
+        tabwidget = self._get_editor_tabwidget(editor)
+        index = tabwidget.indexOf(editor.control)
+        return tabwidget, index
+
     # Trait change handlers ------------------------------------------------
 
     @observe("editors:items:[dirty, name]")
     def _update_label(self, event):
         editor = event.object
-        index = self.active_tabwidget.indexOf(editor.control)
-        self.active_tabwidget.setTabText(index, self._get_label(editor))
+        tabwidget, index = self._get_editor_tabwidget_index(editor)
+        tabwidget.setTabText(index, self._get_label(editor))
 
     @observe("editors:items:tooltip")
     def _update_tooltip(self, event):
         editor = event.object
-        index = self.active_tabwidget.indexOf(editor.control)
-        self.active_tabwidget.setTabToolTip(index, self._get_label(editor))
+        tabwidget, index = self._get_editor_tabwidget_index(editor)
+        tabwidget.setTabToolTip(index, editor.tooltip)
 
     # Signal handlers -----------------------------------------------------#
 

--- a/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/tests/test_split_editor_area_pane.py
@@ -517,3 +517,81 @@ class TestEditorAreaWidget(unittest.TestCase):
 
         with event_loop():
             window.close()
+
+    def test_editor_label_change_inactive(self):
+        # regression test for pyface#523
+        window = TaskWindow(size=(800, 600))
+
+        task = SplitEditorAreaPaneTestTask()
+        editor_area = task.editor_area
+        window.add_task(task)
+
+        # Show the window.
+        with event_loop():
+            window.open()
+
+        with event_loop():
+            app = get_app_qt4()
+            app.setActiveWindow(window.control)
+
+        # Add and activate an editor which contains tabs.
+        left_editor = ViewWithTabsEditor()
+        right_editor = ViewWithTabsEditor()
+
+        with event_loop():
+            editor_area.add_editor(left_editor)
+        with event_loop():
+            editor_area.control.split(orientation=QtCore.Qt.Horizontal)
+        with event_loop():
+            editor_area.add_editor(right_editor)
+
+        editor_area.activate_editor(right_editor)
+
+        # change the name of the inactive editor
+        left_editor.name = "New Name"
+
+        # the text of the editor's tab should have changed
+        left_tabwidget = editor_area.tabwidgets()[0]
+        index = left_tabwidget.indexOf(left_editor.control)
+        tab_text = left_tabwidget.tabText(index)
+
+        self.assertEqual(tab_text, "New Name")
+
+    def test_editor_tooltip_change_inactive(self):
+        # regression test related to pyface#523
+        window = TaskWindow(size=(800, 600))
+
+        task = SplitEditorAreaPaneTestTask()
+        editor_area = task.editor_area
+        window.add_task(task)
+
+        # Show the window.
+        with event_loop():
+            window.open()
+
+        with event_loop():
+            app = get_app_qt4()
+            app.setActiveWindow(window.control)
+
+        # Add and activate an editor which contains tabs.
+        left_editor = ViewWithTabsEditor()
+        right_editor = ViewWithTabsEditor()
+
+        with event_loop():
+            editor_area.add_editor(left_editor)
+        with event_loop():
+            editor_area.control.split(orientation=QtCore.Qt.Horizontal)
+        with event_loop():
+            editor_area.add_editor(right_editor)
+
+        editor_area.activate_editor(right_editor)
+
+        # change the name of the inactive editor
+        left_editor.tooltip = "New Tooltip"
+
+        # the text of the editor's tab should have changed
+        left_tabwidget = editor_area.tabwidgets()[0]
+        index = left_tabwidget.indexOf(left_editor.control)
+        tab_tooltip = left_tabwidget.tabToolTip(index)
+
+        self.assertEqual(tab_tooltip, "New Tooltip")


### PR DESCRIPTION
Ensure editor tab label and tooltip update correctly when not active; fixes #523.

Includes a small refactor to pull out common code that finds an editor's tabwidget and index in that tabwidget.