### PR TITLE
Remove deprecated `Color` and `Font` trait imports

### DIFF
--- a/examples/chained_wizard.py
+++ b/examples/chained_wizard.py
@@ -17,10 +17,11 @@ import sys
 # Put the Enthought library on the Python path.
 sys.path.append(os.path.abspath(r"..\..\.."))
 
+from traits.api import HasTraits, Int, Str
 
 from pyface.api import GUI, OK
 from pyface.wizard.api import ChainedWizard, Wizard, WizardPage
-from traits.api import Color, HasTraits, Int, Str
+from pyface.ui_traits import TraitsUIColor as Color
 
 
 class Details(HasTraits):

--- a/examples/wizard.py
+++ b/examples/wizard.py
@@ -17,10 +17,11 @@ import sys
 # Put the Enthought library on the Python path.
 sys.path.append(os.path.abspath(r"..\..\.."))
 
+from traits.api import HasTraits, Int, Str
 
 from pyface.api import GUI, OK
 from pyface.wizard.api import SimpleWizard, WizardPage
-from traits.api import Color, HasTraits, Int, Str
+from pyface.ui_traits import TraitsUIColor as Color
 
 
 class Details(HasTraits):

--- a/pyface/dock/feature_bar.py
+++ b/pyface/dock/feature_bar.py
@@ -18,9 +18,10 @@
 
 import wx
 
-from traits.api import HasPrivateTraits, Instance, Bool, Event, Color
+from traits.api import HasPrivateTraits, Instance, Bool, Event
 
 from pyface.wx.drag_and_drop import PythonDropTarget, PythonDropSource
+from pyface.ui_traits import TraitsUIColor as Color
 from .dock_sizer import DockControl, FEATURE_EXTERNAL_DRAG
 from .ifeature_tool import IFeatureTool
 

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -41,8 +41,8 @@ from traits.api import (
     Font,
     Instance,
     Int,
-    Trait,
     Undefined,
+    Union,
 )
 from pyface.wx.drag_and_drop import (
     PythonDropSource,
@@ -88,10 +88,12 @@ class Grid(LayoutWidget):
     default_label_text_color = Color("black")
 
     # The color to use for a selection background
-    selection_bg_color = Trait(wx.Colour(49, 106, 197), None, Color)
+    selection_bg_color = Union(None, Color,
+                               default_value=wx.Colour(49, 106, 197))
 
     # The color to use for a selection foreground/text
-    selection_text_color = Trait(wx.Colour(255, 255, 255), None, Color)
+    selection_text_color = Union(None, Color,
+                                 default_value=wx.Colour(255, 255, 255))
 
     # The default font to use for text in cells
     default_cell_font = Font(None)
@@ -103,7 +105,6 @@ class Grid(LayoutWidget):
     default_cell_bg_color = Color("white")
 
     # The default background color to use for read-only cells
-    # default_cell_read_only_color = Trait(Color("linen"), None, Color)
     default_cell_read_only_color = Color(wx.Colour(248, 247, 241))
 
     # Should the grid be read-only? If this is set to false, individual

--- a/pyface/ui/wx/grid/grid.py
+++ b/pyface/ui/wx/grid/grid.py
@@ -30,20 +30,19 @@ from wx.grid import (
     GRID_VALUE_STRING,
 )
 
-
-from pyface.ui.wx.layout_widget import LayoutWidget
-from pyface.timer.api import do_later
 from traits.api import (
     Bool,
-    Color,
     Enum,
     Event,
-    Font,
     Instance,
     Int,
     Undefined,
     Union,
 )
+
+from pyface.timer.api import do_later
+from pyface.ui.wx.layout_widget import LayoutWidget
+from pyface.ui_traits import TraitsUIColor as Color, TraitsUIFont as Font
 from pyface.wx.drag_and_drop import (
     PythonDropSource,
     PythonDropTarget,

--- a/pyface/ui/wx/viewer/table_viewer.py
+++ b/pyface/ui/wx/viewer/table_viewer.py
@@ -14,9 +14,10 @@ import warnings
 
 import wx
 
-from traits.api import Color, Event, Instance, Int, Tuple
+from traits.api import Event, Instance, Int, Tuple
 
 from pyface.ui.wx.image_list import ImageList
+from pyface.ui_traits import TraitsUIColor as Color
 from pyface.viewer.content_viewer import ContentViewer
 from pyface.viewer.table_column_provider import TableColumnProvider
 from pyface.viewer.table_content_provider import TableContentProvider

--- a/pyface/ui_traits.py
+++ b/pyface/ui_traits.py
@@ -24,6 +24,7 @@ from traits.api import (
     Enum,
     Range,
     TraitError,
+    TraitFactory,
     TraitType,
 )
 from traits.trait_base import get_resource_path
@@ -337,3 +338,39 @@ Alignment = Enum("default", "left", "center", "right")
 
 #: Whether the orientation of a widget's contents is horizontal or vertical.
 Orientation = Enum("vertical", "horizontal")
+
+
+# -------------------------------------------------------------------------------
+#  Legacy TraitsuI Color and Font Traits
+# -------------------------------------------------------------------------------
+
+def TraitsUIColor(*args, **metadata):
+    """ Returns a trait whose value must be a GUI toolkit-specific color.
+
+    This is copied from the deprecated trait that is in traits.api.  It adds
+    a deferred dependency on TraitsUI.
+
+    This trait will be replaced by native Pyface color traits in Pyface 8.0.
+    New code should not use this trait.
+    """
+    from traitsui.toolkit_traits import ColorTrait
+
+    return ColorTrait(*args, **metadata)
+
+TraitsUIColor = TraitFactory(TraitsUIColor)
+
+
+def TraitsUIFont(*args, **metadata):
+    """ Returns a trait whose value must be a GUI toolkit-specific font.
+
+    This is copied from the deprecated trait that is in traits.api.  It adds
+    a deferred dependency on TraitsUI.
+
+    This trait will be replaced by native Pyface font traits in Pyface 8.0.
+    New code should not use this trait.
+    """
+    from traitsui.toolkit_traits import FontTrait
+
+    return FontTrait(*args, **metadata)
+
+TraitsUIFont = TraitFactory(TraitsUIFont)

--- a/pyface/ui_traits.py
+++ b/pyface/ui_traits.py
@@ -341,7 +341,7 @@ Orientation = Enum("vertical", "horizontal")
 
 
 # -------------------------------------------------------------------------------
-#  Legacy TraitsuI Color and Font Traits
+#  Legacy TraitsUI Color and Font Traits
 # -------------------------------------------------------------------------------
 
 def TraitsUIColor(*args, **metadata):


### PR DESCRIPTION
This PR removes deprecated imports of `Color` and `Font` traits from `traits.api` by copying the trait definitions into `pyface.ui_traits` and importing from there.  This does not remove the indirect dependence on TraitsUI, and these traits will likely be removed at some point in the future (or the trait definition moved into Pyface itself).

This is a step towards being able to remove those traits in Traits.

~~Requires #1041~~ merged

Fixes #1040 