### PR TITLE
Add experimental support for Qt6

### DIFF
--- a/pyface/qt/QtCore.py
+++ b/pyface/qt/QtCore.py
@@ -39,8 +39,6 @@ elif qt_api == "pyqt6":
     from PyQt6.QtCore import pyqtProperty as Property
     from PyQt6.QtCore import pyqtSignal as Signal
     from PyQt6.QtCore import pyqtSlot as Slot
-    from PyQt6.Qt import QCoreApplication
-    from PyQt6.Qt import Qt
 
     __version__ = QT_VERSION_STR
     __version_info__ = tuple(map(int, QT_VERSION_STR.split(".")))

--- a/pyface/qt/QtCore.py
+++ b/pyface/qt/QtCore.py
@@ -33,6 +33,23 @@ elif qt_api == "pyqt5":
     __version__ = QT_VERSION_STR
     __version_info__ = tuple(map(int, QT_VERSION_STR.split(".")))
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtCore import *
+
+    from PyQt6.QtCore import pyqtProperty as Property
+    from PyQt6.QtCore import pyqtSignal as Signal
+    from PyQt6.QtCore import pyqtSlot as Slot
+    from PyQt6.Qt import QCoreApplication
+    from PyQt6.Qt import Qt
+
+    __version__ = QT_VERSION_STR
+    __version_info__ = tuple(map(int, QT_VERSION_STR.split(".")))
+
+elif qt_api == "pyside6":
+    from PySide6.QtCore import *
+
+    from PySide6 import __version__, __version_info__
+
 else:
     from PySide2.QtCore import *
 

--- a/pyface/qt/QtGui.py
+++ b/pyface/qt/QtGui.py
@@ -36,6 +36,39 @@ elif qt_api == "pyqt5":
     QStyleOptionTabV3 = QStyleOptionTab
     QStyleOptionTabBarBaseV2 = QStyleOptionTabBarBase
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtGui import *
+    from PyQt6.QtWidgets import *
+    from PyQt6.QtPrintSupport import *
+    from PyQt6.QtCore import (
+        QAbstractProxyModel,
+        QItemSelection,
+        QItemSelectionModel,
+        QItemSelectionRange,
+        QSortFilterProxyModel,
+        QStringListModel,
+    )
+
+    QStyleOptionTabV2 = QStyleOptionTab
+    QStyleOptionTabV3 = QStyleOptionTab
+    QStyleOptionTabBarBaseV2 = QStyleOptionTabBarBase
+
+elif qt_api == "pyside6":
+    from PySide6.QtGui import *
+    from PySide6.QtWidgets import *
+    from PySide6.QtPrintSupport import *
+    from PySide6.QtCore import (
+        QAbstractProxyModel,
+        QItemSelection,
+        QItemSelectionModel,
+        QItemSelectionRange,
+        QSortFilterProxyModel,
+    )
+
+    QStyleOptionTabV2 = QStyleOptionTab
+    QStyleOptionTabV3 = QStyleOptionTab
+    QStyleOptionTabBarBaseV2 = QStyleOptionTabBarBase
+
 else:
     from PySide2.QtGui import *
     from PySide2.QtWidgets import *

--- a/pyface/qt/QtMultimedia.py
+++ b/pyface/qt/QtMultimedia.py
@@ -15,6 +15,12 @@ from . import qt_api
 if qt_api == "pyqt5":
     from PyQt5.QtMultimedia import *
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtMultimedia import *
+
+elif qt_api == "pyside6":
+    from PySide6.QtMultimedia import *
+
 elif qt_api == "pyside2":
     from PySide2.QtMultimedia import *
 

--- a/pyface/qt/QtMultimediaWidgets.py
+++ b/pyface/qt/QtMultimediaWidgets.py
@@ -15,6 +15,12 @@ from . import qt_api
 if qt_api == "pyqt5":
     from PyQt5.QtMultimediaWidgets import *
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtMultimediaWidgets import *
+
+elif qt_api == "pyside2":
+    from PySide6.QtMultimediaWidgets import *
+
 elif qt_api == "pyside2":
     from PySide2.QtMultimediaWidgets import *
 

--- a/pyface/qt/QtMultimediaWidgets.py
+++ b/pyface/qt/QtMultimediaWidgets.py
@@ -18,7 +18,7 @@ if qt_api == "pyqt5":
 elif qt_api == "pyqt6":
     from PyQt6.QtMultimediaWidgets import *
 
-elif qt_api == "pyside2":
+elif qt_api == "pyside6":
     from PySide6.QtMultimediaWidgets import *
 
 elif qt_api == "pyside2":

--- a/pyface/qt/QtNetwork.py
+++ b/pyface/qt/QtNetwork.py
@@ -15,5 +15,11 @@ if qt_api == "pyqt":
 elif qt_api == "pyqt5":
     from PyQt5.QtNetwork import *
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtNetwork import *
+
+elif qt_api == "pyside6":
+    from PySide6.QtNetwork import *
+
 else:
     from PySide2.QtNetwork import *

--- a/pyface/qt/QtOpenGL.py
+++ b/pyface/qt/QtOpenGL.py
@@ -15,5 +15,11 @@ if qt_api == "pyqt":
 elif qt_api == "pyqt5":
     from PyQt5.QtOpenGL import *
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtOpenGL import *
+
+elif qt_api == "pyside6":
+    from PySide6.QtOpenGL import *
+
 else:
     from PySide2.QtOpenGL import *

--- a/pyface/qt/QtSvg.py
+++ b/pyface/qt/QtSvg.py
@@ -15,5 +15,11 @@ if qt_api == "pyqt":
 elif qt_api == "pyqt5":
     from PyQt5.QtSvg import *
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtSvg import *
+
+elif qt_api == "pyside6":
+    from PySide6.QtSvg import *
+
 else:
     from PySide2.QtSvg import *

--- a/pyface/qt/QtTest.py
+++ b/pyface/qt/QtTest.py
@@ -15,5 +15,11 @@ if qt_api == "pyqt":
 elif qt_api == "pyqt5":
     from PyQt5.QtTest import *
 
+elif qt_api == "pyqt6":
+    from PyQt6.QtTest import *
+
+elif qt_api == "pyside6":
+    from PySide6.QtTest import *
+
 else:
     from PySide2.QtTest import *

--- a/pyface/qt/QtWebKit.py
+++ b/pyface/qt/QtWebKit.py
@@ -29,7 +29,7 @@ elif qt_api == "pyqt5":
         from PyQt5.QtWebKitWidgets import *
 
 elif qt_api == "pyqt6":
-    from PyQt5.QtWidgets import *
+    from PyQt6.QtWidgets import *
 
     try:
         from PyQt6.QtWebEngine import *

--- a/pyface/qt/QtWebKit.py
+++ b/pyface/qt/QtWebKit.py
@@ -47,7 +47,7 @@ elif qt_api == "pyqt6":
 elif qt_api == "pyside6":
     from PySide6.QtWidgets import *
 
-    # WebKit is currently in flux in PySide2
+    # WebKit is currently in flux in PySide6
     try:
         from PySide6.QtWebEngineWidgets import (
             # QWebEngineHistory as QWebHistory,

--- a/pyface/qt/QtWebKit.py
+++ b/pyface/qt/QtWebKit.py
@@ -28,6 +28,38 @@ elif qt_api == "pyqt5":
         from PyQt5.QtWebKit import *
         from PyQt5.QtWebKitWidgets import *
 
+elif qt_api == "pyqt6":
+    from PyQt5.QtWidgets import *
+
+    try:
+        from PyQt6.QtWebEngine import *
+        from PyQt6.QtWebEngineWidgets import (
+            QWebEngineHistory as QWebHistory,
+            QWebEngineHistoryItem as QWebHistoryItem,
+            QWebEnginePage as QWebPage,
+            QWebEngineView as QWebView,
+            QWebEngineSettings as QWebSettings,
+        )
+    except ImportError:
+        from PyQt6.QtWebKit import *
+        from PyQt6.QtWebKitWidgets import *
+
+elif qt_api == "pyside6":
+    from PySide6.QtWidgets import *
+
+    # WebKit is currently in flux in PySide2
+    try:
+        from PySide6.QtWebEngineWidgets import (
+            # QWebEngineHistory as QWebHistory,
+            QWebEngineHistoryItem as QWebHistoryItem,
+            QWebEnginePage as QWebPage,
+            QWebEngineView as QWebView,
+            QWebEngineSettings as QWebSettings,
+        )
+    except ImportError:
+        from PySide6.QtWebKit import *
+        from PySide6.QtWebKitWidgets import *
+
 else:
     from PySide2.QtWidgets import *
 

--- a/pyface/qt/QtWebKit.py
+++ b/pyface/qt/QtWebKit.py
@@ -31,34 +31,28 @@ elif qt_api == "pyqt5":
 elif qt_api == "pyqt6":
     from PyQt6.QtWidgets import *
 
-    try:
-        from PyQt6.QtWebEngine import *
-        from PyQt6.QtWebEngineWidgets import (
-            QWebEngineHistory as QWebHistory,
-            QWebEngineHistoryItem as QWebHistoryItem,
-            QWebEnginePage as QWebPage,
-            QWebEngineView as QWebView,
-            QWebEngineSettings as QWebSettings,
-        )
-    except ImportError:
-        from PyQt6.QtWebKit import *
-        from PyQt6.QtWebKitWidgets import *
+    from PyQt6.QtWebEngineCore import (
+        QWebEngineHistory as QWebHistory,
+        QWebEngineHistoryItem as QWebHistoryItem,
+        QWebEnginePage as QWebPage,
+        QWebEngineSettings as QWebSettings,
+    )
+    from PyQt6.QtWebEngineWidgets import (
+        QWebEngineView as QWebView,
+    )
 
 elif qt_api == "pyside6":
     from PySide6.QtWidgets import *
 
-    # WebKit is currently in flux in PySide6
-    try:
-        from PySide6.QtWebEngineWidgets import (
-            # QWebEngineHistory as QWebHistory,
-            QWebEngineHistoryItem as QWebHistoryItem,
-            QWebEnginePage as QWebPage,
-            QWebEngineView as QWebView,
-            QWebEngineSettings as QWebSettings,
-        )
-    except ImportError:
-        from PySide6.QtWebKit import *
-        from PySide6.QtWebKitWidgets import *
+    from PySide6.QtWebEngineCore import (
+        QWebEngineHistory as QWebHistory,
+        QWebEngineSettings as QWebSettings,
+        QWebEnginePage as QWebPage,
+        QWebEngineHistoryItem as QWebHistoryItem,
+    )
+    from PySide6.QtWebEngineWidgets import (
+        QWebEngineView as QWebView,
+    )
 
 else:
     from PySide2.QtWidgets import *

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -20,6 +20,7 @@ QtAPIs = [
     ("pyqt6", "PyQt6"),
     ("pyqt", "PyQt4"),
 ]
+api_names, modules = zip(QtAPIs)
 
 
 qt_api = None
@@ -44,13 +45,13 @@ if qt_api is None:
         except ImportError:
             continue
     else:
-        raise ImportError("Cannot import PySide2, PySide6, PyQt5 or PyQt6")
+        raise ImportError("Cannot import an of " + ", ".join(modules))
 
 # otherwise check QT_API value is valid
-elif qt_api not in {api_name for api_name, module in QtAPIs}:
+elif qt_api not in api_names:
     msg = (
         "Invalid Qt API %r, valid values are: "
-        + ', '.join(f"'{api_name}'" for api_name, module in QtAPIs)
+        + ', '.join(api_names)
     ) % qt_api
     raise RuntimeError(msg)
 

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -50,7 +50,7 @@ if qt_api is None:
 elif qt_api not in {api_name for api_name, module in QtAPIs}:
     msg = (
         "Invalid Qt API %r, valid values are: "
-        + "'pyside2', 'pyside6', 'pyqt', 'pyqt5' or 'pyqt6'"
+        + ', '.join(f"'{api_name}'" for api_name, module in QtAPIs)
     ) % qt_api
     raise RuntimeError(msg)
 

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -20,7 +20,7 @@ QtAPIs = [
     ("pyqt6", "PyQt6"),
     ("pyqt", "PyQt4"),
 ]
-api_names, modules = zip(QtAPIs)
+api_names, modules = zip(*QtAPIs)
 
 
 qt_api = None
@@ -45,7 +45,7 @@ if qt_api is None:
         except ImportError:
             continue
     else:
-        raise ImportError("Cannot import an of " + ", ".join(modules))
+        raise ImportError("Cannot import any of " + ", ".join(modules))
 
 # otherwise check QT_API value is valid
 elif qt_api not in api_names:

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -15,7 +15,9 @@ import sys
 
 QtAPIs = [
     ("pyside2", "PySide2"),
+    ("pyside6", "PySide6"),
     ("pyqt5", "PyQt5"),
+    ("pyqt6", "PyQt6"),
     ("pyqt", "PyQt4"),
 ]
 
@@ -42,18 +44,19 @@ if qt_api is None:
         except ImportError:
             continue
     else:
-        raise ImportError("Cannot import PySide2, PyQt5 or PyQt4")
+        raise ImportError("Cannot import PySide2, PySide6, PyQt5 or PyQt6")
 
 # otherwise check QT_API value is valid
 elif qt_api not in {api_name for api_name, module in QtAPIs}:
     msg = (
         "Invalid Qt API %r, valid values are: "
-        + "'pyside2', 'pyqt' or 'pyqt5'"
+        + "'pyside2', 'pyside6', 'pyqt', 'pyqt5' or 'pyqt6'"
     ) % qt_api
     raise RuntimeError(msg)
 
 # useful constants
 is_qt4 = qt_api in {"pyqt"}
 is_qt5 = qt_api in {"pyqt5", "pyside2"}
-is_pyqt = qt_api in {"pyqt", "pyqt5"}
-is_pyside = qt_api in {"pyside", "pyside2"}
+is_qt6 = qt_api in {"pyqt6", "pyside6"}
+is_pyqt = qt_api in {"pyqt", "pyqt5", "pyqt6"}
+is_pyside = qt_api in {"pyside", "pyside2", "pyside6"}


### PR DESCRIPTION
This allows `QT_API` values for `pyside6` and `pyqt6` and tries to set up submodules appropriately, but no guarantees are made that the backends work with these imports.  The goal of this PR is not perfect support, but to allow Pyface and downstream projects which import from `pyface.qt` to work towards support for Qt6.

Quick testing with PySide6 shows basic functionality, but with a lot of errors due to changes in the API.  This is acceptable for now.