### PR TITLE
Fix test hangs with PySide2 / Big Sur

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   INSTALL_EDM_VERSION: 3.2.3
+  QT_MAC_WANTS_LAYER: 1
 
 jobs:
 

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -8,6 +8,7 @@ on: pull_request
 
 env:
   INSTALL_EDM_VERSION: 3.2.3
+  QT_MAC_WANTS_LAYER: 1
 
 jobs:
 


### PR DESCRIPTION
The cron job recently started hanging for builds on PySide2 / macOS; this seems likely to be related to the GitHub Actions move to macOS 11 for its workers.

This (draft) PR gives half of a fix: it fixes the cron job, but not the PR build. I'll add the other half once I've confirmed that the same problem occurs for the PR build (right now we haven't see the issue on PRs).

xref: https://github.com/enthought/pyface/runs/4558033525?check_suite_focus=true