### PR TITLE
Ensure context menu observers are unhooked correctly

### DIFF
--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 import logging
 
 from traits.api import (
-    Bool, Enum, HasStrictTraits, Instance, List, Property,
+    Bool, Enum, HasTraits, Instance, List, Property,
     TraitError, Tuple, cached_property,
 )
 
@@ -56,7 +56,7 @@ class IDataViewWidget(ILayoutWidget):
     exporters = List(Instance(AbstractDataExporter))
 
 
-class MDataViewWidget(HasStrictTraits):
+class MDataViewWidget(HasTraits):
     """ Mixin class for data view widgets. """
 
     # IDataViewWidget Interface traits --------------------------------------

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -19,13 +19,13 @@ from traits.api import (
 from pyface.data_view.abstract_data_model import AbstractDataModel
 from pyface.data_view.abstract_data_exporter import AbstractDataExporter
 from pyface.i_drop_handler import IDropHandler
-from pyface.i_widget import IWidget
+from pyface.i_layout_widget import ILayoutWidget
 
 
 logger = logging.getLogger(__name__)
 
 
-class IDataViewWidget(IWidget):
+class IDataViewWidget(ILayoutWidget):
     """ Interface for data view widgets. """
 
     #: The data model for the data view.

--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -44,16 +44,8 @@ class MField(HasTraits):
 
     def _remove_event_listeners(self):
         """ Remove toolkit-specific bindings for events """
-        if self.control is not None and self.context_menu is not None:
-            self._observe_control_context_menu(remove=True)
         self.observe(
             self._value_updated, "value", dispatch="ui", remove=True
-        )
-        self.observe(
-            self._context_menu_updated,
-            "context_menu",
-            dispatch="ui",
-            remove=True,
         )
         super()._remove_event_listeners()
 

--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -183,6 +183,14 @@ class MWidget(HasTraits):
 
     def _remove_event_listeners(self):
         """ Remove toolkit-specific bindings for events """
+        if self.control is not None and self.context_menu is not None:
+            self._observe_control_context_menu(remove=True)
+        self.observe(
+            self._context_menu_updated,
+            "context_menu",
+            dispatch="ui",
+            remove=True,
+        )
         self.observe(
             self._tooltip_updated, "tooltip", dispatch="ui", remove=True
         )

--- a/pyface/testing/widget_mixin.py
+++ b/pyface/testing/widget_mixin.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
+from unittest.mock import patch
 
 from traits.testing.api import UnittestTools
 
@@ -61,7 +62,42 @@ class WidgetMixin(UnittestTools):
 
         self.assertEqual(self.widget._get_control_tooltip(), "New tooltip.")
 
+    def test_widget_tooltip_cleanup(self):
+        widget = self._create_widget()
+        with patch.object(widget, '_tooltip_updated', return_value=None) as updated:
+            widget._create()
+            try:
+                widget.show(True)
+                self.gui.process_events()
+            finally:
+                widget.destroy()
+                self.gui.process_events()
+
+            widget.tooltip = "New tooltip."
+
+            updated.assert_not_called()
+
+        widget = None
+
     def test_widget_menu(self):
         self._create_widget_control()
         self.widget.context_menu = MenuManager(Action(name="Test"), name="Test")
+
         self.gui.process_events()
+
+    def test_widget_context_menu_cleanup(self):
+        widget = self._create_widget()
+        with patch.object(widget, '_context_menu_updated', return_value=None) as updated:
+            widget._create()
+            try:
+                widget.show(True)
+                self.gui.process_events()
+            finally:
+                widget.destroy()
+                self.gui.process_events()
+
+            widget.context_menu = MenuManager(Action(name="Test"), name="Test")
+
+            updated.assert_not_called()
+
+        widget = None


### PR DESCRIPTION
Also adds tests for unhooking tooltip observer.  In testing for this, #1067 was discovered, so this includes a fix for that.

Fixes #1063 and #1067.