### PR TITLE
Improve data view example performance by limiting colors

### DIFF
--- a/examples/data_view/example_data.py
+++ b/examples/data_view/example_data.py
@@ -14,7 +14,7 @@ This module provides some routines for randomly generating data for use
 in examples.
 """
 
-from random import choice, randint, uniform
+from random import choice, randint
 
 from pyface.color import Color
 
@@ -51,6 +51,10 @@ family_names = [
     'Montague', 'Miller',
 ]
 
+favorite_colors = [
+    Color(hsv=(hue/100, 1.0, 1.0))
+    for hue in range(100)
+]
 
 def any_name():
     return choice(all_names)
@@ -65,7 +69,7 @@ def age():
 
 
 def favorite_color():
-    return Color(hsv=(uniform(0.0, 1.0), 1.0, 1.0))
+    return choice(favorite_colors)
 
 
 def street():


### PR DESCRIPTION
This is a trivial work-around to make the data view examples more performant.

The `Color` class instances are fairly heavyweight as they have lots of observers; they are intended for the use-case where there are a handful of colors that are shared and mutable.  Before this change, the examples were creating lots of color objects.  We now instead select randomly from a much smaller set.  This dramatically improves start-up time.