### PR TITLE
Skip PySide6 on MacOS for now

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2', 'pyside6']
+        exclude:
+          - os: macos-latest
+            toolkit: pyside6
     runs-on: ${{ matrix.os }}
     env:
       # Set root directory, mainly for Windows, so that the EDM Python


### PR DESCRIPTION
Due to some change in the last week or so, the PyPI PySide6 wheels will no longer import on MacOS, Python 3.6.  Skipping for now.