### PR TITLE
Support Python 3.8 runtimes in etstool

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -180,10 +180,6 @@ dependencies = [
     }),
     Package("numpy"),
     Package("pygments"),
-    Package("pillow", {
-        ('3.6',): ('edm', "pillow"),
-        ('3.8',): ('pip', "pillow"),
-    }),
     Package("coverage"),
     Package("flake8"),
     Package("flake8-ets", {
@@ -201,6 +197,10 @@ toolkit_dependencies = {
     "pyside2": [
         Package("shiboken2", ('pip', 'pyside2')),
         Package("pyside2", ('pip', 'pyside2')),
+        Package("pillow", {
+            ('3.6',): ('edm', "pillow"),
+            ('3.8',): ('pip', "pillow"),
+        }),
     ],
     "pyside6": [
         Package("pyside6", {
@@ -208,11 +208,16 @@ toolkit_dependencies = {
             ('3.6',): ('pip', 'pyside6'),
             ('3.8',): ('edm', 'pyside6'),
         }),
+        Package("pillow", ('pip', "pillow")),
     ],
     "pyqt5": [
         Package("pyqt5", {
             ('3.6',): ('edm', 'pyqt5'),
             ('3.8',): ('pip', 'pyqt5'),
+        }),
+        Package("pillow", {
+            ('3.6',): ('edm', "pillow"),
+            ('3.8',): ('pip', "pillow"),
         }),
     ],
     "wx": [
@@ -220,7 +225,11 @@ toolkit_dependencies = {
             ('3.6', 'linux'): ('pip', "-f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1"),
             ('darwin',): ('pip', "wxPython<4.1"),
             (): ('pip', 'wxpython'),
-        })
+        }),
+        Package("pillow", {
+            ('3.6',): ('edm', "pillow"),
+            ('3.8',): ('pip', "pillow"),
+        }),
     ],
     "null": set(),
 }

--- a/etstool.py
+++ b/etstool.py
@@ -75,7 +75,6 @@ how to run commands within an EDM environment.
 from contextlib import contextmanager
 import glob
 import os
-from platform import platform
 import subprocess
 import sys
 from shutil import rmtree, copy as copyfile
@@ -188,7 +187,7 @@ dependencies = [
     Package("coverage"),
     Package("flake8"),
     Package("flake8-ets", {
-        ('3.6',): ('edm', "flake8-ets"),
+        ('3.6',): ('edm', "flake8_ets"),
         ('3.8',): ('pip', "flake8-ets"),
     }),
 ]
@@ -505,7 +504,6 @@ def docs(edm, runtime, toolkit, environment):
             else:
                 pip_packages.append(requirement)
 
-    packages = " ".join(doc_dependencies)
     ignore = " ".join(doc_ignore)
     commands = [
         "{edm} install -y -e {environment} " + " ".join(edm_packages),

--- a/etstool.py
+++ b/etstool.py
@@ -218,6 +218,7 @@ toolkit_dependencies = {
     "wx": [
         Package('wxpython', {
             ('3.6', 'linux'): ('pip', "-f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1"),
+            ('darwin',): ('pip', "wxPython<4.1"),
             (): ('pip', 'wxpython'),
         })
     ],


### PR DESCRIPTION
This is a fairly significant change because the branching if statements about which things to install how in which environment was getting confusing.  This adds a lightweight package class that for a particular runtime and platform tells you how to install the package (edm vs pip and the appropriate requirement/arguments).

This permits cleaner expression of what we actually need.

If this is good, we might copy to other etstool.py scripts.