### PR TITLE
Use colors from widget palette rather than hard-coded

### DIFF
--- a/pyface/ui/qt4/code_editor/code_widget.py
+++ b/pyface/ui/qt4/code_editor/code_widget.py
@@ -31,7 +31,7 @@ class CodeWidget(QtGui.QPlainTextEdit):
     focus_lost = QtCore.Signal()
 
     def __init__(
-        self, parent, should_highlight_current_line=True, font=None, lexer=None
+        self, parent, should_highlight_current_line=False, font=None, lexer=None
     ):
         super().__init__(parent)
 
@@ -58,7 +58,7 @@ class CodeWidget(QtGui.QPlainTextEdit):
         self.should_highlight_current_line = should_highlight_current_line
 
         # What that highlight color should be.
-        self.line_highlight_color = QtGui.QColor(QtCore.Qt.yellow).lighter(160)
+        self.line_highlight_color = self.palette().alternateBase()
 
         # Auto-indentation behavior
         self.auto_indent = True

--- a/pyface/ui/qt4/code_editor/gutters.py
+++ b/pyface/ui/qt4/code_editor/gutters.py
@@ -17,7 +17,6 @@ from pyface.qt import QtCore, QtGui
 class GutterWidget(QtGui.QWidget):
 
     min_width = 5
-    background_color = QtGui.QColor(220, 220, 220)
 
     def sizeHint(self):
         return QtCore.QSize(self.min_width, 0)
@@ -26,7 +25,7 @@ class GutterWidget(QtGui.QWidget):
         """ Paint the line numbers.
         """
         painter = QtGui.QPainter(self)
-        painter.fillRect(event.rect(), QtCore.Qt.lightGray)
+        painter.fillRect(event.rect(), self.pallette().window())
 
     def wheelEvent(self, event):
         """ Delegate mouse wheel events to parent for seamless scrolling.
@@ -52,7 +51,7 @@ class StatusGutterWidget(GutterWidget):
         """ Paint the line numbers.
         """
         painter = QtGui.QPainter(self)
-        painter.fillRect(event.rect(), self.background_color)
+        painter.fillRect(event.rect(), self.palette().window())
 
         cw = self.parent()
 
@@ -117,7 +116,7 @@ class LineNumberWidget(GutterWidget):
         """
         painter = QtGui.QPainter(self)
         painter.setFont(self.font)
-        painter.fillRect(event.rect(), self.background_color)
+        painter.fillRect(event.rect(), self.palette().window())
 
         cw = self.parent()
         block = cw.firstVisibleBlock()
@@ -129,9 +128,9 @@ class LineNumberWidget(GutterWidget):
         )
         bottom = top + int(cw.blockBoundingRect(block).height())
 
+        painter.setBrush(self.palette().windowText())
         while block.isValid() and top <= event.rect().bottom():
             if block.isVisible() and bottom >= event.rect().top():
-                painter.setPen(QtCore.Qt.black)
                 painter.drawText(
                     0,
                     top,


### PR DESCRIPTION
This means that alternate styles/dark mode, etc. should work better for these widgets.

This also changes the default for the code editor to not highlight the current line, as that color should probably have some thought put into it if it is used.  This is a technically non-backward compatible change.