### PR TITLE
Fix test failures on EDM and Python 3.8

### DIFF
--- a/pyface/tests/test_pil_image.py
+++ b/pyface/tests/test_pil_image.py
@@ -10,6 +10,7 @@
 
 
 import os
+import logging
 import unittest
 
 # importlib.resources is new in Python 3.7, and importlib.resources.files is
@@ -20,13 +21,22 @@ try:
 except ImportError:
     from importlib_resources import files
 
-from PIL import Image
+from pyface.util._optional_dependencies import optional_import
 
-from ..pil_image import PILImage
+Image = None
+
+with optional_import(
+        "pillow",
+        msg="PILImage not available due to missing pillow.",
+        logger=logging.getLogger(__name__)):
+
+    from PIL import Image
+    from ..pil_image import PILImage
 
 IMAGE_PATH = os.fspath(files("pyface.tests") / "images" / "core.png")
 
 
+@unittest.skipIf(Image is None, "Pillow not available")
 class TestPILImage(unittest.TestCase):
 
     def setUp(self):

--- a/pyface/ui/qt4/tests/test_qt_imports.py
+++ b/pyface/ui/qt4/tests/test_qt_imports.py
@@ -8,6 +8,7 @@
 #
 # Thanks for using Enthought open source!
 
+import sys
 import unittest
 import warnings
 
@@ -21,9 +22,12 @@ class TestPyfaceQtImports(unittest.TestCase):
         import pyface.qt.QtOpenGL  # noqa: F401
         import pyface.qt.QtSvg  # noqa: F401
         import pyface.qt.QtTest  # noqa: F401
-        import pyface.qt.QtWebKit  # noqa: F401
         import pyface.qt.QtMultimedia  # noqa: F401
         import pyface.qt.QtMultimediaWidgets  # noqa: F401
+
+    @unittest.skipIf(sys.version_info > (3, 6), "Web engine not supported yet")
+    def test_import_web_kit(self):
+        import pyface.qt.QtWebKit  # noqa: F401
 
     def test_import_QtScript(self):
         # QtScript is not supported on PyQt5/PySide2 and

--- a/pyface/ui/qt4/tests/test_qt_imports.py
+++ b/pyface/ui/qt4/tests/test_qt_imports.py
@@ -25,7 +25,7 @@ class TestPyfaceQtImports(unittest.TestCase):
         import pyface.qt.QtMultimedia  # noqa: F401
         import pyface.qt.QtMultimediaWidgets  # noqa: F401
 
-    @unittest.skipIf(sys.version_info > (3, 6), "Web engine not supported yet")
+    @unittest.skipIf(sys.version_info > (3, 6), "WebKit is not available")
     def test_import_web_kit(self):
         import pyface.qt.QtWebKit  # noqa: F401
 

--- a/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
@@ -9,6 +9,7 @@
 # Thanks for using Enthought open source!
 
 
+import sys
 import unittest
 from unittest import mock
 
@@ -19,9 +20,13 @@ from pyface.ui.qt4.workbench.workbench_window_layout import (
 
 
 class TestWorkbenchWindowLayout(unittest.TestCase):
+
+    @unittest.skipIf(sys.version_info == (3, 8), "Can't mock SplitTabWidget")
     def test_change_of_active_qt_editor(self):
         # Test error condition for enthought/mayavi#321
 
+        # This doesn't work on Python 3.8 because of some incompatibility
+        # between unittest.mock.Mock and Qt, I think
         mock_split_tab_widget = mock.Mock(spec=SplitTabWidget)
 
         layout = WorkbenchWindowLayout(_qt4_editor_area=mock_split_tab_widget)


### PR DESCRIPTION
These are fairly basic fixes - just skip when in an incompatible environment - but issues have been opened for more complete fixes.