### PR TITLE
Fix image memory issues

### DIFF
--- a/pyface/ui/qt4/util/image_helpers.py
+++ b/pyface/ui/qt4/util/image_helpers.py
@@ -45,7 +45,9 @@ def image_to_bitmap(image):
     bitmap : QPixmap
         The corresponding QPixmap.
     """
-    return QPixmap.fromImage(image)
+    bitmap = QPixmap.fromImage(image)
+    bitmap._image = image
+    return bitmap
 
 
 def bitmap_to_image(bitmap):

--- a/pyface/ui/qt4/util/image_helpers.py
+++ b/pyface/ui/qt4/util/image_helpers.py
@@ -46,6 +46,7 @@ def image_to_bitmap(image):
         The corresponding QPixmap.
     """
     bitmap = QPixmap.fromImage(image)
+    # keep a reference to the QImage to ensure underlying data is available
     bitmap._image = image
     return bitmap
 
@@ -168,6 +169,7 @@ def array_to_image(array):
     elif channels == 4:
         image = QImage(data.data, width, height, bytes_per_line,
                        QImage.Format.Format_ARGB32)
+    # keep a reference to the array to ensure underlying data is available
     image._numpy_data = data
     return image
 


### PR DESCRIPTION
Fixes #1108 (hopefully).

This stashes a back-reference to a `QImage` when it is used to create a `QPixmap` to ensure that the `QImage` isn't gc-d until we're done with it.

The example from TraitsUI looks like this after the fix:
![image](https://user-images.githubusercontent.com/600761/155495746-7b0349df-4673-4b5f-aeb5-eb4cf914d3af.png)

Unfortunately I don't see a way to create a regression test.

For a reviewer - to replicate set up a Windows/Python3.6/Pyside2 environment with the main branch of TraitsUI and the main branch of Pyface - you should see corruption or get a segfault.  Switching to this branch should fix the problem.