### PR TITLE
Report cron job failures to main Slack channel, not bots channel

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Notify Slack channel on failure
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel_id: ${{ secrets.ETS_BOTS_SLACK_CHANNEL_ID }}
+          channel_id: ${{ secrets.ETS_SLACK_CHANNEL_ID }}
           status: FAILED
           color: danger
         env:


### PR DESCRIPTION
This PR updates the scheduled workflows to report failures to the main ETS channel rather than the more noisy bots channel, in the hope that they're more likely to be noticed there. Successes continue to be reported to the bots channel.