### PR TITLE
Use the "sphinx-copybutton" extension in documentation

### DIFF
--- a/doc-src-requirements.txt
+++ b/doc-src-requirements.txt
@@ -1,0 +1,1 @@
+sphinx-copybutton

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     # Link to code in sphinx generated API docs
     "sphinx.ext.viewcode",
+    "sphinx_copybutton",
     'traits.util.trait_documenter'
 ]
 

--- a/etstool.py
+++ b/etstool.py
@@ -410,6 +410,8 @@ def docs(edm, runtime, toolkit, environment):
     commands = [
         "{edm} install -y -e {environment} " + packages,
         "{edm} run -e {environment} -- pip install -r doc-src-requirements.txt --no-dependencies",  # noqa: E501
+        # Temporarily install sphinx-copybutton from PyPI
+        "{edm} run -e {environment} -- pip install sphinx-copybutton"
     ]
     click.echo(
         "Installing documentation tools in  '{environment}'".format(

--- a/etstool.py
+++ b/etstool.py
@@ -410,8 +410,6 @@ def docs(edm, runtime, toolkit, environment):
     commands = [
         "{edm} install -y -e {environment} " + packages,
         "{edm} run -e {environment} -- pip install -r doc-src-requirements.txt --no-dependencies",  # noqa: E501
-        # Temporarily install sphinx-copybutton from PyPI
-        "{edm} run -e {environment} -- pip install sphinx-copybutton"
     ]
     click.echo(
         "Installing documentation tools in  '{environment}'".format(

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -24,6 +24,7 @@ __requires__ = [
     "traits>=6.2",
 ]
 __extras_require__ = {
+    "docs": ["enthought-sphinx-theme", "sphinx", "sphinx-copybutton"],
     "wx": ["wxpython>=4", "numpy"],
     "pyqt": ["pyqt>=4.10", "pygments"],
     "pyqt5": ["pyqt5", "pygments"],


### PR DESCRIPTION
This PR does the following: 
- Use the `sphinx_copybutton` extension when building the Sphinx documentation
- Create a `docs` extra for the `pyface` package and add `sphinx-copybutton` as a `docs` dependency along with `enthought-sphinx-theme` and `sphinx`
- Install `sphinx-copybutton` from PyPI when building docs using the `etstool.py` utility.

Ref https://sphinx-copybutton.readthedocs.io/en/latest/