### PR TITLE
Fix issues with last window close on recent Qt

### DIFF
--- a/pyface/ui/qt4/layout_widget.py
+++ b/pyface/ui/qt4/layout_widget.py
@@ -104,6 +104,11 @@ class LayoutWidget(MLayoutWidget, Widget):
             vertical_policy = "default"
         return (horizontal_policy, vertical_policy)
 
+    def destroy(self):
+        if self.control is not None:
+            self.control.hide()
+            super().destroy()
+
 
 def _clone_size_policy(size_policy):
     """ Clone the state of an existing QSizePolicy object

--- a/pyface/ui/qt4/tests/test_window.py
+++ b/pyface/ui/qt4/tests/test_window.py
@@ -1,0 +1,47 @@
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""
+Qt-specific tests for the Window class
+"""
+
+import unittest
+
+from pyface.api import Window
+from pyface.qt import QtGui
+from pyface.ui.qt4.util.gui_test_assistant import GuiTestAssistant
+
+
+class TestWindow(GuiTestAssistant, unittest.TestCase):
+
+    def test_close_last_window(self):
+        window = Window()
+
+        last_window_closed = []
+
+        def handle_last_window_closed():
+            last_window_closed.append('fired')
+
+        QtGui.QGuiApplication.instance().lastWindowClosed.connect(
+            handle_last_window_closed
+        )
+
+        try:
+            with self.event_loop():
+                window.create()
+
+            self.gui.invoke_later(window.control.close)
+            self.event_loop_helper.event_loop_with_timeout()
+        finally:
+            QtGui.QGuiApplication.instance().lastWindowClosed.disconnect(
+                handle_last_window_closed
+            )
+
+        self.assertEqual(last_window_closed, ['fired'])

--- a/pyface/ui/qt4/widget.py
+++ b/pyface/ui/qt4/widget.py
@@ -98,7 +98,6 @@ class Widget(MWidget, HasTraits):
 
     def destroy(self):
         if self.control is not None:
-            self.control.hide()
             self.control.deleteLater()
             super().destroy()
 

--- a/pyface/ui/qt4/window.py
+++ b/pyface/ui/qt4/window.py
@@ -119,7 +119,7 @@ class Window(MWindow, Widget):
             # so we need a reference to control
             control = self.control
 
-            # Widget.destroy() hsets self.control to None and deletes it later,
+            # Widget.destroy() sets self.control to None and deletes it later,
             # so we call it before control.close()
             # This is not strictly necessary (closing the window in fact
             # hides it), but the close may trigger an application shutdown,

--- a/pyface/ui/qt4/window.py
+++ b/pyface/ui/qt4/window.py
@@ -119,14 +119,15 @@ class Window(MWindow, Widget):
             # so we need a reference to control
             control = self.control
 
-            # Widget.destroy() hides the widget, sets self.control to None
-            # and deletes it later, so we call it before control.close()
+            # Widget.destroy() hsets self.control to None and deletes it later,
+            # so we call it before control.close()
             # This is not strictly necessary (closing the window in fact
             # hides it), but the close may trigger an application shutdown,
             # which can take a long time and may also attempt to recursively
             # destroy the window again.
             super().destroy()
             control.close()
+            control.hide()
 
     # -------------------------------------------------------------------------
     # Private interface.


### PR DESCRIPTION
This changes when `hide()` is called to ensure that `QGuiApplication.lastWindowClosed` gets emitted properly.

Fixes #1135 