### PR TITLE
BUG: Remove cycle on cleanup.

### DIFF
--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -374,6 +374,9 @@ class _Tool(HasTraits):
         """ Delete the reference to the control to avoid attempting to talk to
         it again.
         """
+        if self.control is not None:
+            # Remove the cycle since we're no longer needed.
+            del self.control._tool_instance
         self.control = None
 
     def _qt4_on_triggered(self):


### PR DESCRIPTION
This cycle does not appear to matter on PyQt5, but will persist in PySide2 and PySide6.

This cleanup is required in order to port Mayavi to PySide6, at least without adding more [test skips](https://github.com/enthought/mayavi/blob/a0b9f1ccebdbea6387329655ac0d099d029226d3/tvtk/tests/test_garbage_collection.py#L48) for Mayavi tests that try to determine if forgetting about `DecoratedScene` objects (which make toolbars) doesn't leave cycles.

I could add tests here if we wanted to introduce `gc`-using tests to pyface.