### PR TITLE
Fixes from investigating #1117

### DIFF
--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -376,7 +376,8 @@ class _Tool(HasTraits):
         """
         if self.control is not None:
             # Remove the cycle since we're no longer needed.
-            del self.control._tool_instance
+            if hasattr(self.control, "_tool_instance"):
+                del self.control._tool_instance
         self.control = None
 
     def _qt4_on_triggered(self):

--- a/pyface/ui/qt4/workbench/split_tab_widget.py
+++ b/pyface/ui/qt4/workbench/split_tab_widget.py
@@ -998,7 +998,7 @@ class _DragableTabBar(QtGui.QTabBar):
         QtGui.QTabBar.mouseReleaseEvent(self, e)
 
         if e.button() != QtCore.Qt.MouseButton.LeftButton:
-            if e.button() == QtCore.Qt.MouseButton.MidddleButton:
+            if e.button() == QtCore.Qt.MouseButton.MiddleButton:
                 self.tabCloseRequested.emit(self.tabAt(e.pos()))
             return
 

--- a/pyface/ui/qt4/workbench/split_tab_widget.py
+++ b/pyface/ui/qt4/workbench/split_tab_widget.py
@@ -998,7 +998,7 @@ class _DragableTabBar(QtGui.QTabBar):
         QtGui.QTabBar.mouseReleaseEvent(self, e)
 
         if e.button() != QtCore.Qt.MouseButton.LeftButton:
-            if e.button() == QtCore.Qt.MidddleButton:
+            if e.button() == QtCore.Qt.MouseButton.MidddleButton:
                 self.tabCloseRequested.emit(self.tabAt(e.pos()))
             return
 

--- a/pyface/ui/qt4/workbench/tests/test_split_tab_widget.py
+++ b/pyface/ui/qt4/workbench/tests/test_split_tab_widget.py
@@ -1,0 +1,34 @@
+# (C) Copyright 2005-2022 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+import unittest
+
+from pyface.qt import QtCore, QtGui
+from pyface.ui.qt4.workbench.split_tab_widget import SplitTabWidget
+
+
+class TestSplitTabWidget(unittest.TestCase):
+
+    def test_mouseReleaseEvent(self):
+        widget = SplitTabWidget(None, None)
+        event = QtGui.QMouseEvent(
+            QtCore.QEvent.Type.MouseButtonRelease,
+            QtCore.QPointF(0.0, 0.0),
+            QtCore.QPointF(0.0, 0.0),
+            QtCore.Qt.MouseButton.RightButton,
+            QtCore.Qt.RightButton,
+            QtCore.Qt.NoModifier,
+        )
+
+        # smoke test: should do nothing
+        widget.mouseReleaseEvent(event)
+
+        widget.destroy()

--- a/pyface/ui/qt4/workbench/tests/test_split_tab_widget.py
+++ b/pyface/ui/qt4/workbench/tests/test_split_tab_widget.py
@@ -12,13 +12,13 @@
 import unittest
 
 from pyface.qt import QtCore, QtGui
-from pyface.ui.qt4.workbench.split_tab_widget import SplitTabWidget
+from pyface.ui.qt4.workbench.split_tab_widget import _DragableTabBar
 
 
 class TestSplitTabWidget(unittest.TestCase):
 
     def test_mouseReleaseEvent(self):
-        widget = SplitTabWidget(None, None)
+        widget = _DragableTabBar(None, None)
         event = QtGui.QMouseEvent(
             QtCore.QEvent.Type.MouseButtonRelease,
             QtCore.QPointF(0.0, 0.0),

--- a/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
@@ -21,12 +21,8 @@ from pyface.ui.qt4.workbench.workbench_window_layout import (
 
 class TestWorkbenchWindowLayout(unittest.TestCase):
 
-    @unittest.skipIf(sys.version_info == (3, 8), "Can't mock SplitTabWidget")
     def test_change_of_active_qt_editor(self):
         # Test error condition for enthought/mayavi#321
-
-        # This doesn't work on Python 3.8 because of some incompatibility
-        # between unittest.mock.Mock and Qt, I think
         mock_split_tab_widget = mock.Mock(spec=SplitTabWidget)
 
         layout = WorkbenchWindowLayout(_qt4_editor_area=mock_split_tab_widget)

--- a/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/tests/test_workbench_window_layout.py
@@ -9,7 +9,6 @@
 # Thanks for using Enthought open source!
 
 
-import sys
 import unittest
 from unittest import mock
 

--- a/pyface/ui/qt4/workbench/workbench_window_layout.py
+++ b/pyface/ui/qt4/workbench/workbench_window_layout.py
@@ -203,8 +203,7 @@ class WorkbenchWindowLayout(MWorkbenchWindowLayout):
         view_ids = [v.id for v in self.window.views if self.contains_view(v)]
 
         # Everything else is provided by QMainWindow.
-        state = self.window.control.saveState()
-
+        state = self.window.control.saveState().data()
         return (0, (view_ids, state))
 
     def set_view_memento(self, memento):


### PR DESCRIPTION
These are some drive-by fixes from issues found when investigating #1117.  None of these actually fix the issue, however.

The changes to the state-saving code don't impact the file format, as no changes are needed for the reader (it can happily ingest both `QByteArray` and `bytes` objects).