### PR TITLE
BUG: Safe hasattr for PyQt5

### DIFF
--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2', 'pyside6']
+    timeout-minutes: 20  # should be plenty, it's usually < 5
     runs-on: ${{ matrix.os }}
     env:
       # Set root directory, mainly for Windows, so that the EDM Python

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -376,7 +376,12 @@ class _Tool(HasTraits):
         """
         if self.control is not None:
             # Remove the cycle since we're no longer needed.
-            if hasattr(self.control, "_tool_instance"):
+            try:
+                has_instance = hasattr(self.control, "_tool_instance")
+            # PyQt5 "wrapped C/C++ object ... has been deleted"
+            except RuntimeError:
+                has_instance = False
+            if has_instance:
                 del self.control._tool_instance
         self.control = None
 

--- a/pyface/ui/qt4/action/action_item.py
+++ b/pyface/ui/qt4/action/action_item.py
@@ -378,7 +378,7 @@ class _Tool(HasTraits):
             # Remove the cycle since we're no longer needed.
             try:
                 has_instance = hasattr(self.control, "_tool_instance")
-            # PyQt5 "wrapped C/C++ object ... has been deleted"
+            # fixes mayavi #1180: PyQt5 "wrapped C/C++ object ... has been deleted"
             except RuntimeError:
                 has_instance = False
             if has_instance:


### PR DESCRIPTION
Over in https://github.com/enthought/mayavi/pull/1180 I am working on VTK 9.2.2 fixes, and I am getting a segfault in CIs during GC:

https://github.com/enthought/mayavi/actions/runs/3222141217/jobs/5270891488

Locally I don't get a segfault but rather a slightly nicer error message:

```
Exceptions caught in Qt event loop:
________________________________________________________________________________
Traceback (most recent call last):
  File "/home/larsoner/python/pyface/pyface/ui/qt4/action/action_item.py", line 379, in _qt4_on_destroyed
    if hasattr(self.control, "_tool_instance"):
RuntimeError: wrapped C/C++ object of type QAction has been deleted
```

This PR fixes this by catching this `RuntimeError` during `hasattr`. Locally at least the Mayavi tests pass with PyQt5 with this change.