### PR TITLE
Add temporary pin for PySide6 version

### DIFF
--- a/etstool.py
+++ b/etstool.py
@@ -222,10 +222,10 @@ def install(edm, runtime, toolkit, environment, editable, source):
             commands.append(
                 "{edm} run -e {environment} -- pip install pyside6<6.4"
             )
-        else:
+        else:  # Windows
             parameters["pyside6"] = "pyside6 < 6.4"
             commands.append(
-                '{edm} run -e {environment} -- pip install "{pyside6}"'
+                '{edm} run -e {environment} -- pip install {pyside6}'
             )
 
         commands.append(


### PR DESCRIPTION
This PR temporarily pins the PySide6 version in CI, to give us breathing space to adapt to the backwards-incompatible Enum-related changes introduced in PySide6 6.4.0.