### PR TITLE
Fix DirectoryDialog issue on manual close (vs. cancel)

### DIFF
--- a/pyface/ui/qt4/directory_dialog.py
+++ b/pyface/ui/qt4/directory_dialog.py
@@ -52,7 +52,10 @@ class DirectoryDialog(MDirectoryDialog, Dialog):
 
     def close(self):
         # Get the path of the chosen directory.
-        files = self.control.selectedFiles()
+        if self.control is not None:
+            files = self.control.selectedFiles()
+        else:
+            files = []
 
         if files:
             self.path = str(files[0])

--- a/pyface/ui/qt4/file_dialog.py
+++ b/pyface/ui/qt4/file_dialog.py
@@ -102,9 +102,10 @@ class FileDialog(MFileDialog, Dialog):
         self.directory, self.filename = os.path.split(self.path)
 
         # Get the index of the selected filter.
-        self.wildcard_index = self.control.nameFilters().index(
-            self.control.selectedNameFilter()
-        )
+        if self.control is not None:
+            self.wildcard_index = self.control.nameFilters().index(
+                self.control.selectedNameFilter()
+            )
 
         # Let the window close as normal.
         super().close()

--- a/pyface/ui/qt4/file_dialog.py
+++ b/pyface/ui/qt4/file_dialog.py
@@ -86,7 +86,10 @@ class FileDialog(MFileDialog, Dialog):
 
     def close(self):
         # Get the path of the chosen directory.
-        files = self.control.selectedFiles()
+        if self.control is not None:
+            files = self.control.selectedFiles()
+        else:
+            files = []
 
         if files:
             self.path = str(files[0])


### PR DESCRIPTION
This guards against the control having been deleted when we try to get the paths.

Fixes #1158.
