### PR TITLE
Explicitly convert float to int in gutter widget

### DIFF
--- a/pyface/ui/qt4/code_editor/gutters.py
+++ b/pyface/ui/qt4/code_editor/gutters.py
@@ -133,7 +133,7 @@ class LineNumberWidget(GutterWidget):
             if block.isVisible() and bottom >= event.rect().top():
                 painter.drawText(
                     0,
-                    top,
+                    int(top),
                     self.width() - 2,
                     self.fontMetrics().height(),
                     QtCore.Qt.AlignmentFlag.AlignRight,


### PR DESCRIPTION
Fixes #1167 

This should prevent deprecation warnings/errors on more recent versions of Python.