### PR TITLE
CI changes for Ubuntu 22.04

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2']
+      exclude:
+        os: ubuntu-latest
+        toolkit: 'wx'
     runs-on: ${{ matrix.os }}
     env:
       # Set root directory, mainly for Windows, so that the EDM Python

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -30,14 +30,14 @@ jobs:
       - name: Install Qt dependencies for Linux
         run: |
           sudo apt-get update
-          sudo apt-get install qt5-default
+          sudo apt-get install libegl1
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
           sudo apt-get install libxcb-image0
           sudo apt-get install libxcb-keysyms1
           sudo apt-get install libxcb-randr0
           sudo apt-get install libxcb-render-util0
-          sudo apt-get install libxcb-xinerama0
+          sudo apt-get install libxcb-shape0
           sudo apt-get install pulseaudio
           sudo apt-get install libpulse-mainloop-glib0
         shell: bash
@@ -62,10 +62,12 @@ jobs:
         run: edm install -y wheel click coverage
       - name: Install test environment
         run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }} --source
-      - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
+      - name: Run tests (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: xvfb-run -a edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
+      - name: Run tests (not Linux)
+        if: matrix.os != 'ubuntu-latest'
+        run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
 
   notify-on-failure:
     needs: test-with-edm

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2']
-      exclude:
-        os: ubuntu-latest
-        toolkit: 'wx'
+        exclude:
+          - os: ubuntu-latest
+            toolkit: 'wx'
     runs-on: ${{ matrix.os }}
     env:
       # Set root directory, mainly for Windows, so that the EDM Python

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -33,6 +33,10 @@ jobs:
       - name: Install Qt dependencies for Linux
         run: |
           sudo apt-get update
+          sudo apt-get install qtbase5-dev
+          sudo apt-get install qtchooser
+          sudo apt-get install qt5-qmake
+          sudo apt-get install qtbase5-dev-tools
           sudo apt-get install libegl1
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
@@ -40,6 +44,7 @@ jobs:
           sudo apt-get install libxcb-keysyms1
           sudo apt-get install libxcb-randr0
           sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
           sudo apt-get install libxcb-shape0
           sudo apt-get install pulseaudio
           sudo apt-get install libpulse-mainloop-glib0

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2', 'pyside6']
-      exclude:
-        os: ubuntu-latest
-        toolkit: 'wx'
+        exclude:
+          - os: ubuntu-latest
+            toolkit: 'wx'
     timeout-minutes: 20  # should be plenty, it's usually < 5
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -34,6 +34,10 @@ jobs:
       - name: Install Qt dependencies for Linux
         run: |
           sudo apt-get update
+          sudo apt-get install qtbase5-dev
+          sudo apt-get install qtchooser
+          sudo apt-get install qt5-qmake
+          sudo apt-get install qtbase5-dev-tools
           sudo apt-get install libegl1
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
@@ -41,6 +45,7 @@ jobs:
           sudo apt-get install libxcb-keysyms1
           sudo apt-get install libxcb-randr0
           sudo apt-get install libxcb-render-util0
+          sudo apt-get install libxcb-xinerama0
           sudo apt-get install libxcb-shape0
           sudo apt-get install pulseaudio
           sudo apt-get install libpulse-mainloop-glib0

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         toolkit: ['wx', 'pyqt5', 'pyside2', 'pyside6']
+      exclude:
+        os: ubuntu-latest
+        toolkit: 'wx'
     timeout-minutes: 20  # should be plenty, it's usually < 5
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Install Qt dependencies for Linux
         run: |
           sudo apt-get update
-          sudo apt-get install qt5-default
+          sudo apt-get install libegl1
           sudo apt-get install libxkbcommon-x11-0
           sudo apt-get install libxcb-icccm4
           sudo apt-get install libxcb-image0
           sudo apt-get install libxcb-keysyms1
           sudo apt-get install libxcb-randr0
           sudo apt-get install libxcb-render-util0
-          sudo apt-get install libxcb-xinerama0
+          sudo apt-get install libxcb-shape0
           sudo apt-get install pulseaudio
           sudo apt-get install libpulse-mainloop-glib0
           sudo apt-get install libgstreamer-gl1.0-0
@@ -64,7 +64,9 @@ jobs:
         run: edm install -y wheel click coverage
       - name: Install test environment
         run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }}
-      - name: Run tests
-        uses: GabrielBB/xvfb-action@v1
-        with:
-          run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
+      - name: Run tests (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: xvfb-run -a edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}
+      - name: Run tests (not Linux)
+        if: matrix.os != 'ubuntu-latest'
+        run: edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}

--- a/etstool.py
+++ b/etstool.py
@@ -239,7 +239,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
         elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1"  # noqa: E501
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ wxPython"  # noqa: E501
             )
         else:
             commands.append(

--- a/etstool.py
+++ b/etstool.py
@@ -239,7 +239,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
         elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1.0"  # noqa: E501
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1"  # noqa: E501
             )
         else:
             commands.append(

--- a/etstool.py
+++ b/etstool.py
@@ -239,7 +239,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
         elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/ wxPython<4.2.0"  # noqa: E501
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/ wxPython<4.1.0"  # noqa: E501
             )
         else:
             commands.append(

--- a/etstool.py
+++ b/etstool.py
@@ -239,7 +239,7 @@ def install(edm, runtime, toolkit, environment, editable, source):
         elif sys.platform == "linux":
             # XXX this is mainly for TravisCI workers; need a generic solution
             commands.append(
-                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-22.04/ wxPython"  # noqa: E501
+                "{edm} run -e {environment} -- pip install -f https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-20.04/ wxPython<4.2.0"  # noqa: E501
             )
         else:
             commands.append(


### PR DESCRIPTION
This PR fixes CI for Ubuntu 22.04 so that it is back into a working state.  To this end it:

- updates the Qt debian packages
- removes the use of `GabrielBB/xvfb-action@v1` (`xvfb` is in the default 22.04 image)
- removes linux/wx tests as we don't have a compatible wxpython wheel/egg for ubuntu 22.04/wxPython 4.0