### PR TITLE
Remove 'parent' argument from wx StatusBarManager

### DIFF
--- a/pyface/ui/wx/action/status_bar_manager.py
+++ b/pyface/ui/wx/action/status_bar_manager.py
@@ -50,7 +50,7 @@ class StatusBarManager(HasTraits):
 
         return self.status_bar
 
-    def destroy(self, parent):
+    def destroy(self):
         """ Removes a status bar. """
 
         if self.status_bar is not None:

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -222,7 +222,7 @@ class ApplicationWindow(MApplicationWindow, Window):
         if self.control is not None:
             if old is not None:
                 self.control.SetStatusBar(None)
-                old.destroy(self.control)
+                old.destroy()
             self._create_status_bar(self.control)
 
     @observe("tool_bar_manager, tool_bar_managers.items")


### PR DESCRIPTION
Another small fix:

Remove the 'parent' argument from 'StatusBarManager.destroy' in the wx backend. The argument is unused, and doesn't match the interface definition.

If you prefer keeping the argument (to not break applications which may pass it explicitly?), I'd propose adding a default `=None`, and emitting a deprecation warning.