### PR TITLE
Change assert to warning in SplitTabWidget

### DIFF
--- a/pyface/ui/qt4/workbench/split_tab_widget.py
+++ b/pyface/ui/qt4/workbench/split_tab_widget.py
@@ -17,6 +17,7 @@
 
 
 import sys
+import warnings
 
 
 from pyface.qt import QtCore, QtGui, qt_api
@@ -121,8 +122,8 @@ class SplitTabWidget(QtGui.QSplitter):
         callable returns the restored widget.
         """
 
-        # Ensure we are not restoring to a non-empty widget.
-        assert self.count() == 0
+        # Warn if we are restoring to a non-empty widget.
+        warnings.warn("Attempting to restore to a non-empty widget.")
 
         self._restore_qsplitter(state, factory, self)
 


### PR DESCRIPTION
Hi,

this should fix https://github.com/enthought/mayavi/issues/1163. As suggested by @corranwebster there the assertion error is replaced by a warning.
