### PR TITLE
Use `exec` instead of `exec_` where possible for Qt

### DIFF
--- a/pyface/ui/qt4/code_editor/code_widget.py
+++ b/pyface/ui/qt4/code_editor/code_widget.py
@@ -839,4 +839,7 @@ if __name__ == "__main__":
 
     window.resize(640, 640)
     window.show()
-    sys.exit(app.exec_())
+    if hasattr(app, "exec"):
+        sys.exit(app.exec())
+    else:
+        sys.exit(app.exec_())

--- a/pyface/ui/qt4/confirmation_dialog.py
+++ b/pyface/ui/qt4/confirmation_dialog.py
@@ -53,9 +53,7 @@ class ConfirmationDialog(MConfirmationDialog, Dialog):
 
     # If we create custom buttons with the various roles, then we need to
     # keep track of the buttons so we can see what the user clicked.  It's
-    # not correct nor sufficient to check the return result from QMessageBox.exec_().
-    # (As of Qt 4.5.1, even clicking a button with the YesRole would lead to
-    # exec_() returning QDialog.DialogCode.Rejected.
+    # not correct nor sufficient to check the return result from QMessageBox.exec().
     _button_result_map = Dict()
 
     # ------------------------------------------------------------------------
@@ -127,7 +125,10 @@ class ConfirmationDialog(MConfirmationDialog, Dialog):
 
     def _show_modal(self):
         self.control.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
-        retval = self.control.exec_()
+        if hasattr(self.control, "exec"):
+            retval = self.control.exec()
+        else:
+            retval = self.control.exec_()
         if self.control is None:
             # dialog window closed
             if self.cancel:

--- a/pyface/ui/qt4/console/console_widget.py
+++ b/pyface/ui/qt4/console/console_widget.py
@@ -597,7 +597,12 @@ class ConsoleWidget(QtGui.QWidget):
         """
         if not printer:
             printer = QtGui.QPrinter()
-            if QtGui.QPrintDialog(printer).exec_() != QtGui.QDialog.DialogCode.Accepted:
+            dialog = QtGui.QPrintDialog(printer)
+            if hasattr(dialog, "exec"):
+                result = dialog.exec()
+            else:
+                result = dialog.exec_()
+            if result != QtGui.QDialog.DialogCode.Accepted:
                 return
         self._control.print_(printer)
 
@@ -616,7 +621,11 @@ class ConsoleWidget(QtGui.QWidget):
             root, ext = os.path.splitext(self._filename)
             if ext.lower() in (".xml", ".xhtml"):
                 dialog.selectNameFilter(filters[-1])
-        if dialog.exec_():
+        if hasattr(dialog, "exec"):
+            result = dialog.exec()
+        else:
+            result = dialog.exec_()
+        if result:
             filename = str(dialog.selectedFiles()[0])
             self._filename = filename
             choice = str(dialog.selectedNameFilter())
@@ -688,8 +697,11 @@ class ConsoleWidget(QtGui.QWidget):
             layout.addWidget(checkbox)
             widget.setLayout(layout)
             widget.show()
-            reply = box.exec_()
-            inline = reply == 0
+            if hasattr(box, "exec"):
+                reply = box.exec()
+            else:
+                reply = box.exec_()
+            inline = (reply == 0)
             if checkbox.checkState():
                 # don't ask anymore, always use this choice
                 if inline:
@@ -2029,4 +2041,7 @@ class ConsoleWidget(QtGui.QWidget):
         """ Shows a context menu at the given QPoint (in widget coordinates).
         """
         menu = self._context_menu_make(pos)
-        menu.exec_(self._control.mapToGlobal(pos))
+        if hasattr(menu, "exec"):
+            menu.exec(self._control.mapToGlobal(pos))
+        else:
+            menu.exec_(self._control.mapToGlobal(pos))

--- a/pyface/ui/qt4/dialog.py
+++ b/pyface/ui/qt4/dialog.py
@@ -145,7 +145,10 @@ class Dialog(MDialog, Window):
             dialog.windowFlags() & ~QtCore.Qt.WindowType.WindowContextHelpButtonHint
         )
 
-        retval = dialog.exec_()
+        if hasattr(self.control, "exec"):
+            retval = self.control.exec()
+        else:
+            retval = self.control.exec_()
         return _RESULT_MAP[retval]
 
     # -------------------------------------------------------------------------

--- a/pyface/ui/qt4/single_choice_dialog.py
+++ b/pyface/ui/qt4/single_choice_dialog.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 
-from pyface.qt import QtCore, QtGui, qt_api
+from pyface.qt import QtCore, QtGui
 
 from traits.api import Any, List, Str, provides
 

--- a/pyface/ui/qt4/single_choice_dialog.py
+++ b/pyface/ui/qt4/single_choice_dialog.py
@@ -9,7 +9,7 @@
 # Thanks for using Enthought open source!
 
 
-from pyface.qt import QtCore, QtGui
+from pyface.qt import QtCore, QtGui, qt_api
 
 from traits.api import Any, List, Str, provides
 
@@ -60,7 +60,10 @@ class SingleChoiceDialog(MSingleChoiceDialog, Dialog):
 
     def _show_modal(self):
         self.control.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
-        retval = self.control.exec_()
+        if qt_api == 'pyside2':
+            retval = self.control.exec_()
+        else:
+            retval = self.control.exec()
         if self.control is None:
             # dialog window closed, treat as Cancel, nullify choice
             retval = CANCEL

--- a/pyface/ui/qt4/single_choice_dialog.py
+++ b/pyface/ui/qt4/single_choice_dialog.py
@@ -60,10 +60,10 @@ class SingleChoiceDialog(MSingleChoiceDialog, Dialog):
 
     def _show_modal(self):
         self.control.setWindowModality(QtCore.Qt.WindowModality.ApplicationModal)
-        if qt_api == 'pyside2':
-            retval = self.control.exec_()
-        else:
+        if hasattr(self.control, 'exec'):
             retval = self.control.exec()
+        else:
+            retval = self.control.exec_()
         if self.control is None:
             # dialog window closed, treat as Cancel, nullify choice
             retval = CANCEL

--- a/pyface/ui/qt4/tasks/split_editor_area_pane.py
+++ b/pyface/ui/qt4/tasks/split_editor_area_pane.py
@@ -952,7 +952,10 @@ class DraggableTabWidget(QtGui.QTabWidget):
             menu = self.editor_area.get_context_menu(pos=global_pos)
             if menu is not None:
                 qmenu = menu.create_menu(self)
-                qmenu.exec_(global_pos)
+                if hasattr(qmenu, 'exec'):
+                    qmenu.exec(global_pos)
+                else:
+                    qmenu.exec_(global_pos)
 
     def dragEnterEvent(self, event):
         """ Re-implemented to highlight the tabwidget on drag enter
@@ -1026,7 +1029,10 @@ class DraggableTabBar(QtGui.QTabBar):
                 drag.setPixmap(self.drag_obj.get_pixmap())
                 drag.setHotSpot(self.drag_obj.get_hotspot())
                 drag.setMimeData(mimedata)
-                drag.exec_()
+                if hasattr(drag, 'exec'):
+                    drag.exec()
+                else:
+                    drag.exec_()
                 self.drag_obj = None  # deactivate the drag_obj again
                 return
         return super().mouseMoveEvent(event)

--- a/pyface/ui/qt4/util/event_loop_helper.py
+++ b/pyface/ui/qt4/util/event_loop_helper.py
@@ -160,7 +160,10 @@ class EventLoopHelper(HasStrictTraits):
             timeout_timer.start()
             condition_timer.start()
             try:
-                self.qt_app.exec_()
+                if hasattr(self.qt_app, 'exec'):
+                    self.qt_app.exec()
+                else:
+                    self.qt_app.exec_()
                 if not condition_result:
                     if condition_result is None:
                         status = "without evaluating condition"
@@ -203,7 +206,10 @@ class EventLoopHelper(HasStrictTraits):
         widget.destroyed.connect(self.qt_app.quit)
         yield
         timer.start()
-        self.qt_app.exec_()
+        if hasattr(self.qt_app, 'exec'):
+            self.qt_app.exec()
+        else:
+            self.qt_app.exec_()
         if not timer.isActive():
             # We exited the event loop on timeout
             raise ConditionTimeoutError(

--- a/pyface/ui/qt4/util/testing.py
+++ b/pyface/ui/qt4/util/testing.py
@@ -48,7 +48,10 @@ def delete_widget(widget, timeout=1.0):
     yield
 
     timer.start()
-    app.exec_()
+    if hasattr(app, 'exec'):
+        app.exec()
+    else:
+        app.exec_()
 
     if not timer.isActive():
         # We exited the event loop on timeout.

--- a/pyface/util/guisupport.py
+++ b/pyface/util/guisupport.py
@@ -152,7 +152,10 @@ def start_event_loop_qt4(app=None):
         app = get_app_qt4([""])
     if not is_event_loop_running_qt4(app):
         app._in_event_loop = True
-        app.exec_()
+        if hasattr(app, 'exec'):
+            app.exec()
+        else:
+            app.exec_()
         app._in_event_loop = False
     else:
         app._in_event_loop = True


### PR DESCRIPTION
This uses `hasattr` to test whether `exec` is available, which should be all Qt backends except PySide2.

Fixes #1179 and is more complete than #1198