### PR TITLE
Workaround for end-of-process segfault on Linux

### DIFF
--- a/pyface/ui/qt4/gui.py
+++ b/pyface/ui/qt4/gui.py
@@ -161,7 +161,7 @@ class _FutureCall(QtCore.QObject):
 
         # Move to the main GUI thread if necessary.
         # Note that calling QApplication.thread() seems to cause an
-        # atexit-time segfault on Linux.
+        # atexit-time segfault on Linux under some versions of PySide6.
         # xref: https://bugreports.qt.io/browse/PYSIDE-2254
         # xref: https://github.com/enthought/pyface/issues/1211
         if threading.current_thread() != threading.main_thread():

--- a/pyface/ui/qt4/gui.py
+++ b/pyface/ui/qt4/gui.py
@@ -159,7 +159,11 @@ class _FutureCall(QtCore.QObject):
         finally:
             self._calls_mutex.unlock()
 
-        # Move to the main GUI thread.
+        # Move to the main GUI thread if necessary.
+        # Note that calling QApplication.thread() seems to cause an
+        # atexit-time segfault on Linux.
+        # xref: https://bugreports.qt.io/browse/PYSIDE-2254
+        # xref: https://github.com/enthought/pyface/issues/1211
         if threading.current_thread() != threading.main_thread():
             self.moveToThread(QtGui.QApplication.instance().thread())
 

--- a/pyface/ui/qt4/gui.py
+++ b/pyface/ui/qt4/gui.py
@@ -13,6 +13,7 @@
 
 
 import logging
+import threading
 
 
 from pyface.qt import QtCore, QtGui
@@ -159,7 +160,8 @@ class _FutureCall(QtCore.QObject):
             self._calls_mutex.unlock()
 
         # Move to the main GUI thread.
-        self.moveToThread(QtGui.QApplication.instance().thread())
+        if threading.current_thread() != threading.main_thread():
+            self.moveToThread(QtGui.QApplication.instance().thread())
 
         # Post an event to be dispatched on the main GUI thread. Note that
         # we do not call QTimer.singleShot here, which would be simpler, because


### PR DESCRIPTION
On Linux, calling `QApplication.thread()` appears to cause an end-of-process segfault. We've been seeing this in the test suites of several applications using the ETS stack.

I've opened an upstream bug report here: https://bugreports.qt.io/browse/PYSIDE-2254

In the meantime, we can avoid _most_ calls to `QApplication.thread` (those not involving a background thread): it's used in a `moveToThread` operation, but we can skip that operation if the current thread _is_ the GUI thread.

This PR makes that change, and adds issue references. I suspect we'll still have the end-of-process segfault problem from code that uses `GUI.invoke_after` / `GUI.invoke_later` / `GUI.set_trait_later` etc. from background threads.