### PR TITLE
Don't list pyface as a dependency of pyface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
 ]
 dependencies = [
     'importlib-resources>=1.1.0; python_version<"3.9"',
-    'pyface',
     'traits>=6.2',
 ]
 version = '8.0.0.dev0'


### PR DESCRIPTION
I just noticed in passing that `pyface` lists `pyface` as a dependency. This PR fixes that.
