### PR TITLE
Add missing importlib-metadata dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ classifiers = [
     'Programming Language :: Python :: 3',
 ]
 dependencies = [
+    'importlib-metadata>=3.6; python_version<"3.10"',
     'importlib-resources>=1.1.0; python_version<"3.9"',
     'traits>=6.2',
 ]


### PR DESCRIPTION
This PR adds a missing dependency for `importlib_metadata`.

Strictly, we only need `importlib_metadata` for Python < 3.8. But using it for all Python < 3.10 allows us to use a uniform interface when dealing with entry points.
