### PR TITLE
Add `parent` argument to `IWidget.create()`

### DIFF
--- a/examples/application/python_shell/python_shell_window.py
+++ b/examples/application/python_shell/python_shell_window.py
@@ -74,7 +74,7 @@ class PythonShellWindow(ApplicationWindow):
     icon = ImageResource("python_icon")
 
     #: The Python shell widget to use.
-    shell = Instance("pyface.i_python_shell.IPythonShell")
+    shell = Instance("pyface.i_python_shell.IPythonShell", allow_none=False)
 
     def do_run_file(self):
         """ Run a file selected by the user. """
@@ -85,9 +85,12 @@ class PythonShellWindow(ApplicationWindow):
 
     def _create_contents(self, parent):
         """ Create the shell widget. """
-        self.shell = PythonShell()
         self.shell.create(parent)
         return self.shell.control
+
+    def destroy(self):
+        self.shell.destroy()
+        super().destroy()
 
     def _menu_bar_manager_default(self):
         menu_bar = MenuBarManager(
@@ -118,6 +121,9 @@ class PythonShellWindow(ApplicationWindow):
 
     def _status_bar_manager_default(self):
         return StatusBarManager()
+
+    def _shell_default(self):
+        return PythonShell()
 
 
 if __name__ == "__main__":

--- a/examples/application/python_shell/python_shell_window.py
+++ b/examples/application/python_shell/python_shell_window.py
@@ -85,7 +85,8 @@ class PythonShellWindow(ApplicationWindow):
 
     def _create_contents(self, parent):
         """ Create the shell widget. """
-        self.shell = PythonShell(parent)
+        self.shell = PythonShell()
+        self.shell.create(parent)
         return self.shell.control
 
     def _menu_bar_manager_default(self):

--- a/examples/data_view/array_example.py
+++ b/examples/data_view/array_example.py
@@ -43,10 +43,23 @@ class MainWindow(ApplicationWindow):
             logger.exception()
 
     def _create_contents(self, parent):
-        """ Creates the left hand side or top depending on the style. """
+        self.data_view.create(parent)
+        return self.data_view.control
 
-        self.data_view = DataViewWidget(
-            parent=parent,
+    def destroy(self):
+        self.data_view.destroy()
+        super().destroy()
+
+    @observe('data')
+    def _data_updated(self, event):
+        if self.data_view is not None:
+            self.data_view.data_model.data = self.data
+
+    def _data_default(self):
+        return np.random.uniform(size=(10000, 10, 10)) * 1000000
+
+    def _data_view_default(self):
+        return DataViewWidget(
             data_model=ArrayDataModel(
                 data=self.data,
                 value_type=FloatValue(),
@@ -61,20 +74,6 @@ class MainWindow(ApplicationWindow):
                 FileDropHandler(extensions=['.npy'], open_file=self.load_data),
             ],
         )
-        self.data_view.create()
-        return self.data_view.control
-
-    def destroy(self):
-        self.data_view.destroy()
-        super().destroy()
-
-    @observe('data')
-    def _data_updated(self, event):
-        if self.data_view is not None:
-            self.data_view.data_model.data = self.data
-
-    def _data_default(self):
-        return np.random.uniform(size=(10000, 10, 10))*1000000
 
 
 # Application entry point.

--- a/examples/data_view/column_example.py
+++ b/examples/data_view/column_example.py
@@ -122,28 +122,7 @@ class MainWindow(ApplicationWindow):
     data_view = Instance(IDataViewWidget)
 
     def _create_contents(self, parent):
-        """ Creates the left hand side or top depending on the style. """
-
-        self.data_view = DataViewWidget(
-            parent=parent,
-            data_model=ColumnDataModel(
-                data=self.data,
-                row_info=self.row_info,
-            ),
-            selection_mode='extended',
-            exporters=[
-                RowExporter(
-                    format=table_format,
-                    column_headers=True,
-                    row_headers=True,
-                ),
-                RowExporter(
-                    format=csv_format,
-                    column_headers=True,
-                ),
-            ]
-        )
-        self.data_view.create()
+        self.data_view.create(parent)
         return self.data_view.control
 
     def _data_default(self):
@@ -163,6 +142,26 @@ class MainWindow(ApplicationWindow):
         ]
         logger.info("Data initialized")
         return people
+
+    def _data_view_default(self):
+        return DataViewWidget(
+            data_model=ColumnDataModel(
+                data=self.data,
+                row_info=self.row_info,
+            ),
+            selection_mode='extended',
+            exporters=[
+                RowExporter(
+                    format=table_format,
+                    column_headers=True,
+                    row_headers=True,
+                ),
+                RowExporter(
+                    format=csv_format,
+                    column_headers=True,
+                ),
+            ]
+        )
 
     def destroy(self):
         self.data_view.destroy()

--- a/examples/data_view/row_table_example.py
+++ b/examples/data_view/row_table_example.py
@@ -109,16 +109,7 @@ class MainWindow(ApplicationWindow):
 
     def _create_contents(self, parent):
         """ Creates the left hand side or top depending on the style. """
-
-        self.data_view = DataViewWidget(
-            parent=parent,
-            data_model=RowTableDataModel(
-                data=self.data,
-                row_header_data=row_header_data,
-                column_data=column_data
-            ),
-        )
-        self.data_view.create()
+        self.data_view.create(parent)
         return self.data_view.control
 
     def _data_default(self):
@@ -138,6 +129,15 @@ class MainWindow(ApplicationWindow):
         ]
         logger.info("Data initialized")
         return people
+
+    def _data_view_default(self):
+        return DataViewWidget(
+            data_model=RowTableDataModel(
+                data=self.data,
+                row_header_data=row_header_data,
+                column_data=column_data
+            ),
+        )
 
     def destroy(self):
         self.data_view.destroy()

--- a/examples/expandable.py
+++ b/examples/expandable.py
@@ -41,8 +41,8 @@ class MainWindow(SplitApplicationWindow):
     def _create_lhs(self, parent):
         """ Creates the left hand side or top depending on the split. """
 
-        self._expandable = expandable = ExpandablePanel(parent)
-        self._expandable.create()
+        self._expandable = expandable = ExpandablePanel()
+        self._expandable.create(parent)
 
         for i in range(10):
             panel = self._create_content(expandable.control)

--- a/examples/python_editor.py
+++ b/examples/python_editor.py
@@ -10,6 +10,7 @@
 
 """ Python editor example. """
 
+from traits.api import Instance
 
 from pyface.api import ApplicationWindow, FileDialog, GUI, OK, PythonEditor
 from pyface.action.api import (
@@ -21,11 +22,15 @@ from pyface.action.api import (
     ToolBarManager,
 )
 from pyface.fields.api import ComboField
+from pyface.i_python_editor import IPythonEditor
 from pyface.toolkit import toolkit_object
 
 
 class MainWindow(ApplicationWindow):
     """ The main application window. """
+
+    #: The PythonEditor instance
+    _editor = Instance(IPythonEditor)
 
     # ------------------------------------------------------------------------
     # 'object' interface.
@@ -36,6 +41,9 @@ class MainWindow(ApplicationWindow):
 
         # Base class constructor.
         super().__init__(**traits)
+
+        # The main editor Widget
+        self._editor = PythonEditor()
 
         # Add a menu bar.
         self.menu_bar_manager = MenuBarManager(
@@ -99,10 +107,13 @@ class MainWindow(ApplicationWindow):
 
     def _create_contents(self, parent):
         """ Create the editor. """
-
-        self._editor = PythonEditor(parent)
-
+        self._editor.create(parent)
         return self._editor.control
+
+    def destroy(self):
+        if self._editor is not None:
+            self._editor.destroy()
+        super().destroy()
 
     # ------------------------------------------------------------------------
     # Private interface.

--- a/examples/python_shell.py
+++ b/examples/python_shell.py
@@ -12,11 +12,15 @@
 
 
 from pyface.api import ApplicationWindow, GUI, PythonShell
-from pyface.action.api import Action, MenuManager, MenuBarManager
+from pyface.i_python_shell import IPythonShell
+from traits.api import Instance
 
 
 class MainWindow(ApplicationWindow):
     """ The main application window. """
+
+    #: The PythonShell that forms the contents of the window
+    _shell = Instance(IPythonShell, allow_none=False)
 
     # 'IWindow' interface --------------------------------------------------
 
@@ -32,10 +36,15 @@ class MainWindow(ApplicationWindow):
 
     def _create_contents(self, parent):
         """ Create the editor. """
-
-        self._shell = PythonShell(parent)
-
+        self._shell.create(parent)
         return self._shell.control
+
+    def destroy(self):
+        self._shell.destroy()
+        super().destroy()
+
+    def __shell_default(self):
+        return PythonShell()
 
 
 # Application entry point.

--- a/examples/traitsui_window.py
+++ b/examples/traitsui_window.py
@@ -13,7 +13,7 @@
 
 from pyface.api import ApplicationWindow, GUI
 from traits.api import Enum, HasTraits, Instance, Int, Str
-from traitsui.api import View, Item
+from traitsui.api import View, Item, UI
 
 
 class Person(HasTraits):
@@ -42,14 +42,17 @@ class MainWindow(ApplicationWindow):
 
     # 'IWindow' interface --------------------------------------------------
 
-    # The size of the window.
+    #: The size of the window.
     size = (320, 240)
 
-    # The window title.
+    #: The window title.
     title = "TraitsUI Person"
 
-    # The traits object to display
+    #: The traits object to display
     person = Instance(Person, ())
+
+    #: The TraitsUI UI instance
+    _ui = Instance(UI)
 
     # ------------------------------------------------------------------------
     # Protected 'IApplication' interface.
@@ -57,8 +60,14 @@ class MainWindow(ApplicationWindow):
 
     def _create_contents(self, parent):
         """ Create the editor. """
-        self._ui = self.person.edit_traits(kind="panel", parent=parent)
+        self._ui = self.person.edit_traits(kind="subpanel", parent=parent)
         return self._ui.control
+
+    def destroy(self):
+        if self._ui is not None:
+            self._ui.dispose()
+            self._ui = None
+        super().destroy()
 
 
 # Application entry point.

--- a/pyface/data_view/i_data_view_widget.py
+++ b/pyface/data_view/i_data_view_widget.py
@@ -222,13 +222,13 @@ class MDataViewWidget(HasTraits):
     # Widget Interface
     # ------------------------------------------------------------------------
 
-    def create(self):
+    def create(self, parent=None):
         """ Creates the toolkit specific control.
 
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
         """
-        super().create()
+        super().create(parent=parent)
 
         self.show(self.visible)
         self.enable(self.enabled)

--- a/pyface/data_view/tests/test_data_view_widget.py
+++ b/pyface/data_view/tests/test_data_view_widget.py
@@ -37,13 +37,11 @@ selection_types = DataViewWidget().trait("selection_type").trait_type.values
 @requires_numpy
 class TestWidget(LayoutWidgetMixin, unittest.TestCase):
 
-    def _create_widget(self):
+    def _create_widget_simple(self, **traits):
         self.data = np.arange(120.0).reshape(4, 5, 6)
         self.model = ArrayDataModel(data=self.data, value_type=FloatValue())
-        return DataViewWidget(
-            parent=self.parent.control,
-            data_model=self.model
-        )
+        traits.setdefault("data_model", self.model)
+        return DataViewWidget(**traits)
 
     def test_defaults(self):
         self.assertTrue(self.widget.header_visible)

--- a/pyface/fields/i_field.py
+++ b/pyface/fields/i_field.py
@@ -53,13 +53,13 @@ class MField(HasTraits):
     # Private interface
     # ------------------------------------------------------------------------
 
-    def create(self):
+    def create(self, parent=None):
         """ Creates the toolkit specific control.
 
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
         """
-        super().create()
+        super().create(parent=parent)
 
         self.show(self.visible)
         self.enable(self.enabled)

--- a/pyface/fields/tests/test_combo_field.py
+++ b/pyface/fields/tests/test_combo_field.py
@@ -18,13 +18,12 @@ from .field_mixin import FieldMixin
 
 
 class TestComboField(FieldMixin, unittest.TestCase):
-    def _create_widget(self):
-        return ComboField(
-            parent=self.parent.control,
-            value="one",
-            values=["one", "two", "three", "four"],
-            tooltip="Dummy",
-        )
+
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("value", "one")
+        traits.setdefault("values", ["one", "two", "three", "four"])
+        traits.setdefault("tooltip", "Dummy")
+        return ComboField(**traits)
 
     # Tests ------------------------------------------------------------------
 

--- a/pyface/fields/tests/test_spin_field.py
+++ b/pyface/fields/tests/test_spin_field.py
@@ -16,13 +16,12 @@ from .field_mixin import FieldMixin
 
 
 class TestSpinField(FieldMixin, unittest.TestCase):
-    def _create_widget(self):
-        return SpinField(
-            parent=self.parent.control,
-            value=1,
-            bounds=(0, 100),
-            tooltip="Dummy",
-        )
+
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("value", 1)
+        traits.setdefault("bounds", (0, 100))
+        traits.setdefault("tooltip", "Dummy")
+        return SpinField(**traits)
 
     # Tests ------------------------------------------------------------------
 

--- a/pyface/fields/tests/test_text_field.py
+++ b/pyface/fields/tests/test_text_field.py
@@ -20,10 +20,11 @@ is_wx = toolkit.toolkit == "wx"
 
 
 class TestTextField(FieldMixin, unittest.TestCase):
-    def _create_widget(self):
-        return TextField(
-            parent=self.parent.control, value="test", tooltip="Dummy"
-        )
+
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("value", "test")
+        traits.setdefault("tooltip", "Dummy")
+        return TextField(**traits)
 
     # Tests ------------------------------------------------------------------
 

--- a/pyface/fields/tests/test_time_field.py
+++ b/pyface/fields/tests/test_time_field.py
@@ -18,12 +18,10 @@ from .field_mixin import FieldMixin
 
 class TestTimeField(FieldMixin, unittest.TestCase):
 
-    def _create_widget(self):
-        return TimeField(
-            parent=self.parent.control,
-            value=time(12, 0, 0),
-            tooltip="Dummy",
-        )
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("value", time(12, 0, 0))
+        traits.setdefault("tooltip", "Dummy")
+        return TimeField(**traits)
 
     # Tests ------------------------------------------------------------------
 

--- a/pyface/fields/tests/test_toggle_field.py
+++ b/pyface/fields/tests/test_toggle_field.py
@@ -60,29 +60,23 @@ class ToggleFieldMixin(FieldMixin):
 
 class TestCheckboxField(ToggleFieldMixin, unittest.TestCase):
 
-    def _create_widget(self):
-        return CheckBoxField(
-            parent=self.parent.control,
-            text="Toggle",
-            tooltip="Dummy",
-        )
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("text", "Toggle")
+        traits.setdefault("tooltip", "Dummy")
+        return CheckBoxField(**traits)
 
 
 class TestRadioButtonField(ToggleFieldMixin, unittest.TestCase):
 
-    def _create_widget(self):
-        return RadioButtonField(
-            parent=self.parent.control,
-            text="Toggle",
-            tooltip="Dummy",
-        )
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("text", "Toggle")
+        traits.setdefault("tooltip", "Dummy")
+        return RadioButtonField(**traits)
 
 
 class TestToggleButtonField(ToggleFieldMixin, unittest.TestCase):
 
-    def _create_widget(self):
-        return ToggleButtonField(
-            parent=self.parent.control,
-            text="Toggle",
-            tooltip="Dummy",
-        )
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("text", "Toggle")
+        traits.setdefault("tooltip", "Dummy")
+        return ToggleButtonField(**traits)

--- a/pyface/i_dialog.py
+++ b/pyface/i_dialog.py
@@ -177,9 +177,9 @@ class MDialog(HasTraits):
     # Protected 'IWidget' interface.
     # ------------------------------------------------------------------------
 
-    def create(self):
+    def create(self, parent=None):
         """ Creates the window's widget hierarchy. """
 
-        super().create()
+        super().create(parent=parent)
 
         self._create_contents(self.control)

--- a/pyface/i_widget.py
+++ b/pyface/i_widget.py
@@ -73,7 +73,7 @@ class IWidget(Interface):
             Whether or not the widget has keyboard focus.
         """
 
-    def create(self):
+    def create(self, parent=None):
         """ Creates the toolkit specific control.
 
         This method should create the control and assign it to the
@@ -120,12 +120,14 @@ class MWidget(HasTraits):
     #: An optional context menu for the widget.
     context_menu = Instance("pyface.action.menu_manager.MenuManager")
 
-    def create(self):
+    def create(self, parent=None):
         """ Creates the toolkit specific control.
 
         This method should create the control and assign it to the
         :py:attr:``control`` trait.
         """
+        if parent is not None:
+            self.parent = parent
         self.control = self._create_control(self.parent)
         self._initialize_control()
         self._add_event_listeners()

--- a/pyface/testing/widget_mixin.py
+++ b/pyface/testing/widget_mixin.py
@@ -37,6 +37,9 @@ class WidgetMixin(UnittestTools):
         return Window()
 
     def _create_widget(self):
+        return self._create_widget_simple(parent=self.parent.control)
+
+    def _create_widget_simple(self, **traits):
         raise NotImplementedError()
 
     def _create_widget_control(self):
@@ -54,6 +57,16 @@ class WidgetMixin(UnittestTools):
         self.widget.destroy()
         self.gui.process_events()
         self.widget = None
+
+    def test_lazy_parent_create(self):
+        self.widget = self._create_widget_simple()
+        self.widget.create(parent=self.parent.control)
+        try:
+            self.assertIsNotNone(self.widget.control)
+            self.widget.show(True)
+            self.gui.process_events()
+        finally:
+            self.widget.destroy()
 
     def test_widget_tooltip(self):
         self._create_widget_control()

--- a/pyface/tests/test_about_dialog.py
+++ b/pyface/tests/test_about_dialog.py
@@ -53,9 +53,8 @@ class TestAboutDialog(unittest.TestCase, GuiTestAssistant):
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
         parent = Window()
-        self.dialog.parent = parent.control
         with self.event_loop():
-            parent.create()
+            parent.create(parent.control)
             self.dialog.create()
 
         with self.event_loop():

--- a/pyface/tests/test_confirmation_dialog.py
+++ b/pyface/tests/test_confirmation_dialog.py
@@ -79,8 +79,7 @@ class TestConfirmationDialog(unittest.TestCase, GuiTestAssistant):
         # test that creation and destruction works as expected with a parent
         with self.event_loop():
             parent = Window()
-            self.dialog.parent = parent.control
-            parent.create()
+            parent.create(parent.control)
         with self.event_loop():
             self.dialog.create()
         with self.event_loop():

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -49,8 +49,7 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -76,8 +75,7 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_heading_text.py
+++ b/pyface/tests/test_heading_text.py
@@ -49,7 +49,7 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -75,7 +75,7 @@ class TestHeadingText(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_layered_panel.py
+++ b/pyface/tests/test_layered_panel.py
@@ -47,7 +47,7 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -62,8 +62,8 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
         layer_widget = HeadingText()
 
         with self.event_loop():
-            self.widget.create(self.window.control)
-            layer_widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
+            layer_widget.create(parent=self.window.control)
 
         try:
             with self.event_loop():
@@ -83,9 +83,9 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
         layer_widget_2 = HeadingText()
 
         with self.event_loop():
-            self.widget.create(self.window.control)
-            layer_widget_1.create(self.window.control)
-            layer_widget_2.create(self.window.control)
+            self.widget.create(parent=self.window.control)
+            layer_widget_1.create(parent=self.window.control)
+            layer_widget_2.create(parent=self.window.control)
             self.widget.add_layer("test 1", layer_widget_1.control)
             self.widget.add_layer("test 2", layer_widget_2.control)
 
@@ -114,9 +114,9 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
         layer_widget_2 = HeadingText()
 
         with self.event_loop():
-            self.widget.create(self.window.control)
-            layer_widget_1.create(self.window.control)
-            layer_widget_2.create(self.window.control)
+            self.widget.create(parent=self.window.control)
+            layer_widget_1.create(parent=self.window.control)
+            layer_widget_2.create(parent=self.window.control)
             self.widget.add_layer("test 1", layer_widget_1.control)
             self.widget.add_layer("test 2", layer_widget_2.control)
 

--- a/pyface/tests/test_layered_panel.py
+++ b/pyface/tests/test_layered_panel.py
@@ -47,8 +47,7 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -60,13 +59,11 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
     def test_add_layer(self):
         # test that a layer can be added
         self.widget = LayeredPanel()
-        with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+        layer_widget = HeadingText()
 
-        layer_widget = HeadingText(parent=self.window.control)
         with self.event_loop():
-            layer_widget.create()
+            self.widget.create(self.window.control)
+            layer_widget.create(self.window.control)
 
         try:
             with self.event_loop():
@@ -77,22 +74,18 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
         finally:
             with self.event_loop():
                 layer_widget.destroy()
-
-        with self.event_loop():
-            self.widget.destroy()
+                self.widget.destroy()
 
     def test_show_layer(self):
         # test that a layer can be shown
         self.widget = LayeredPanel()
-        with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+        layer_widget_1 = HeadingText()
+        layer_widget_2 = HeadingText()
 
-        layer_widget_1 = HeadingText(parent=self.window.control)
-        layer_widget_2 = HeadingText(parent=self.window.control)
         with self.event_loop():
-            layer_widget_1.create()
-            layer_widget_2.create()
+            self.widget.create(self.window.control)
+            layer_widget_1.create(self.window.control)
+            layer_widget_2.create(self.window.control)
             self.widget.add_layer("test 1", layer_widget_1.control)
             self.widget.add_layer("test 2", layer_widget_2.control)
 
@@ -112,22 +105,18 @@ class TestLayeredPanel(unittest.TestCase, GuiTestAssistant):
             with self.event_loop():
                 layer_widget_1.destroy()
                 layer_widget_2.destroy()
-
-        with self.event_loop():
-            self.widget.destroy()
+                self.widget.destroy()
 
     def test_has_layer(self):
         # test that a has_layer works
         self.widget = LayeredPanel()
-        with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+        layer_widget_1 = HeadingText()
+        layer_widget_2 = HeadingText()
 
-        layer_widget_1 = HeadingText(parent=self.window.control)
-        layer_widget_2 = HeadingText(parent=self.window.control)
         with self.event_loop():
-            layer_widget_1.create()
-            layer_widget_2.create()
+            self.widget.create(self.window.control)
+            layer_widget_1.create(self.window.control)
+            layer_widget_2.create(self.window.control)
             self.widget.add_layer("test 1", layer_widget_1.control)
             self.widget.add_layer("test 2", layer_widget_2.control)
 

--- a/pyface/tests/test_message_dialog.py
+++ b/pyface/tests/test_message_dialog.py
@@ -79,9 +79,8 @@ class TestMessageDialog(unittest.TestCase, GuiTestAssistant):
     def test_create_parent(self):
         # test that creation and destruction works as expected with a parent
         parent = Window()
-        self.dialog.parent = parent.control
         with self.event_loop():
-            parent.create()
+            parent.create(parent.control)
             self.dialog.create()
         with self.event_loop():
             self.dialog.destroy()

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -49,8 +49,7 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -76,8 +75,7 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_python_editor.py
+++ b/pyface/tests/test_python_editor.py
@@ -49,7 +49,7 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -75,7 +75,7 @@ class TestPythonEditor(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -50,7 +50,7 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -76,7 +76,7 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_python_shell.py
+++ b/pyface/tests/test_python_shell.py
@@ -50,8 +50,7 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -77,8 +76,7 @@ class TestPythonShell(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_single_choice_dialog.py
+++ b/pyface/tests/test_single_choice_dialog.py
@@ -66,10 +66,9 @@ class TestSingleChoiceDialog(unittest.TestCase, GuiTestAssistant):
         # test that creation and destruction works as expected with a parent
         with self.event_loop():
             parent = Window()
-            self.dialog.parent = parent.control
             parent.create()
         with self.event_loop():
-            self.dialog.create()
+            self.dialog.create(parent.control)
         with self.event_loop():
             self.dialog.destroy()
         with self.event_loop():

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -47,7 +47,7 @@ class TestSplitPanel(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -73,7 +73,7 @@ class TestSplitPanel(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.create(self.window.control)
+            self.widget.create(parent=self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_split_panel.py
+++ b/pyface/tests/test_split_panel.py
@@ -47,8 +47,7 @@ class TestSplitPanel(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 
@@ -74,8 +73,7 @@ class TestSplitPanel(unittest.TestCase, GuiTestAssistant):
         self.assertIsNone(self.widget.control)
 
         with self.event_loop():
-            self.widget.parent = self.window.control
-            self.widget.create()
+            self.widget.create(self.window.control)
 
         self.assertIsNotNone(self.widget.control)
 

--- a/pyface/tests/test_widget.py
+++ b/pyface/tests/test_widget.py
@@ -340,5 +340,6 @@ class TestConcreteWidget(unittest.TestCase, GuiTestAssistant):
 
 class TestWidgetCommon(WidgetMixin, unittest.TestCase):
 
-    def _create_widget(self):
-        return ConcreteWidget(parent=self.parent.control, tooltip='Dummy')
+    def _create_widget_simple(self, **traits):
+        traits.setdefault("tooltip", "Dummy")
+        return ConcreteWidget(**traits)

--- a/pyface/ui/qt4/application_window.py
+++ b/pyface/ui/qt4/application_window.py
@@ -129,8 +129,8 @@ class ApplicationWindow(MApplicationWindow, Window):
     # Protected 'IWidget' interface.
     # ------------------------------------------------------------------------
 
-    def create(self):
-        super().create()
+    def create(self, parent=None):
+        super().create(parent=parent)
 
         contents = self._create_contents(self.control)
         self.control.setCentralWidget(contents)

--- a/pyface/ui/qt4/progress_dialog.py
+++ b/pyface/ui/qt4/progress_dialog.py
@@ -272,8 +272,8 @@ class ProgressDialog(MProgressDialog, Window):
     def _create_control(self, parent):
         return QtGui.QDialog(parent)
 
-    def create(self):
-        super().create()
+    def create(self, parent=None):
+        super().create(parent=parent)
         self._create_contents(self.control)
 
     def _create_contents(self, parent):

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -107,9 +107,9 @@ class ApplicationWindow(MApplicationWindow, Window):
     # Protected 'IWidget' interface.
     # ------------------------------------------------------------------------
 
-    def create(self):
+    def create(self, parent=None):
 
-        super().create()
+        super().create(parent=parent)
 
         self._aui_manager = PyfaceAuiManager()
         self._aui_manager.SetManagedWindow(self.control)

--- a/pyface/ui/wx/list_box.py
+++ b/pyface/ui/wx/list_box.py
@@ -55,8 +55,8 @@ class ListBox(LayoutWidget):
                 stacklevel=2,
             )
 
-    def create(self):
-        super().create()
+    def create(self, parent=None):
+        super().create(parent=parent)
 
         self._populate()
 


### PR DESCRIPTION
Fixes #1218 

This performs the addition, plus although it is optional, uses it where it makes sense in the tests and examples.  There is a little drive-by cleanup as well.
