### PR TITLE
Expose interfaces in `pyface.api`

### DIFF
--- a/pyface/api.py
+++ b/pyface/api.py
@@ -45,6 +45,36 @@ Dialogs
 - :class:`~.SingleChoiceDialog`
 - :class:`~.SplitDialog`
 
+Interfaces
+----------
+
+- :class:`~.IAboutDialog`
+- :class:`~.IApplicationWindow`
+- :class:`~.IClipboard`
+- :class:`~.IConfirmationDialog`
+- :class:`~.IDialog`
+- :class:`~.IDirectoryDialog`
+- :class:`~.IDropHandler`
+- :class:`~.IFileDialog`
+- :class:`~.IGUI`
+- :class:`~.IHeadingText`
+- :class:`~.IImage`
+- :class:`~.IImageResource`
+- :class:`~.ILayeredPanel`
+- :class:`~.ILayoutItem`
+- :class:`~.ILayoutWidget`
+- :class:`~.IMessageDialog`
+- :class:`~.IPILImage`
+- :class:`~.IPythonEditor`
+- :class:`~.IPythonShell`
+- :class:`~.IProgressDialog`
+- :class:`~.ISingleChoiceDialog`
+- :class:`~.ISplashScreen`
+- :class:`~.ISplitWidget`
+- :class:`~.ISystemMetrics`
+- :class:`~.IWindow`
+- :class:`~.IWidget`
+
 Constants
 ---------
 
@@ -171,6 +201,37 @@ from .system_metrics import SystemMetrics
 from .ui_traits import Alignment, Border, HasBorder, HasMargin, Image, Margin
 from .window import Window
 from .widget import Widget
+
+# ----------------------------------------------------------------------------
+# Public Interfaces
+# ----------------------------------------------------------------------------
+
+# Import from pyface.interfaces if you don't want toolit side-effects
+from .i_about_dialog import IAboutDialog
+from .i_application_window import IApplicationWindow
+from .i_clipboard import IClipboard
+from .i_confirmation_dialog import IConfirmationDialog
+from .i_dialog import IDialog
+from .i_directory_dialog import IDirectoryDialog
+from .i_drop_handler import IDropHandler
+from .i_file_dialog import IFileDialog
+from .i_gui import IGUI
+from .i_heading_text import IHeadingText
+from .i_image_resource import IImageResource
+from .i_layered_panel import ILayeredPanel
+from .i_layout_item import ILayoutItem
+from .i_layout_widget import ILayoutWidget
+from .i_message_dialog import IMessageDialog
+from .i_progress_dialog import IProgressDialog
+from .i_pil_image import IPILImage
+from .i_python_editor import IPythonEditor
+from .i_python_shell import IPythonShell
+from .i_single_choice_dialog import ISingleChoiceDialog
+from .i_splash_screen import ISplashScreen
+from .i_split_widget import ISplitWidget
+from .i_system_metrics import ISystemMetrics
+from .i_window import IWindow
+from .i_widget import IWidget
 
 # ----------------------------------------------------------------------------
 # Legacy and Wx-specific imports.

--- a/pyface/tests/test_api.py
+++ b/pyface/tests/test_api.py
@@ -34,7 +34,7 @@ class TestApiQt(unittest.TestCase):
     def test_importable_items_minimal(self):
         # Test items should be importable in a minimal Qt environment
         # Pygments is excused. Attempt to import PythonEditor or PythonShell
-        # will fail in an environment without pygments will fail, just as it
+        # will fail in an environment without pygments, just as it
         # would if these items were imported directly from the corresponding
         # subpackages.
         from pyface.api import (   # noqa: F401
@@ -90,6 +90,32 @@ class TestApiQt(unittest.TestCase):
             error,
             information,
             warning,
+            # Interfaces
+            IAboutDialog,
+            IApplicationWindow,
+            IClipboard,
+            IConfirmationDialog,
+            IDialog,
+            IDirectoryDialog,
+            IDropHandler,
+            IFileDialog,
+            IGUI,
+            IHeadingText,
+            IImageResource,
+            ILayeredPanel,
+            ILayoutItem,
+            ILayoutWidget,
+            IMessageDialog,
+            IProgressDialog,
+            IPILImage,
+            IPythonEditor,
+            IPythonShell,
+            ISingleChoiceDialog,
+            ISplashScreen,
+            ISplitWidget,
+            ISystemMetrics,
+            IWindow,
+            IWidget,
         )
 
     def test_python_editor_python_shell_importable(self):
@@ -167,4 +193,30 @@ class TestApiWx(unittest.TestCase):
             fix_introspect_bug,
             information,
             warning,
+            # Interfaces
+            IAboutDialog,
+            IApplicationWindow,
+            IClipboard,
+            IConfirmationDialog,
+            IDialog,
+            IDirectoryDialog,
+            IDropHandler,
+            IFileDialog,
+            IGUI,
+            IHeadingText,
+            IImageResource,
+            ILayeredPanel,
+            ILayoutItem,
+            ILayoutWidget,
+            IMessageDialog,
+            IProgressDialog,
+            IPILImage,
+            IPythonEditor,
+            IPythonShell,
+            ISingleChoiceDialog,
+            ISplashScreen,
+            ISplitWidget,
+            ISystemMetrics,
+            IWindow,
+            IWidget,
         )


### PR DESCRIPTION
Fixes #702

I'd sort of like to have a separate "interfaces API" module (`pyface.interfaces` or `pyface.i_api`?) where these can be imported from without side-effects, but this is good enough for now.