### PR TITLE
Don't try to dispatch immediately in Qt Gui `_FutureCall`

### DIFF
--- a/pyface/ui/qt/gui.py
+++ b/pyface/ui/qt/gui.py
@@ -177,18 +177,8 @@ class _FutureCall(QtCore.QObject):
         """ QObject event handler.
         """
         if event.type() == self._pyface_event:
-            if self._ms == 0:
-                # Invoke the callable now
-                try:
-                    self._callable(*self._args, **self._kw)
-                finally:
-                    # We cannot remove from self._calls here. QObjects don't like being
-                    # garbage collected during event handlers (there are tracebacks,
-                    # plus maybe a memory leak, I think).
-                    QtCore.QTimer.singleShot(0, self._finished)
-            else:
-                # Invoke the callable (puts it at the end of the event queue)
-                QtCore.QTimer.singleShot(self._ms, self._dispatch)
+            # Invoke the callable (puts it at the end of the event queue)
+            QtCore.QTimer.singleShot(self._ms, self._dispatch)
             return True
 
         return super().event(event)


### PR DESCRIPTION
This has gone back and forth a few times, but right now unhandled exceptions in the `event` handler are causing test failures in TraitsUI on 6.4.3 and this fixes them.