### PR TITLE
Delay imports in api modules if toolkit will be imported

### DIFF
--- a/docs/source/toolkits.rst
+++ b/docs/source/toolkits.rst
@@ -23,9 +23,10 @@ ways:
     from tratis.etsconfig.api import ETSConfig
     ETSConfig.toolkit = 'qt'
 
-  This must be done _before_ any widget imports in your application, including
-  importing :py:mod:`pyface.api`.  Precisely, this must be set before the
-  first import of :py:mod:`pyface.toolkit`.
+  This must be done _before_ any widget imports in your application.
+  Precisely, this must be set before the first call to
+  :py:func:`pyface.base_toolkit.find_toolkit` (which usually happens
+  as a side-effect of importing :py:mod:`pyface.toolkit`).
 
 If for some reason Pyface can't load a deliberately specified toolkit, then it
 will raise an exception.
@@ -34,6 +35,14 @@ If the toolkit is not specified, Pyface will try to load the ``qt`` or ``wx``
 toolkits, in that order, and then any other toolkits that it knows about
 other than ``null``.  If all of those fail, then it will try to load the
 ``null`` toolkit.
+
+Pyface tries to defer toolkit selection as long as possible until it is
+actually needed because importing a toolkit tends to be slow and have
+significant side-effects. Very occasionally an application or test suite may
+need to ensure that the toolkit has been selected (for example, to enable
+"ui" dispatch from background threads in Traits).  This can be achieved by
+either importing :py:mod:`pyface.toolkit` or, more directly, by calling
+:py:func:`pyface.base_toolkit.find_toolkit`.
 
 Once selected, the toolkit infrastructure is largely transparent to the
 application.

--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -272,6 +272,8 @@ class ActionManager(HasTraits):
 
         Parameters
         ----------
+        group : Group
+            The group to walk.
         fn : callable
             A callable to apply to the tree of groups and items.
         """
@@ -290,6 +292,9 @@ class ActionManager(HasTraits):
 
         Parameters
         ----------
+        item : item
+            The item to walk.  This may be a submenu or similar in addition to
+            simple Action items.
         fn : callable
             A callable to apply to the tree of items and subgroups.
         """

--- a/pyface/action/action_manager.py
+++ b/pyface/action/action_manager.py
@@ -45,7 +45,7 @@ class ActionManager(HasTraits):
     enabled = Bool(True)
 
     #: All of the contribution groups in the manager.
-    groups = Property(List(Group))
+    groups = Property(List(Instance(Group)), observe='_groups.items')
 
     #: The manager's unique identifier (if it has one).
     id = Str()
@@ -61,7 +61,7 @@ class ActionManager(HasTraits):
     # Private interface ----------------------------------------------------
 
     #: All of the contribution groups in the manager.
-    _groups = List(Group)
+    _groups = List(Instance(Group))
 
     # ------------------------------------------------------------------------
     # 'object' interface.

--- a/pyface/action/action_manager_item.py
+++ b/pyface/action/action_manager_item.py
@@ -32,7 +32,7 @@ class ActionManagerItem(HasTraits):
     id = Str()
 
     #: The group the item belongs to.
-    parent = Instance("pyface.action.api.Group")
+    parent = Instance("pyface.action.group.Group")
 
     #: Is the item enabled?
     enabled = Bool(True)

--- a/pyface/action/api.py
+++ b/pyface/action/api.py
@@ -81,6 +81,11 @@ from .gui_application_action import (
     ExitAction,
     GUIApplicationAction,
 )
+from .i_action_manager import IActionManager
+from .i_menu_bar_manager import IMenuBarManager
+from .i_menu_manager import IMenuManager
+from .i_status_bar_manager import IStatusBarManager
+from .i_tool_bar_manager import IToolBarManager
 from .listening_action import ListeningAction
 from .traitsui_widget_action import TraitsUIWidgetAction
 from .window_action import CloseWindowAction, WindowAction

--- a/pyface/action/group.py
+++ b/pyface/action/group.py
@@ -18,7 +18,6 @@ from traits.trait_base import user_name_for
 
 
 from pyface.action.action import Action
-from pyface.action.action_item import ActionItem
 
 
 class Group(HasTraits):
@@ -151,6 +150,8 @@ class Group(HasTraits):
         action, and that is inserted.  If the item is a callable, then an
         Action is created for the callable, and then that is handled as above.
         """
+        from pyface.action.action_item import ActionItem
+
         if isinstance(item, Action):
             item = ActionItem(action=item)
         elif callable(item):

--- a/pyface/action/i_action_manager.py
+++ b/pyface/action/i_action_manager.py
@@ -1,0 +1,192 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+"""Interface for all action managers."""
+
+
+from traits.api import Bool, Constant, Event, Instance, Interface, List, Str
+
+from pyface.action.action_controller import ActionController
+from pyface.action.group import Group
+
+
+class IActionManager(Interface):
+    """ Abstract base class for all action managers.
+
+    An action manager contains a list of groups, with each group containing a
+    list of items.
+
+    There are currently three concrete sub-classes:
+
+    1) 'MenuBarManager'
+    2) 'MenuManager'
+    3) 'ToolBarManager'
+
+    """
+
+    # 'ActionManager' interface --------------------------------------------
+
+    #: The Id of the default group.
+    DEFAULT_GROUP = Constant("additions")
+
+    #: The action controller (if any) used to control how actions are performed.
+    controller = Instance(ActionController)
+
+    #: Is the action manager enabled?
+    enabled = Bool(True)
+
+    #: All of the contribution groups in the manager.
+    groups = List(Instance(Group))
+
+    #: The manager's unique identifier (if it has one).
+    id = Str()
+
+    #: Is the action manager visible?
+    visible = Bool(True)
+
+    # Events ----
+
+    #: fixme: We probably need more granular events than this!
+    changed = Event()
+
+    # ------------------------------------------------------------------------
+    # 'object' interface.
+    # ------------------------------------------------------------------------
+
+    def __init__(self, *args, **traits):
+        """ Creates a new action manager.
+
+        Parameters
+        ----------
+        args : collection of strings, Group instances, or ActionManagerItem instances
+            Positional arguments are interpreted as Items or Groups managed
+            by the action manager.
+
+        Notes
+        -----
+
+        If a Group is passed as a positional agrument then it is added to the
+        manager and any subsequent Items arguments are appended to the Group
+        until another Group is encountered.
+
+        If a string is passed, a Group is created with id set to the string.
+        """
+
+    # ------------------------------------------------------------------------
+    # 'IActionManager' interface.
+    # ------------------------------------------------------------------------
+
+    def append(self, item):
+        """ Append an item to the manager.
+
+        Parameters
+        ----------
+        item : string, Group instance or ActionManagerItem instance
+            The item to append.
+
+        Notes
+        -----
+
+        If the item is a group, the Group is appended to the manager's list
+        of groups.  It the item is a string, then a group is created with
+        the string as the ``id`` and the new group is appended to the list
+        of groups.  If the item is an ActionManagerItem then the item is
+        appended to the manager's default group.
+        """
+
+    def destroy(self):
+        """ Called when the manager is no longer required.
+
+        By default this method simply calls 'destroy' on all of the manager's
+        groups.
+        """
+
+    def insert(self, index, item):
+        """ Insert an item into the manager at the specified index.
+
+        Parameters
+        ----------
+        index : int
+            The position at which to insert the object
+        item : string, Group instance or ActionManagerItem instance
+            The item to insert.
+
+        Notes
+        -----
+
+        If the item is a group, the Group is inserted into the manager's list
+        of groups.  It the item is a string, then a group is created with
+        the string as the ``id`` and the new group is inserted into the list
+        of groups.  If the item is an ActionManagerItem then the item is
+        inserted into the manager's defualt group.
+        """
+
+    def find_group(self, id):
+        """ Find a group with a specified Id.
+
+        Parameters
+        ----------
+        id : str
+            The id of the group to find.
+
+        Returns
+        -------
+        group : Group instance
+            The group which matches the id, or None if no such group exists.
+        """
+
+    def find_item(self, path):
+        """ Find an item using a path.
+
+        Parameters
+        ----------
+        path : str
+            A '/' separated list of contribution Ids.
+
+        Returns
+        -------
+        item : ActionManagerItem or None
+            Returns the matching ActionManagerItem, or None if any component
+            of the path is not found.
+        """
+
+    def walk(self, fn):
+        """ Walk the manager applying a function at every item.
+
+        The components are walked in pre-order.
+
+        Parameters
+        ----------
+        fn : callable
+            A callable to apply to the tree of groups and items, starting with
+            the manager.
+        """
+
+    def walk_group(self, group, fn):
+        """ Walk a group applying a function at every item.
+
+        The components are walked in pre-order.
+
+        Parameters
+        ----------
+        fn : callable
+            A callable to apply to the tree of groups and items.
+        """
+
+    def walk_item(self, item, fn):
+        """ Walk an item (may be a sub-menu manager remember!).
+
+        The components are walked in pre-order.
+
+        Parameters
+        ----------
+        fn : callable
+            A callable to apply to the tree of items and subgroups.
+        """

--- a/pyface/action/i_action_manager.py
+++ b/pyface/action/i_action_manager.py
@@ -60,14 +60,16 @@ class IActionManager(Interface):
     # 'object' interface.
     # ------------------------------------------------------------------------
 
-    def __init__(self, *args, **traits):
+    def __init__(self, *items, **traits):
         """ Creates a new action manager.
 
         Parameters
         ----------
-        args : collection of strings, Group instances, or ActionManagerItem instances
-            Positional arguments are interpreted as Items or Groups managed
-            by the action manager.
+        items : collection of strings, Group, or ActionManagerItem instances
+            Positional arguments are interpreted as Items or Groups
+            managed by the action manager.
+        traits : additional traits
+            Traits to be passed to the usual Traits ``__init__``.
 
         Notes
         -----
@@ -176,6 +178,8 @@ class IActionManager(Interface):
 
         Parameters
         ----------
+        group : Group
+            The group to walk.
         fn : callable
             A callable to apply to the tree of groups and items.
         """
@@ -187,6 +191,9 @@ class IActionManager(Interface):
 
         Parameters
         ----------
+        item : item
+            The item to walk.  This may be a submenu or similar in addition to
+            simple Action items.
         fn : callable
             A callable to apply to the tree of items and subgroups.
         """

--- a/pyface/action/i_menu_bar_manager.py
+++ b/pyface/action/i_menu_bar_manager.py
@@ -1,0 +1,25 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+""" The interface for a menu bar manager. """
+
+from pyface.action.i_action_manager import IActionManager
+
+
+class IMenuBarManager(IActionManager):
+    """ The interface for a menu bar manager. """
+
+    # ------------------------------------------------------------------------
+    # 'MenuBarManager' interface.
+    # ------------------------------------------------------------------------
+
+    def create_menu_bar(self, parent, controller=None):
+        """ Creates a menu bar representation of the manager. """

--- a/pyface/action/i_menu_bar_manager.py
+++ b/pyface/action/i_menu_bar_manager.py
@@ -22,4 +22,12 @@ class IMenuBarManager(IActionManager):
     # ------------------------------------------------------------------------
 
     def create_menu_bar(self, parent, controller=None):
-        """ Creates a menu bar representation of the manager. """
+        """ Creates a menu bar representation of the manager.
+
+        Parameters
+        ----------
+        parent : toolkit control
+            The toolkit control that owns the menubar.
+        controller : ActionController
+            An optional ActionController for all items in the menubar.
+        """

--- a/pyface/action/i_menu_manager.py
+++ b/pyface/action/i_menu_manager.py
@@ -11,8 +11,8 @@
 from traits.api import Instance, Str
 
 
+from pyface.action.action import Action
 from pyface.action.i_action_manager import IActionManager
-from pyface.action.action_item import Action
 
 
 class IMenuManager(IActionManager):

--- a/pyface/action/i_menu_manager.py
+++ b/pyface/action/i_menu_manager.py
@@ -10,7 +10,6 @@
 
 from traits.api import Instance, Str
 
-
 from pyface.action.action import Action
 from pyface.action.i_action_manager import IActionManager
 
@@ -35,4 +34,12 @@ class IMenuManager(IActionManager):
     # ------------------------------------------------------------------------
 
     def create_menu(self, parent, controller=None):
-        """ Creates a menu representation of the manager. """
+        """ Creates a menu representation of the manager.
+
+        Parameters
+        ----------
+        parent : toolkit control
+            The toolkit control that owns the menu.
+        controller : ActionController
+            An optional ActionController for all items in the menu.
+        """

--- a/pyface/action/i_menu_manager.py
+++ b/pyface/action/i_menu_manager.py
@@ -1,0 +1,38 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traits.api import Instance, Str
+
+
+from pyface.action.i_action_manager import IActionManager
+from pyface.action.action_item import Action
+
+
+class IMenuManager(IActionManager):
+    """ A menu manager realizes itself in a menu control.
+
+    This could be a sub-menu or a context (popup) menu.
+    """
+
+    # 'IMenuManager' interface ---------------------------------------------#
+
+    # The menu manager's name (if the manager is a sub-menu, this is what its
+    # label will be).
+    name = Str()
+
+    # The default action for tool button when shown in a toolbar (Qt only)
+    action = Instance(Action)
+
+    # ------------------------------------------------------------------------
+    # 'IMenuManager' interface.
+    # ------------------------------------------------------------------------
+
+    def create_menu(self, parent, controller=None):
+        """ Creates a menu representation of the manager. """

--- a/pyface/action/i_status_bar_manager.py
+++ b/pyface/action/i_status_bar_manager.py
@@ -1,0 +1,37 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+
+from traits.api import Any, Bool, Interface, List, Str
+
+
+class IStatusBarManager(Interface):
+    """ The interface for a status bar manager. """
+
+    # The message displayed in the first field of the status bar.
+    message = Str()
+
+    # The messages to be displayed in the status bar fields.
+    messages = List(Str)
+
+    # The toolkit-specific control that represents the status bar.
+    status_bar = Any()
+
+    # Whether to show a size grip on the status bar.
+    size_grip = Bool(False)
+
+    # Whether the status bar is visible.
+    visible = Bool(True)
+
+    def create_status_bar(self, parent):
+        """ Creates a status bar. """
+
+    def destroy(self):
+        """ Destroys the status bar. """

--- a/pyface/action/i_status_bar_manager.py
+++ b/pyface/action/i_status_bar_manager.py
@@ -31,7 +31,13 @@ class IStatusBarManager(Interface):
     visible = Bool(True)
 
     def create_status_bar(self, parent):
-        """ Creates a status bar. """
+        """ Creates a status bar.
+
+        Parameters
+        ----------
+        parent : toolkit control
+            The toolkit control that owns the status bar.
+        """
 
     def destroy(self):
         """ Destroys the status bar. """

--- a/pyface/action/i_tool_bar_manager.py
+++ b/pyface/action/i_tool_bar_manager.py
@@ -39,4 +39,12 @@ class IToolBarManager(IActionManager):
     # ------------------------------------------------------------------------
 
     def create_tool_bar(self, parent, controller=None):
-        """ Creates a tool bar. """
+        """ Creates a tool bar.
+
+        Parameters
+        ----------
+        parent : toolkit control
+            The toolkit control that owns the toolbar.
+        controller : ActionController
+            An optional ActionController for all items in the toolbar.
+        """

--- a/pyface/action/i_tool_bar_manager.py
+++ b/pyface/action/i_tool_bar_manager.py
@@ -1,0 +1,41 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+from traits.api import Bool, Enum, Str, Tuple
+
+from pyface.action.i_action_manager import IActionManager
+
+
+class IToolBarManager(IActionManager):
+    """ The interface for a tool bar manager. """
+
+    # 'IToolBarManager' interface -------------------------------------------
+
+    # The size of tool images (width, height).
+    image_size = Tuple((16, 16))
+
+    # The toolbar name (used to distinguish multiple toolbars).
+    name = Str("ToolBar")
+
+    # The orientation of the toolbar.
+    orientation = Enum("horizontal", "vertical")
+
+    # Should we display the name of each tool bar tool under its image?
+    show_tool_names = Bool(True)
+
+    # Should we display the horizontal divider?
+    show_divider = Bool(True)
+
+    # ------------------------------------------------------------------------
+    # 'ToolBarManager' interface.
+    # ------------------------------------------------------------------------
+
+    def create_tool_bar(self, parent, controller=None):
+        """ Creates a tool bar. """

--- a/pyface/action/i_tool_bar_manager.py
+++ b/pyface/action/i_tool_bar_manager.py
@@ -8,9 +8,10 @@
 #
 # Thanks for using Enthought open source!
 
-from traits.api import Bool, Enum, Str, Tuple
+from traits.api import Bool, Str, Tuple
 
 from pyface.action.i_action_manager import IActionManager
+from pyface.ui_traits import Orientation
 
 
 class IToolBarManager(IActionManager):
@@ -25,7 +26,7 @@ class IToolBarManager(IActionManager):
     name = Str("ToolBar")
 
     # The orientation of the toolbar.
-    orientation = Enum("horizontal", "vertical")
+    orientation = Orientation("horizontal")
 
     # Should we display the name of each tool bar tool under its image?
     show_tool_names = Bool(True)

--- a/pyface/action/tests/test_api.py
+++ b/pyface/action/tests/test_api.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test for pyface.api """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    """ Test importable items in any environment."""
+
+    def test_api_importable(self):
+        # make sure api is importable with the most minimal
+        # required dependencies, including in the absence of toolkit backends.
+        from pyface.action import api   # noqa: F401
+
+    def test_public_attrs(self):
+        # make sure everything advertised by dir() is available except optional
+        from pyface.action import api
+
+        attrs = [
+            name
+            for name in dir(api)
+            if not name.startswith('_')
+        ]
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                self.assertIsNotNone(getattr(api, attr, None))

--- a/pyface/action/window_action.py
+++ b/pyface/action/window_action.py
@@ -13,11 +13,10 @@
 """ Abstract base class for all window actions. """
 
 
-from pyface.window import Window
 from traits.api import Instance, Property
 
-
 from pyface.action.listening_action import ListeningAction
+from pyface.i_window import IWindow
 
 
 class WindowAction(ListeningAction):
@@ -30,7 +29,7 @@ class WindowAction(ListeningAction):
     # 'WindowAction' interface -----------------------------------------------
 
     #: The window that the action is associated with.
-    window = Instance(Window)
+    window = Instance(IWindow)
 
     # ------------------------------------------------------------------------
     # Protected interface.

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -14,8 +14,10 @@ API for the ``pyface`` package.
 
 - :class:`~.Application`
 - :class:`~.ApplicationWindow`
+- :class:`~.BaseToolkit`
 - :attr:`~.clipboard`
 - :class:`~.Clipboard`
+- :func:`~.find_toolkit`
 - :class:`~.GUI`
 - :class:`~.GUIApplication`
 - :class:`~.ImageResource`
@@ -137,6 +139,7 @@ Wx-specific classes
 # Imports which don't select the toolkit as a side-effect.
 
 from .application import Application
+from .base_toolkit import BaseToolkit, find_toolkit
 from .color import Color
 from .constant import OK, CANCEL, YES, NO
 from .filter import Filter

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -134,87 +134,14 @@ Wx-specific classes
 
 """
 
-import logging as _logging
+# Imports which don't select the toolkit as a side-effect.
 
-from .about_dialog import AboutDialog
 from .application import Application
-from .application_window import ApplicationWindow
-from .beep import beep
-from .clipboard import clipboard, Clipboard
-from .confirmation_dialog import confirm, ConfirmationDialog
 from .color import Color
 from .constant import OK, CANCEL, YES, NO
-from .dialog import Dialog
-from .directory_dialog import DirectoryDialog
-from .drop_handler import BaseDropHandler, FileDropHandler
-from .file_dialog import FileDialog
 from .filter import Filter
 from .font import Font
-from .gui import GUI
 from .gui_application import GUIApplication
-from .heading_text import HeadingText
-from .image_cache import ImageCache
-from .image_resource import ImageResource
-from .key_pressed_event import KeyPressedEvent
-from .layered_panel import LayeredPanel
-from .message_dialog import error, information, warning, MessageDialog
-from .progress_dialog import ProgressDialog
-
-from .util._optional_dependencies import optional_import as _optional_import
-
-# Excuse numpy dependency, otherwise re-raise
-with _optional_import(
-        "numpy",
-        msg="ArrayImage not available due to missing numpy.",
-        logger=_logging.getLogger(__name__)):
-
-    # We need to manually try importing numpy because the ``ArrayImage``
-    # import will end up raising a ``TraitError`` exception instead of an
-    # ``ImportError``, which isnt caught by ``_optional_import``.
-    import numpy
-
-    from .array_image import ArrayImage
-
-    del numpy
-
-# Excuse pillow dependency, otherwise re-raise
-with _optional_import(
-        "pillow",
-        msg="PILImage not available due to missing pillow.",
-        logger=_logging.getLogger(__name__)):
-    from .pil_image import PILImage
-
-# Excuse pygments dependency (for Qt), otherwise re-raise
-with _optional_import(
-        "pygments",
-        msg="PythonEditor not available due to missing pygments.",
-        logger=_logging.getLogger(__name__)):
-    from .python_editor import PythonEditor
-
-with _optional_import(
-        "pygments",
-        msg="PythonShell not available due to missing pygments.",
-        logger=_logging.getLogger(__name__)):
-    from .python_shell import PythonShell
-
-from .sorter import Sorter
-from .single_choice_dialog import choose_one, SingleChoiceDialog
-from .splash_screen import SplashScreen
-from .split_application_window import SplitApplicationWindow
-from .split_dialog import SplitDialog
-from .split_panel import SplitPanel
-from .system_metrics import SystemMetrics
-from .ui_traits import (
-    Alignment, Border, HasBorder, HasMargin, Image, Margin, Orientation,
-    Position, PyfaceColor, PyfaceFont
-)
-from .window import Window
-from .widget import Widget
-
-# ----------------------------------------------------------------------------
-# Public Interfaces
-# ----------------------------------------------------------------------------
-
 from .i_about_dialog import IAboutDialog
 from .i_application_window import IApplicationWindow
 from .i_clipboard import IClipboard
@@ -241,27 +168,121 @@ from .i_split_widget import ISplitWidget
 from .i_system_metrics import ISystemMetrics
 from .i_widget import IWidget
 from .i_window import IWindow
+from .sorter import Sorter
+from .ui_traits import (
+    Alignment, Border, HasBorder, HasMargin, Image, Margin, Orientation,
+    Position, PyfaceColor, PyfaceFont
+)
 
 # ----------------------------------------------------------------------------
-# Legacy and Wx-specific imports.
+# Deferred imports
 # ----------------------------------------------------------------------------
 
-# These widgets currently only have Wx implementations
-# will return Unimplemented for Qt.
+# These imports have the side-effect of performing toolkit selection
 
-from .expandable_panel import ExpandablePanel
-from .image_widget import ImageWidget
-from .mdi_application_window import MDIApplicationWindow
-from .mdi_window_menu import MDIWindowMenu
-from .multi_toolbar_window import MultiToolbarWindow
+_toolkit_imports = {
+    'AboutDialog': 'about_dialog',
+    'ApplicationWindow': "application_window",
+    'BaseDropHandler': "drop_handler",
+    'beep': "beep",
+    'Clipboard': "clipboard",
+    'ConfirmationDialog': "confirmation_dialog",
+    'Dialog': "dialog",
+    'DirectoryDialog': "directory_dialog",
+    'FileDropHandler': "drop_handler",
+    'FileDialog': "file_dialog",
+    'GUI': 'gui',
+    'HeadingText': "heading_text",
+    'ImageCache': "image_cache",
+    'ImageResource': "image_resource",
+    'KeyPressedEvent': "key_pressed_event",
+    'LayeredPanel': "layered_panel",
+    'MessageDialog': "message_dialog",
+    'ProgressDialog': "progress_dialog",
+    'SingleChoiceDialog': "single_choice_dialog",
+    'SplashScreen': "splash_screen",
+    'SystemMetrics': "system_metrics",
+    'Window': "window",
+    'Widget': "widget",
 
-# This code isn't toolkit widget code, but is wx-specific
-from traits.etsconfig.api import ETSConfig
+    # Wx-only (or legacy) imports
+    'ExpandablePanel': "expandable_panel",
+    'ImageWidget': "image_widget",
+    'MDIApplicationWindow': "mdi_application_window",
+    'MDIWindowMenu': "mdi_window_menu",
+    'MultiToolbarWindow': "multi_toolbar_window",
+}
 
-if ETSConfig.toolkit == "wx":
+# These are pyface.* imports that have selection as a side-effect
+# TODO: refactor to delay imports where possible
+_relative_imports = {
+    'choose_one': "single_choice_dialog",
+    'clipboard': "clipboard",
+    'confirm': "confirmation_dialog",
+    'error': "message_dialog",
+    'information': "message_dialog",
+    'SplitApplicationWindow': "split_application_window",
+    'SplitDialog': "split_dialog",
+    'SplitPanel': "split_panel",
+    'warning': "message_dialog",
+}
+_optional_imports = {
+    'ArrayImage': ("numpy", "array_image"),
+    'PILImage': ("pillow", "pil_image"),
+    'PythonEditor': ("pygments", "python_editor"),
+    'PythonShell': ("pygments", "python_shell"),
+}
 
-    # Fix for broken Pycrust introspect module.
-    # XXX move this somewhere better? - CJW 2017
-    from .util import fix_introspect_bug
 
-del ETSConfig
+def __getattr__(name):
+    """Lazily load attributes with side-effects
+
+    In particular, lazily load toolkit backend names.  For efficiency, lazily
+    loaded objects are injected into the module namespace
+    """
+    # sentinel object for no result
+    not_found = object()
+    result = not_found
+
+    if name in _relative_imports:
+        from importlib import import_module
+        source = _relative_imports[name]
+        module = import_module(f"pyface.{source}")
+        result = getattr(module, name)
+
+    elif name in _toolkit_imports:
+        from pyface.toolkit import toolkit_object
+        source = _toolkit_imports[name]
+        result = toolkit_object(f"{source}:{name}")
+
+    elif name in _optional_imports:
+        import logging
+        from pyface.toolkit import toolkit_object
+        from pyface.util._optional_dependencies import optional_import
+        dependency, source = _optional_imports[name]
+        with optional_import(
+            dependency,
+            msg=f"{name} is not available due to missing {dependency}.",
+            logger=logging.getLogger(__name__),
+        ):
+            result = toolkit_object(f"{source}:{name}")
+
+    if result is not_found:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = result
+    return result
+
+
+# ----------------------------------------------------------------------------
+# Introspection support
+# ----------------------------------------------------------------------------
+
+# the list of available names we report for introspection purposes
+_extra_names = (
+    set(_toolkit_imports) | set(_relative_imports) | set(_optional_imports)
+)
+
+
+def __dir__():
+    return sorted(set(globals()) | _extra_names)

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -14,7 +14,6 @@ API for the ``pyface`` package.
 
 - :class:`~.Application`
 - :class:`~.ApplicationWindow`
-- :class:`~.BaseToolkit`
 - :attr:`~.clipboard`
 - :class:`~.Clipboard`
 - :func:`~.find_toolkit`
@@ -26,6 +25,7 @@ API for the ``pyface`` package.
 - :class:`~.SplitApplicationWindow`
 - :class:`~.SplitPanel`
 - :class:`~.SystemMetrics`
+- :class:`~.Toolkit`
 - :class:`~.Window`
 - :class:`~.Widget`
 
@@ -139,7 +139,7 @@ Wx-specific classes
 # Imports which don't select the toolkit as a side-effect.
 
 from .application import Application
-from .base_toolkit import BaseToolkit, find_toolkit
+from .base_toolkit import Toolkit, find_toolkit
 from .color import Color
 from .constant import OK, CANCEL, YES, NO
 from .filter import Filter

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -232,10 +232,10 @@ def import_toolkit(toolkit_name, entry_point="pyface.toolkits"):
 
 
 def find_toolkit(
-        entry_point="pyface.toolkits",
-        toolkits=None,
-        priorities=default_priorities,
-    ):
+    entry_point="pyface.toolkits",
+    toolkits=None,
+    priorities=default_priorities,
+):
     """ Find a toolkit that works.
 
     If ETSConfig is set, then attempt to find a matching toolkit.  Otherwise

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -231,7 +231,11 @@ def import_toolkit(toolkit_name, entry_point="pyface.toolkits"):
     raise RuntimeError(msg) from toolkit_exception
 
 
-def find_toolkit(entry_point, toolkits=None, priorities=default_priorities):
+def find_toolkit(
+        entry_point="pyface.toolkits",
+        toolkits=None,
+        priorities=default_priorities,
+    ):
     """ Find a toolkit that works.
 
     If ETSConfig is set, then attempt to find a matching toolkit.  Otherwise

--- a/pyface/data_view/api.py
+++ b/pyface/data_view/api.py
@@ -65,24 +65,64 @@ Interfaces
 
 """
 
-from pyface.data_view.abstract_data_exporter import AbstractDataExporter  # noqa: 401
-from pyface.data_view.abstract_data_model import AbstractDataModel  # noqa: 401
-from pyface.data_view.abstract_value_type import AbstractValueType  # noqa: 401
-from pyface.data_view.data_formats import (  # noqa: 401
+from pyface.data_view.abstract_data_exporter import AbstractDataExporter
+from pyface.data_view.abstract_data_model import AbstractDataModel
+from pyface.data_view.abstract_value_type import AbstractValueType
+from pyface.data_view.data_formats import (
     csv_column_format, csv_format, csv_row_format, from_csv, from_csv_column,
     from_csv_row, from_json, from_npy, html_format, npy_format,
     standard_text_format, to_csv, to_csv_column, to_csv_row, to_json, to_npy,
     table_format, text_column_format, text_row_format
 )
-from pyface.data_view.data_view_errors import (  # noqa: 401
+from pyface.data_view.data_view_errors import (
     DataViewError, DataViewGetError, DataViewSetError
 )
-from pyface.data_view.data_view_widget import DataViewWidget  # noqa: 401
-from pyface.data_view.data_wrapper import DataWrapper  # noqa: 401
-from pyface.data_view.i_data_view_widget import IDataViewWidget  # noqa: 401
-from pyface.data_view.i_data_wrapper import (  # noqa: 401
+from pyface.data_view.i_data_view_widget import IDataViewWidget
+from pyface.data_view.i_data_wrapper import (
     DataFormat, IDataWrapper, text_format
 )
-from pyface.data_view.index_manager import (  # noqa: 401
+from pyface.data_view.index_manager import (
     AbstractIndexManager, IntIndexManager, TupleIndexManager
 )
+
+
+# ----------------------------------------------------------------------------
+# Deferred imports
+# ----------------------------------------------------------------------------
+
+# These imports have the side-effect of performing toolkit selection
+
+_toolkit_imports = {
+    'DataViewWidget': 'data_view_widget',
+    'DataWrapper': 'data_wrapper',
+}
+
+
+def __getattr__(name):
+    """Lazily load attributes with side-effects
+
+    In particular, lazily load toolkit backend names.  For efficiency, lazily
+    loaded objects are injected into the module namespace
+    """
+    # sentinel object for no result
+    not_found = object()
+    result = not_found
+
+    if name in _toolkit_imports:
+        from pyface.toolkit import toolkit_object
+        source = _toolkit_imports[name]
+        result = toolkit_object(f"data_view.{source}:{name}")
+
+    if result is not_found:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = result
+    return result
+
+
+# ----------------------------------------------------------------------------
+# Introspection support
+# ----------------------------------------------------------------------------
+
+def __dir__():
+    return sorted(set(globals()) | set(_toolkit_imports))

--- a/pyface/fields/tests/test_api.py
+++ b/pyface/fields/tests/test_api.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test for pyface.api """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    """ Test importable items in any environment."""
+
+    def test_api_importable(self):
+        # make sure api is importable with the most minimal
+        # required dependencies, including in the absence of toolkit backends.
+        from pyface.fields import api   # noqa: F401
+
+    def test_public_attrs(self):
+        # make sure everything advertised by dir() is available except optional
+        from pyface.fields import api
+
+        attrs = [
+            name
+            for name in dir(api)
+            if not name.startswith('_')
+        ]
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                self.assertIsNotNone(getattr(api, attr, None))

--- a/pyface/i_application_window.py
+++ b/pyface/i_application_window.py
@@ -135,9 +135,6 @@ class MApplicationWindow(HasTraits):
         if self.menu_bar_manager is not None:
             self.menu_bar_manager.destroy()
 
-        if self.tool_bar_manager is not None:
-            self.tool_bar_manager.destroy()
-
         if self.status_bar_manager is not None:
             self.status_bar_manager.destroy()
 

--- a/pyface/i_application_window.py
+++ b/pyface/i_application_window.py
@@ -13,6 +13,9 @@
 
 from traits.api import HasTraits, Instance, List
 
+from pyface.action.i_menu_bar_manager import IMenuBarManager
+from pyface.action.i_status_bar_manager import IStatusBarManager
+from pyface.action.i_tool_bar_manager import IToolBarManager
 from pyface.i_window import IWindow
 from pyface.ui_traits import Image
 
@@ -35,26 +38,14 @@ class IApplicationWindow(IWindow):
     #: The window icon.  The default is toolkit specific.
     icon = Image()
 
-    #: The menu bar manager (None iff there is no menu bar).
-    menu_bar_manager = Instance(
-        "pyface.action.menu_bar_manager.MenuBarManager"
-    )
+    #: The menu bar manager for the window.
+    menu_bar_manager = Instance(IMenuBarManager)
 
-    #: The status bar manager (None iff there is no status bar).
-    status_bar_manager = Instance(
-        "pyface.action.status_bar_manager.StatusBarManager"
-    )
+    #: The status bar manager for the window.
+    status_bar_manager = Instance(IStatusBarManager)
 
-    #: The tool bar manager (None iff there is no tool bar).
-    tool_bar_manager = Instance(
-        "pyface.action.tool_bar_manager.ToolBarManager"
-    )
-
-    #: If the underlying toolkit supports multiple toolbars, you can use this
-    #: list instead of the single ToolBarManager instance above.
-    tool_bar_managers = List(
-        Instance("pyface.action.menu_bar_manager.ToolBarManager")
-    )
+    #: The collection of tool bar managers for the window.
+    tool_bar_managers = List(Instance(IToolBarManager))
 
     # ------------------------------------------------------------------------
     # Protected 'IApplicationWindow' interface.
@@ -121,6 +112,18 @@ class MApplicationWindow(HasTraits):
 
     Implements: destroy(), _create_trim_widgets()
     """
+
+    #: The icon to display in the application window title bar.
+    icon = Image()
+
+    #: The menu bar manager for the window.
+    menu_bar_manager = Instance(IMenuBarManager)
+
+    #: The status bar manager for the window.
+    status_bar_manager = Instance(IStatusBarManager)
+
+    #: The collection of tool bar managers for the window.
+    tool_bar_managers = List(Instance(IToolBarManager))
 
     # ------------------------------------------------------------------------
     # 'IWidget' interface.

--- a/pyface/i_application_window.py
+++ b/pyface/i_application_window.py
@@ -13,8 +13,6 @@
 
 from traits.api import HasTraits, Instance, List
 
-
-from pyface.action.api import MenuBarManager, StatusBarManager, ToolBarManager
 from pyface.i_window import IWindow
 from pyface.ui_traits import Image
 
@@ -38,17 +36,25 @@ class IApplicationWindow(IWindow):
     icon = Image()
 
     #: The menu bar manager (None iff there is no menu bar).
-    menu_bar_manager = Instance(MenuBarManager)
+    menu_bar_manager = Instance(
+        "pyface.action.menu_bar_manager.MenuBarManager"
+    )
 
     #: The status bar manager (None iff there is no status bar).
-    status_bar_manager = Instance(StatusBarManager)
+    status_bar_manager = Instance(
+        "pyface.action.status_bar_manager.StatusBarManager"
+    )
 
     #: The tool bar manager (None iff there is no tool bar).
-    tool_bar_manager = Instance(ToolBarManager)
+    tool_bar_manager = Instance(
+        "pyface.action.tool_bar_manager.ToolBarManager"
+    )
 
     #: If the underlying toolkit supports multiple toolbars, you can use this
     #: list instead of the single ToolBarManager instance above.
-    tool_bar_managers = List(ToolBarManager)
+    tool_bar_managers = List(
+        Instance("pyface.action.menu_bar_manager.ToolBarManager")
+    )
 
     # ------------------------------------------------------------------------
     # Protected 'IApplicationWindow' interface.

--- a/pyface/i_image_resource.py
+++ b/pyface/i_image_resource.py
@@ -14,7 +14,6 @@ from collections.abc import Sequence
 from traits.api import HasTraits, List, Str
 
 from pyface.i_image import IImage
-from pyface.resource_manager import resource_manager
 from pyface.resource.resource_path import resource_module, resource_path
 
 
@@ -130,6 +129,8 @@ class MImageResource(HasTraits):
         """
 
         if self._ref is None:
+            from pyface.resource_manager import resource_manager
+
             self._ref = resource_manager.locate_image(
                 self.name, self.search_path, size
             )

--- a/pyface/tasks/action/api.py
+++ b/pyface/tasks/action/api.py
@@ -78,7 +78,8 @@ from .schema import (
     SMenuBar,
     SToolBar,
 )
-from .schema_addition import SchemaAddition
+# deprecated: will be removed in a future Pyface release
+from pyface.action.schema.schema_addition import SchemaAddition
 from .task_action import (
     CentralPaneAction,
     DockPaneAction,

--- a/pyface/tasks/action/dock_pane_toggle_group.py
+++ b/pyface/tasks/action/dock_pane_toggle_group.py
@@ -10,7 +10,6 @@
 """ A Group for toggling the visibility of a task's dock panes. """
 
 
-from pyface.action.api import Action, ActionItem, Group
 from traits.api import (
     cached_property,
     Instance,
@@ -21,6 +20,7 @@ from traits.api import (
 )
 
 
+from pyface.action.api import Action, Group
 from pyface.tasks.i_dock_pane import IDockPane
 
 
@@ -123,6 +123,7 @@ class DockPaneToggleGroup(Group):
     def _dock_panes_updated(self, event):
         """Recreate the group items when dock panes have been added/removed.
         """
+        from pyface.action.action_item import ActionItem
 
         # Remove the previous group items.
         self.destroy()

--- a/pyface/tasks/action/task_action.py
+++ b/pyface/tasks/action/task_action.py
@@ -12,7 +12,9 @@
 from traits.api import Instance, Property, Str, cached_property
 
 
-from pyface.tasks.api import Editor, Task, TaskPane
+from pyface.tasks.i_editor import IEditor
+from pyface.tasks.task import Task
+from pyface.tasks.i_task_pane import ITaskPane
 from pyface.action.listening_action import ListeningAction
 
 
@@ -74,7 +76,7 @@ class CentralPaneAction(TaskAction):
     # CentralPaneAction interface -----------------------------------------#
 
     #: The central pane with which the action is associated.
-    central_pane = Property(Instance(TaskPane), observe="task")
+    central_pane = Property(Instance(ITaskPane), observe="task")
 
     # ------------------------------------------------------------------------
     # Protected interface.
@@ -101,7 +103,7 @@ class DockPaneAction(TaskAction):
     # DockPaneAction interface ---------------------------------------------
 
     #: The dock pane with which the action is associated. Set by the framework.
-    dock_pane = Property(Instance(TaskPane), observe="task")
+    dock_pane = Property(Instance(ITaskPane), observe="task")
 
     #: The ID of the dock pane with which the action is associated.
     dock_pane_id = Str()
@@ -132,7 +134,7 @@ class EditorAction(CentralPaneAction):
 
     #: The active editor in the central pane with which the action is associated.
     active_editor = Property(
-        Instance(Editor), observe="central_pane.active_editor"
+        Instance(IEditor), observe="central_pane.active_editor"
     )
 
     # ------------------------------------------------------------------------

--- a/pyface/tasks/action/task_toggle_group.py
+++ b/pyface/tasks/action/task_toggle_group.py
@@ -9,12 +9,11 @@
 # Thanks for using Enthought open source!
 
 
-from pyface.action.api import Action, ActionItem, Group
+from pyface.action.api import Action, Group
 from traits.api import Any, List, Instance, Property, Str, observe
 
 
 from pyface.tasks.task import Task
-from pyface.tasks.task_window import TaskWindow
 
 
 class TaskToggleAction(Action):
@@ -89,13 +88,15 @@ class TaskToggleGroup(Group):
     manager = Any()
 
     #: The window that contains the group.
-    window = Instance(TaskWindow)
+    window = Instance("pyface.tasks.task_window.TaskWindow")
 
     # ------------------------------------------------------------------------
     # Private interface.
     # ------------------------------------------------------------------------
 
     def _get_items(self):
+        from pyface.action.api import ActionItem
+
         items = []
         if len(self.window.tasks) > 1:
             # at least two tasks, so something to toggle

--- a/pyface/tasks/action/task_window_toggle_group.py
+++ b/pyface/tasks/action/task_window_toggle_group.py
@@ -9,8 +9,9 @@
 # Thanks for using Enthought open source!
 
 
-from pyface.action.api import Action, ActionItem, Group
 from traits.api import Any, Instance, List, Property, Str, observe
+
+from pyface.action.api import Action, Group
 
 
 class TaskWindowToggleAction(Action):
@@ -94,6 +95,8 @@ class TaskWindowToggleGroup(Group):
     # -------------------------------------------------------------------------
 
     def _get_items(self):
+        from pyface.action.action_item import ActionItem
+
         items = []
         for window in self.application.windows:
             active = window == self.application.active_window

--- a/pyface/tasks/api.py
+++ b/pyface/tasks/api.py
@@ -57,14 +57,6 @@ Enaml-specific Tasks functionality
 
 """
 
-from .advanced_editor_area_pane import AdvancedEditorAreaPane
-from .split_editor_area_pane import SplitEditorAreaPane
-from .dock_pane import DockPane
-from .editor import Editor
-from .editor_area_pane import EditorAreaPane
-from .enaml_dock_pane import EnamlDockPane
-from .enaml_editor import EnamlEditor
-from .enaml_task_pane import EnamlTaskPane
 from .i_dock_pane import IDockPane
 from .i_editor import IEditor
 from .i_editor_area_pane import IEditorAreaPane
@@ -79,9 +71,72 @@ from .task_layout import (
     HSplitter,
     VSplitter,
 )
-from .task_pane import TaskPane
-from .task_window import TaskWindow
 from .task_window_layout import TaskWindowLayout
-from .traits_dock_pane import TraitsDockPane
-from .traits_editor import TraitsEditor
-from .traits_task_pane import TraitsTaskPane
+
+
+# ----------------------------------------------------------------------------
+# Deferred imports
+# ----------------------------------------------------------------------------
+
+# These imports have the side-effect of performing toolkit selection
+
+_toolkit_imports = {
+    'AdvancedEditorAreaPane': "advanced_editor_area_pane",
+    'DockPane': "dock_pane",
+    'EditorAreaPane': "editor_area_pane",
+    'Editor': "editor",
+    'SplitEditorAreaPane': "split_editor_area_pane",
+    'TaskPane': "task_pane",
+}
+
+# These are pyface.* imports that have selection as a side-effect
+# TODO: refactor to delay imports where possible
+_relative_imports = {
+    'EnamlDockPane': "enaml_dock_pane",
+    'EnamlEditor': "enaml_editor",
+    'EnamlTaskPane': "enaml_task_pane",
+    'TaskWindow': "task_window",
+    'TraitsDockPane': "traits_dock_pane",
+    'TraitsEditor': "traits_editor",
+    'TraitsTaskPane': "traits_task_pane",
+}
+
+
+def __getattr__(name):
+    """Lazily load attributes with side-effects
+
+    In particular, lazily load toolkit backend names.  For efficiency, lazily
+    loaded objects are injected into the module namespace
+    """
+    # sentinel object for no result
+    not_found = object()
+    result = not_found
+
+    if name in _relative_imports:
+        from importlib import import_module
+        source = _relative_imports[name]
+        module = import_module(f"pyface.tasks.{source}")
+        result = getattr(module, name)
+
+    elif name in _toolkit_imports:
+        from pyface.toolkit import toolkit_object
+        source = _toolkit_imports[name]
+        result = toolkit_object(f"tasks.{source}:{name}")
+
+    if result is not_found:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = result
+    return result
+
+
+# ----------------------------------------------------------------------------
+# Introspection support
+# ----------------------------------------------------------------------------
+
+# the list of available names we report for introspection purposes
+_extra_names = set(_toolkit_imports) | set(_relative_imports)
+
+
+def __dir__():
+    return sorted(set(globals()) | _extra_names)

--- a/pyface/tasks/task.py
+++ b/pyface/tasks/task.py
@@ -8,7 +8,6 @@
 #
 # Thanks for using Enthought open source!
 
-from pyface.action.api import StatusBarManager
 from traits.api import Callable, HasTraits, Instance, List, Str
 
 
@@ -49,7 +48,7 @@ class Task(HasTraits):
     menu_bar = Instance(MenuBarSchema)
 
     #: The (optional) status bar for the task.
-    status_bar = Instance(StatusBarManager)
+    status_bar = Instance("pyface.action.status_bar_manager.StatusBarManager")
 
     #: The list of tool bars for the tasks.
     tool_bars = List(ToolBarSchema)

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -451,15 +451,29 @@ class TaskState(HasStrictTraits):
         with an attached Task.
     """
 
+    #: The Task that the state comes from.
     task = Instance(Task)
+
+    #: The layout of panes in the TaskWindow.
     layout = Instance(TaskLayout)
+
+    #: Whether the task state has been initialized.
     initialized = Bool(False)
 
+    #: The central pane of the TaskWindow
     central_pane = Instance(ITaskPane)
-    dock_panes = List(IDockPane)
+
+    #: The list of all dock panes.
+    dock_panes = List(Instance(IDockPane))
+
+    #: The TaskWindow's menu bar manager instance.
     menu_bar_manager = Instance(IMenuBarManager)
+
+    #: The TaskWindow's status bar instance.
     status_bar_manager = Instance(IStatusBarManager)
-    tool_bar_managers = List(IToolBarManager)
+
+    #: The TaskWindow's tool bar instances.
+    tool_bar_managers = List(Instance(IToolBarManager))
 
     def get_dock_pane(self, id):
         """ Returns the dock pane with the specified id, or None if no such dock

--- a/pyface/tasks/task_window.py
+++ b/pyface/tasks/task_window.py
@@ -11,8 +11,6 @@
 import logging
 
 
-from pyface.action.api import MenuBarManager, StatusBarManager, ToolBarManager
-from pyface.api import ApplicationWindow
 from traits.api import (
     Bool,
     Callable,
@@ -26,13 +24,17 @@ from traits.api import (
 )
 
 
+from pyface.action.i_menu_bar_manager import IMenuBarManager
+from pyface.action.i_status_bar_manager import IStatusBarManager
+from pyface.action.i_tool_bar_manager import IToolBarManager
+from pyface.application_window import ApplicationWindow
 from pyface.tasks.action.task_action_manager_builder import (
     TaskActionManagerBuilder,
 )
 from pyface.tasks.i_dock_pane import IDockPane
 from pyface.tasks.i_task_pane import ITaskPane
+from pyface.tasks.i_task_window_backend import ITaskWindowBackend
 from pyface.tasks.task import Task, TaskLayout
-from pyface.tasks.task_window_backend import TaskWindowBackend
 from pyface.tasks.task_window_layout import TaskWindowLayout
 
 # Logging.
@@ -81,7 +83,7 @@ class TaskWindow(ApplicationWindow):
     _active_state = Instance("pyface.tasks.task_window.TaskState")
     _states = List(Instance("pyface.tasks.task_window.TaskState"))
     _title = Str()
-    _window_backend = Instance(TaskWindowBackend)
+    _window_backend = Instance(ITaskWindowBackend)
 
     # ------------------------------------------------------------------------
     # 'Widget' interface.
@@ -403,6 +405,7 @@ class TaskWindow(ApplicationWindow):
     # Trait initializers ---------------------------------------------------
 
     def __window_backend_default(self):
+        from pyface.tasks.task_window_backend import TaskWindowBackend
         return TaskWindowBackend(window=self)
 
     # Trait property getters/setters ---------------------------------------
@@ -454,9 +457,9 @@ class TaskState(HasStrictTraits):
 
     central_pane = Instance(ITaskPane)
     dock_panes = List(IDockPane)
-    menu_bar_manager = Instance(MenuBarManager)
-    status_bar_manager = Instance(StatusBarManager)
-    tool_bar_managers = List(ToolBarManager)
+    menu_bar_manager = Instance(IMenuBarManager)
+    status_bar_manager = Instance(IStatusBarManager)
+    tool_bar_managers = List(IToolBarManager)
 
     def get_dock_pane(self, id):
         """ Returns the dock pane with the specified id, or None if no such dock

--- a/pyface/tasks/tests/test_api.py
+++ b/pyface/tasks/tests/test_api.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test for pyface.api """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    """ Test importable items in any environment."""
+
+    def test_api_importable(self):
+        # make sure api is importable with the most minimal
+        # required dependencies, including in the absence of toolkit backends.
+        from pyface.tasks import api   # noqa: F401
+
+    def test_public_attrs(self):
+        # make sure everything advertised by dir() is available except optional
+        from pyface.tasks import api
+
+        attrs = [
+            name
+            for name in dir(api)
+            if not name.startswith('_')
+        ]
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                self.assertIsNotNone(getattr(api, attr, None))

--- a/pyface/tests/test_api.py
+++ b/pyface/tests/test_api.py
@@ -26,6 +26,19 @@ class TestApi(unittest.TestCase):
         # required dependencies, including in the absence of toolkit backends.
         from pyface import api   # noqa: F401
 
+    def test_public_attrs(self):
+        # make sure everything advertised by dir() is available except optional
+        from pyface import api
+
+        attrs = [
+            name
+            for name in dir(api)
+            if not name.startswith('_') or name in api._optional_imports
+        ]
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                self.assertIsNotNone(getattr(api, attr, None))
+
 
 @unittest.skipIf(not is_qt, "This test is for qt.")
 class TestApiQt(unittest.TestCase):
@@ -191,7 +204,6 @@ class TestApiWx(unittest.TestCase):
             clipboard,
             confirm,
             error,
-            fix_introspect_bug,
             information,
             warning,
             # Interfaces

--- a/pyface/timer/api.py
+++ b/pyface/timer/api.py
@@ -27,6 +27,53 @@ Interfaces
 
 """
 
-from .do_later import do_later, do_after, DoLaterTimer
 from .i_timer import ICallbackTimer, IEventTimer, ITimer
-from .timer import CallbackTimer, EventTimer, Timer
+
+
+# ----------------------------------------------------------------------------
+# Deferred imports
+# ----------------------------------------------------------------------------
+
+# These imports have the side-effect of performing toolkit selection
+
+# These are pyface.undo.* imports that have selection as a side-effect
+# TODO: refactor to delay imports where possible
+_relative_imports = {
+    'do_later': 'do_later',
+    'do_after': 'do_after',
+    'DoLaterTimer': 'do_after',
+    'CallbackTimer': 'timer',
+    'EventTimer': 'timer',
+    'Timer': 'timer',
+}
+
+
+def __getattr__(name):
+    """Lazily load attributes with side-effects
+
+    In particular, lazily load toolkit backend names.  For efficiency, lazily
+    loaded objects are injected into the module namespace
+    """
+    # sentinel object for no result
+    not_found = object()
+    result = not_found
+
+    if name in _relative_imports:
+        from importlib import import_module
+        source = _relative_imports[name]
+        module = import_module(f"pyface.timer.{source}")
+        result = getattr(module, name)
+
+    if result is not_found:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = result
+    return result
+
+
+# ----------------------------------------------------------------------------
+# Introspection support
+# ----------------------------------------------------------------------------
+
+def __dir__():
+    return sorted(set(globals()) | set(_relative_imports))

--- a/pyface/timer/api.py
+++ b/pyface/timer/api.py
@@ -40,8 +40,8 @@ from .i_timer import ICallbackTimer, IEventTimer, ITimer
 # TODO: refactor to delay imports where possible
 _relative_imports = {
     'do_later': 'do_later',
-    'do_after': 'do_after',
-    'DoLaterTimer': 'do_after',
+    'do_after': 'do_later',
+    'DoLaterTimer': 'do_later',
     'CallbackTimer': 'timer',
     'EventTimer': 'timer',
     'Timer': 'timer',

--- a/pyface/timer/tests/test_api.py
+++ b/pyface/timer/tests/test_api.py
@@ -1,0 +1,35 @@
+# (C) Copyright 2005-2023 Enthought, Inc., Austin, TX
+# All rights reserved.
+#
+# This software is provided without warranty under the terms of the BSD
+# license included in LICENSE.txt and may be redistributed only under
+# the conditions described in the aforementioned license. The license
+# is also available online at http://www.enthought.com/licenses/BSD.txt
+#
+# Thanks for using Enthought open source!
+
+""" Test for pyface.api """
+
+import unittest
+
+
+class TestApi(unittest.TestCase):
+    """ Test importable items in any environment."""
+
+    def test_api_importable(self):
+        # make sure api is importable with the most minimal
+        # required dependencies, including in the absence of toolkit backends.
+        from pyface.timer import api   # noqa: F401
+
+    def test_public_attrs(self):
+        # make sure everything advertised by dir() is available except optional
+        from pyface.timer import api
+
+        attrs = [
+            name
+            for name in dir(api)
+            if not name.startswith('_')
+        ]
+        for attr in attrs:
+            with self.subTest(attr=attr):
+                self.assertIsNotNone(getattr(api, attr, None))

--- a/pyface/ui/qt/action/menu_bar_manager.py
+++ b/pyface/ui/qt/action/menu_bar_manager.py
@@ -17,13 +17,14 @@
 
 import sys
 
+from traits.api import provides
 
 from pyface.qt import QtGui
-
-
 from pyface.action.action_manager import ActionManager
+from pyface.action.i_menu_bar_manager import IMenuBarManager
 
 
+@provides(IMenuBarManager)
 class MenuBarManager(ActionManager):
     """ A menu bar manager realizes itself in errr, a menu bar control. """
 

--- a/pyface/ui/qt/action/menu_manager.py
+++ b/pyface/ui/qt/action/menu_manager.py
@@ -18,15 +18,17 @@
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Instance, List, Str
+from traits.api import Instance, List, Str, provides
 
 
 from pyface.action.action_manager import ActionManager
 from pyface.action.action_manager_item import ActionManagerItem
 from pyface.action.action_item import _Tool, Action
+from pyface.action.i_menu_manager import IMenuManager
 from pyface.action.group import Group
 
 
+@provides(IMenuManager)
 class MenuManager(ActionManager, ActionManagerItem):
     """ A menu manager realizes itself in a menu control.
 

--- a/pyface/ui/qt/action/status_bar_manager.py
+++ b/pyface/ui/qt/action/status_bar_manager.py
@@ -17,9 +17,12 @@
 from pyface.qt import QtGui
 
 
-from traits.api import Any, Bool, HasTraits, List, Property, Str
+from traits.api import Any, Bool, HasTraits, List, Property, Str, provides
+
+from pyface.action.i_status_bar_manager import IStatusBarManager
 
 
+@provides(IStatusBarManager)
 class StatusBarManager(HasTraits):
     """ A status bar manager realizes itself in a status bar control. """
 

--- a/pyface/ui/qt/action/tool_bar_manager.py
+++ b/pyface/ui/qt/action/tool_bar_manager.py
@@ -17,13 +17,16 @@
 from pyface.qt import QtCore, QtGui
 
 
-from traits.api import Bool, Enum, Instance, List, Str, Tuple
+from traits.api import Bool, Instance, List, Str, Tuple, provides
 
 
 from pyface.image_cache import ImageCache
 from pyface.action.action_manager import ActionManager
+from pyface.action.i_tool_bar_manager import IToolBarManager
+from pyface.ui_traits import Orientation
 
 
+@provides(IToolBarManager)
 class ToolBarManager(ActionManager):
     """ A tool bar manager realizes itself in errr, a tool bar control. """
 
@@ -42,7 +45,7 @@ class ToolBarManager(ActionManager):
     name = Str("ToolBar")
 
     # The orientation of the toolbar.
-    orientation = Enum("horizontal", "vertical")
+    orientation = Orientation("horizontal")
 
     # Should we display the name of each tool bar tool under its image?
     show_tool_names = Bool(True)

--- a/pyface/ui/qt/application_window.py
+++ b/pyface/ui/qt/application_window.py
@@ -66,7 +66,7 @@ class ApplicationWindow(MApplicationWindow, Window):
             status_bar.setVisible(self.status_bar_manager.visible)
 
     def _create_tool_bar(self, parent):
-        tool_bar_managers = self._get_tool_bar_managers()
+        tool_bar_managers = self.tool_bar_managers
         visible = self.control.isVisible()
         for tool_bar_manager in tool_bar_managers:
             # Add the tool bar and make sure it is visible.
@@ -126,18 +126,6 @@ class ApplicationWindow(MApplicationWindow, Window):
     # Private interface.
     # ------------------------------------------------------------------------
 
-    def _get_tool_bar_managers(self):
-        """ Return all tool bar managers specified for the window. """
-
-        # fixme: V3 remove the old-style single toolbar option!
-        if self.tool_bar_manager is not None:
-            tool_bar_managers = [self.tool_bar_manager]
-
-        else:
-            tool_bar_managers = self.tool_bar_managers
-
-        return tool_bar_managers
-
     # Trait change handlers ------------------------------------------------
 
     # QMainWindow takes ownership of the menu bar and the status bar upon
@@ -156,7 +144,7 @@ class ApplicationWindow(MApplicationWindow, Window):
                 event.old.destroy()
             self._create_status_bar(self.control)
 
-    @observe("tool_bar_manager, tool_bar_managers.items")
+    @observe("tool_bar_managers.items")
     def _update_tool_bar_managers(self, event):
         if self.control is not None:
             # Remove the old toolbars.

--- a/pyface/ui/qt/application_window.py
+++ b/pyface/ui/qt/application_window.py
@@ -18,7 +18,7 @@
 
 import sys
 
-from traits.api import Instance, List, observe, provides, Str
+from traits.api import observe, provides, Str
 
 from pyface.qt import QtGui
 from pyface.i_application_window import IApplicationWindow, MApplicationWindow

--- a/pyface/ui/qt/application_window.py
+++ b/pyface/ui/qt/application_window.py
@@ -18,17 +18,10 @@
 
 import sys
 
-
-from pyface.qt import QtGui
-
-
-from pyface.action.api import MenuBarManager, StatusBarManager
-from pyface.action.api import ToolBarManager
 from traits.api import Instance, List, observe, provides, Str
 
-
+from pyface.qt import QtGui
 from pyface.i_application_window import IApplicationWindow, MApplicationWindow
-from pyface.ui_traits import Image
 from .image_resource import ImageResource
 from .window import Window
 
@@ -38,23 +31,6 @@ class ApplicationWindow(MApplicationWindow, Window):
     """ The toolkit specific implementation of an ApplicationWindow.  See the
     IApplicationWindow interface for the API documentation.
     """
-
-    # 'IApplicationWindow' interface ---------------------------------------
-
-    #: The icon to display in the application window title bar.
-    icon = Image()
-
-    #: The menu bar manager for the window.
-    menu_bar_manager = Instance(MenuBarManager)
-
-    #: The status bar manager for the window.
-    status_bar_manager = Instance(StatusBarManager)
-
-    #: DEPRECATED: The tool bar manager for the window.
-    tool_bar_manager = Instance(ToolBarManager)
-
-    #: The collection of tool bar managers for the window.
-    tool_bar_managers = List(ToolBarManager)
 
     # 'IWindow' interface -------------------------------------------------#
 

--- a/pyface/ui/wx/action/menu_bar_manager.py
+++ b/pyface/ui/wx/action/menu_bar_manager.py
@@ -15,10 +15,13 @@
 
 import wx
 
+from traits.api import provides
 
 from pyface.action.action_manager import ActionManager
+from pyface.action.i_menu_bar_manager import IMenuBarManager
 
 
+@provides(IMenuBarManager)
 class MenuBarManager(ActionManager):
     """ A menu bar manager realizes itself in errr, a menu bar control. """
 

--- a/pyface/ui/wx/action/menu_manager.py
+++ b/pyface/ui/wx/action/menu_manager.py
@@ -16,14 +16,16 @@
 import wx
 
 
-from traits.api import Str, Bool
+from traits.api import Str, Bool, provides
 
 
 from pyface.action.action_manager import ActionManager
 from pyface.action.action_manager_item import ActionManagerItem
 from pyface.action.group import Group
+from pyface.action.i_menu_manager import IMenuManager
 
 
+@provides(IMenuManager)
 class MenuManager(ActionManager, ActionManagerItem):
     """ A menu manager realizes itself in a menu control.
 

--- a/pyface/ui/wx/action/status_bar_manager.py
+++ b/pyface/ui/wx/action/status_bar_manager.py
@@ -16,9 +16,12 @@
 import wx
 
 
-from traits.api import Any, HasTraits, List, Property, Str
+from traits.api import Any, HasTraits, List, Property, Str, provides
+
+from pyface.action.i_status_bar_manager import IStatusBarManager
 
 
+@provides(IStatusBarManager)
 class StatusBarManager(HasTraits):
     """ A status bar manager realizes itself in a status bar control. """
 

--- a/pyface/ui/wx/action/tool_bar_manager.py
+++ b/pyface/ui/wx/action/tool_bar_manager.py
@@ -15,15 +15,16 @@
 
 import wx
 
-
-from traits.api import Bool, Enum, Instance, Str, Tuple
-
+from traits.api import Bool, Instance, Str, Tuple, provides
 
 from pyface.wx.aui import aui as AUI
 from pyface.image_cache import ImageCache
 from pyface.action.action_manager import ActionManager
+from pyface.action.i_tool_bar_manager import IToolBarManager
+from pyface.ui_traits import Orientation
 
 
+@provides(IToolBarManager)
 class ToolBarManager(ActionManager):
     """ A tool bar manager realizes itself in errr, a tool bar control. """
 
@@ -42,7 +43,7 @@ class ToolBarManager(ActionManager):
     name = Str("ToolBar")
 
     # The orientation of the toolbar.
-    orientation = Enum("horizontal", "vertical")
+    orientation = Orientation("horizontal")
 
     # Should we display the name of each tool bar tool under its image?
     show_tool_names = Bool(True)

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -52,7 +52,7 @@ class ApplicationWindow(MApplicationWindow, Window):
             self.control.SetStatusBar(status_bar)
 
     def _create_tool_bar(self, parent):
-        tool_bar_managers = self._get_tool_bar_managers()
+        tool_bar_managers = self.tool_bar_managers
         if len(tool_bar_managers) > 0:
             for tool_bar_manager in reversed(tool_bar_managers):
                 tool_bar = tool_bar_manager.create_tool_bar(parent, aui=True)
@@ -147,18 +147,6 @@ class ApplicationWindow(MApplicationWindow, Window):
 
         return info
 
-    def _get_tool_bar_managers(self):
-        """ Return all tool bar managers specified for the window. """
-
-        # fixme: V3 remove the old-style single toolbar option!
-        if self.tool_bar_manager is not None:
-            tool_bar_managers = [self.tool_bar_manager]
-
-        else:
-            tool_bar_managers = self.tool_bar_managers
-
-        return tool_bar_managers
-
     def _wx_enable_tool_bar(self, tool_bar, enabled):
         """ Enable/Disablea tool bar. """
 
@@ -198,7 +186,7 @@ class ApplicationWindow(MApplicationWindow, Window):
                 old.destroy()
             self._create_status_bar(self.control)
 
-    @observe("tool_bar_manager, tool_bar_managers.items")
+    @observe("tool_bar_managers.items")
     def _update_tool_bar_managers(self, event):
         if self.control is not None:
             self._create_tool_bar(self.control)

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -14,7 +14,7 @@
 
 import wx
 
-from traits.api import Instance, List, Str, observe, provides
+from traits.api import Str, observe, provides
 
 from pyface.i_application_window import IApplicationWindow, MApplicationWindow
 from pyface.wx.aui import aui, PyfaceAuiManager

--- a/pyface/ui/wx/application_window.py
+++ b/pyface/ui/wx/application_window.py
@@ -16,12 +16,7 @@ import wx
 
 from traits.api import Instance, List, Str, observe, provides
 
-from pyface.action.api import MenuBarManager, StatusBarManager
-from pyface.action.api import ToolBarManager
-from pyface.i_application_window import (
-    IApplicationWindow, MApplicationWindow,
-)
-from pyface.ui_traits import Image
+from pyface.i_application_window import IApplicationWindow, MApplicationWindow
 from pyface.wx.aui import aui, PyfaceAuiManager
 from .image_resource import ImageResource
 from .window import Window
@@ -33,29 +28,7 @@ class ApplicationWindow(MApplicationWindow, Window):
     IApplicationWindow interface for the API documentation.
     """
 
-    # 'IApplicationWindow' interface ---------------------------------------
-
-    icon = Image()
-
-    menu_bar_manager = Instance(MenuBarManager)
-
-    status_bar_manager = Instance(StatusBarManager)
-
-    tool_bar_manager = Instance(ToolBarManager)
-
-    # If the underlying toolkit supports multiple toolbars then you can use
-    # this list instead.
-    tool_bar_managers = List(ToolBarManager)
-
     # 'IWindow' interface -------------------------------------------------#
-
-    # fixme: We can't set the default value of the actual 'size' trait here as
-    # in the toolkit-specific event handlers for window size and position
-    # changes, we set the value of the shadow '_size' trait. The problem is
-    # that by doing that traits never knows that the trait has been set and
-    # hence always returns the default value! Using a trait initializer method
-    # seems to work however (e.g. 'def _size_default'). Hmmmm....
-    ##     size = (800, 600)
 
     title = Str("Pyface")
 

--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -37,5 +37,6 @@ if ui_handler is None:
     # Tell the traits notification handlers to use this UI handler
     set_ui_handler(GUI.invoke_later)
 
-# Fix for broken Pycrust introspect module.  Imported to patch pycrust
-from pyface.util import fix_introspect_bug  # noqa: F401
+# Fix for broken Pycrust introspect module.  Imported to patch pycrust.
+# CJW: is this still needed? Has been in for years.
+from pyface.util import fix_introspect_bug  # noqa: F401, E402

--- a/pyface/ui/wx/init.py
+++ b/pyface/ui/wx/init.py
@@ -36,3 +36,6 @@ toolkit_object = Toolkit("pyface", "wx", "pyface.ui.wx")
 if ui_handler is None:
     # Tell the traits notification handlers to use this UI handler
     set_ui_handler(GUI.invoke_later)
+
+# Fix for broken Pycrust introspect module.  Imported to patch pycrust
+from pyface.util import fix_introspect_bug  # noqa: F401

--- a/pyface/wizard/api.py
+++ b/pyface/wizard/api.py
@@ -27,14 +27,65 @@ Interfaces
 
 """
 
+from .chained_wizard_controller import ChainedWizardController
 from .i_wizard_page import IWizardPage
-from .wizard_page import WizardPage
-
 from .i_wizard import IWizard
-from .wizard import Wizard
-
 from .i_wizard_controller import IWizardController
 from .wizard_controller import WizardController
 
-from .chained_wizard import ChainedWizard
-from .chained_wizard_controller import ChainedWizardController
+
+# ----------------------------------------------------------------------------
+# Deferred imports
+# ----------------------------------------------------------------------------
+
+# These imports have the side-effect of performing toolkit selection
+
+_toolkit_imports = {
+    'Wizard': 'wizard',
+    'WizardPage': 'wizard_page',
+}
+
+# These are pyface.* imports that have selection as a side-effect
+_relative_imports = {
+    'ChainedWizard': "chained_wizard",
+}
+
+
+def __getattr__(name):
+    """Lazily load attributes with side-effects
+
+    In particular, lazily load toolkit backend names.  For efficiency, lazily
+    loaded objects are injected into the module namespace
+    """
+    # sentinel object for no result
+    not_found = object()
+    result = not_found
+
+    if name in _relative_imports:
+        from importlib import import_module
+        source = _relative_imports[name]
+        module = import_module(f"pyface.wizard.{source}")
+        result = getattr(module, name)
+
+    elif name in _toolkit_imports:
+        from pyface.toolkit import toolkit_object
+        source = _toolkit_imports[name]
+        result = toolkit_object(f"wizard.{source}:{name}")
+
+    if result is not_found:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    globals()[name] = result
+    return result
+
+
+# ----------------------------------------------------------------------------
+# Introspection support
+# ----------------------------------------------------------------------------
+
+# the list of available names we report for introspection purposes
+_extra_names = set(_toolkit_imports) | set(_relative_imports)
+
+
+def __dir__():
+    return sorted(set(globals()) | _extra_names)


### PR DESCRIPTION
This is uses module `__getattr__` and `__dir__` based on [PEP 562](https://peps.python.org/pep-0562/) which is available now we are dropping Python 3.6 support.

Basic strategy is to handle two classes of imports - those which come directly via the toolkit object, and those which are via an import relative to the api module.  This allows us to eventually deprecate and remove stub modules which do nothing more than import using the toolkit, but we don't do that in this PR.

We test by checking that every public attribute returned by `dir()` can be accessed.

Includes a few drive-by fixes to avoid toolkit selection where where possible.  The most significant is adding formal `Interface` classes for `ActionManager` and its subclasses (and using those on `ApplicationWindow`).  It also cleans up a deprecated trait on `ApplicationWindow`.
