### PR TITLE
Update Qt APIs to be more Qt5/Qt6-ish

### DIFF
--- a/pyface/qt/QtCore.py
+++ b/pyface/qt/QtCore.py
@@ -9,19 +9,7 @@
 # Thanks for using Enthought open source!
 from . import qt_api
 
-if qt_api == "pyqt":
-    from PyQt4.QtCore import *
-
-    from PyQt4.QtCore import pyqtProperty as Property
-    from PyQt4.QtCore import pyqtSignal as Signal
-    from PyQt4.QtCore import pyqtSlot as Slot
-    from PyQt4.Qt import QCoreApplication
-    from PyQt4.Qt import Qt
-
-    __version__ = QT_VERSION_STR
-    __version_info__ = tuple(map(int, QT_VERSION_STR.split(".")))
-
-elif qt_api == "pyqt5":
+if qt_api == "pyqt5":
     from PyQt5.QtCore import *
 
     from PyQt5.QtCore import pyqtProperty as Property

--- a/pyface/qt/QtGui.py
+++ b/pyface/qt/QtGui.py
@@ -9,17 +9,7 @@
 # Thanks for using Enthought open source!
 from . import qt_api
 
-if qt_api == "pyqt":
-    from PyQt4.Qt import QKeySequence, QTextCursor
-    from PyQt4.QtGui import *
-
-    # forward-compatible font weights
-    # see https://doc.qt.io/qt-5/qfont.html#Weight-enum
-    QFont.Weight.ExtraLight = 12
-    QFont.Weight.Medium = 57
-    QFont.Weight.ExtraBold = 81
-
-elif qt_api == "pyqt5":
+if qt_api == "pyqt5":
     from PyQt5.QtGui import *
     from PyQt5.QtWidgets import *
     from PyQt5.QtPrintSupport import *

--- a/pyface/qt/QtOpenGL.py
+++ b/pyface/qt/QtOpenGL.py
@@ -9,10 +9,7 @@
 # Thanks for using Enthought open source!
 from . import qt_api
 
-if qt_api == "pyqt":
-    from PyQt4.QtOpenGL import *
-
-elif qt_api == "pyqt5":
+if qt_api == "pyqt5":
     from PyQt5.QtOpenGL import *
     from PyQt5.QtWidgets import QOpenGLWidget
 

--- a/pyface/qt/QtOpenGLWidgets.py
+++ b/pyface/qt/QtOpenGLWidgets.py
@@ -10,13 +10,15 @@
 from . import qt_api
 
 if qt_api == "pyqt5":
-    from PyQt5.QtNetwork import *
+    from PyQt5.QtOpenGL import *
+    from PyQt5.QtWidgets import QOpenGLWidget
 
 elif qt_api == "pyqt6":
-    from PyQt6.QtNetwork import *
+    from PyQt6.QtOpenGLWidgets import *
 
 elif qt_api == "pyside6":
-    from PySide6.QtNetwork import *
+    from PySide6.QtOpenGLWidgets import *
 
 else:
-    from PySide2.QtNetwork import *
+    from PySide2.QtOpenGL import *
+    from PySide2.QtWidgets import QOpenGLWidget

--- a/pyface/qt/QtScript.py
+++ b/pyface/qt/QtScript.py
@@ -7,12 +7,8 @@
 # is also available online at http://www.enthought.com/licenses/BSD.txt
 #
 # Thanks for using Enthought open source!
-from . import qt_api
 
-if qt_api == "pyqt":
-    from PyQt4.QtScript import *
 
-else:
-    import warnings
+import warnings
 
-    warnings.warn(DeprecationWarning("QtScript is not supported in PyQt5/PySide2"))
+warnings.warn(DeprecationWarning("QtScript is not supported after Qt4"))

--- a/pyface/qt/QtSvg.py
+++ b/pyface/qt/QtSvg.py
@@ -9,17 +9,18 @@
 # Thanks for using Enthought open source!
 from . import qt_api
 
-if qt_api == "pyqt":
-    from PyQt4.QtSvg import *
-
-elif qt_api == "pyqt5":
+if qt_api == "pyqt5":
     from PyQt5.QtSvg import *
 
 elif qt_api == "pyqt6":
     from PyQt6.QtSvg import *
+    # Backwards compatibility imports
+    from PyQt6.QtSvgWidgets import *
 
 elif qt_api == "pyside6":
     from PySide6.QtSvg import *
+    # Backwards compatibility imports
+    from PySide6.QtSvgWidgets import *
 
 else:
     from PySide2.QtSvg import *

--- a/pyface/qt/QtSvgWidgets.py
+++ b/pyface/qt/QtSvgWidgets.py
@@ -10,13 +10,15 @@
 from . import qt_api
 
 if qt_api == "pyqt5":
-    from PyQt5.QtNetwork import *
+    # Forwards compatibility imports
+    from PyQt5.QtSvg import *
 
 elif qt_api == "pyqt6":
-    from PyQt6.QtNetwork import *
+    from PyQt6.QtSvgWidgets import *
 
 elif qt_api == "pyside6":
-    from PySide6.QtNetwork import *
+    from PySide6.QtSvgWidgets import *
 
 else:
-    from PySide2.QtNetwork import *
+    # Forwards compatibility imports
+    from PySide2.QtSvg import *

--- a/pyface/qt/QtTest.py
+++ b/pyface/qt/QtTest.py
@@ -9,10 +9,7 @@
 # Thanks for using Enthought open source!
 from . import qt_api
 
-if qt_api == "pyqt":
-    from PyQt4.QtTest import *
-
-elif qt_api == "pyqt5":
+if qt_api == "pyqt5":
     from PyQt5.QtTest import *
 
 elif qt_api == "pyqt6":

--- a/pyface/qt/QtWebKit.py
+++ b/pyface/qt/QtWebKit.py
@@ -9,10 +9,7 @@
 # Thanks for using Enthought open source!
 from . import qt_api
 
-if qt_api == "pyqt":
-    from PyQt4.QtWebKit import *
-
-elif qt_api == "pyqt5":
+if qt_api == "pyqt5":
     from PyQt5.QtWidgets import *
 
     try:

--- a/pyface/qt/QtWidgets.py
+++ b/pyface/qt/QtWidgets.py
@@ -10,13 +10,13 @@
 from . import qt_api
 
 if qt_api == "pyqt5":
-    from PyQt5.QtNetwork import *
+    from PyQt5.QtWidgets import *
 
 elif qt_api == "pyqt6":
-    from PyQt6.QtNetwork import *
+    from PyQt6.QtWidgets import *
 
 elif qt_api == "pyside6":
-    from PySide6.QtNetwork import *
+    from PySide6.QtWidgets import *
 
 else:
-    from PySide2.QtNetwork import *
+    from PySide2.QtWidgets import *

--- a/pyface/qt/__init__.py
+++ b/pyface/qt/__init__.py
@@ -18,7 +18,6 @@ QtAPIs = [
     ("pyside6", "PySide6"),
     ("pyqt5", "PyQt5"),
     ("pyqt6", "PyQt6"),
-    ("pyqt", "PyQt4"),
 ]
 api_names, modules = zip(*QtAPIs)
 
@@ -56,7 +55,7 @@ elif qt_api not in api_names:
     raise RuntimeError(msg)
 
 # useful constants
-is_qt4 = qt_api in {"pyqt"}
+is_qt4 = False
 is_qt5 = qt_api in {"pyqt5", "pyside2"}
 is_qt6 = qt_api in {"pyqt6", "pyside6"}
 is_pyqt = qt_api in {"pyqt", "pyqt5", "pyqt6"}

--- a/pyface/ui/qt/code_editor/code_widget.py
+++ b/pyface/ui/qt/code_editor/code_widget.py
@@ -844,14 +844,6 @@ class AdvancedCodeWidget(QtGui.QWidget):
 
 if __name__ == "__main__":
 
-    def set_trace():
-        from PyQt4.QtCore import pyqtRemoveInputHook
-
-        pyqtRemoveInputHook()
-        import pdb
-
-        pdb.Pdb().set_trace(sys._getframe().f_back)
-
     app = QtGui.QApplication(sys.argv)
     window = AdvancedCodeWidget(None)
 

--- a/pyface/ui/qt/data_view/data_view_widget.py
+++ b/pyface/ui/qt/data_view/data_view_widget.py
@@ -12,10 +12,10 @@ import logging
 
 from traits.api import Callable, Enum, Instance, observe, provides
 
-from pyface.qt.QtCore import QAbstractItemModel
-from pyface.qt.QtGui import (
-    QAbstractItemView, QItemSelection, QItemSelectionModel, QTreeView
+from pyface.qt.QtCore import (
+    QAbstractItemModel, QItemSelection, QItemSelectionModel
 )
+from pyface.qt.QtGui import QAbstractItemView, QTreeView
 from pyface.data_view.i_data_view_widget import (
     IDataViewWidget, MDataViewWidget
 )

--- a/pyface/ui/qt/tests/test_qt_imports.py
+++ b/pyface/ui/qt/tests/test_qt_imports.py
@@ -21,10 +21,13 @@ class TestPyfaceQtImports(unittest.TestCase):
         import pyface.qt.QtGui  # noqa: F401
         import pyface.qt.QtNetwork  # noqa: F401
         import pyface.qt.QtOpenGL  # noqa: F401
+        import pyface.qt.QtOpenGLWidgets  # noqa: F401
         import pyface.qt.QtSvg  # noqa: F401
+        import pyface.qt.QtSvgWidgets  # noqa: F401
         import pyface.qt.QtTest  # noqa: F401
         import pyface.qt.QtMultimedia  # noqa: F401
         import pyface.qt.QtMultimediaWidgets  # noqa: F401
+        import pyface.qt.QtWidgets  # noqa: F401
 
     @unittest.skipIf(sys.version_info > (3, 6), "WebKit is not available")
     def test_import_web_kit(self):

--- a/pyface/ui/qt/workbench/split_tab_widget.py
+++ b/pyface/ui/qt/workbench/split_tab_widget.py
@@ -19,8 +19,7 @@
 import sys
 import warnings
 
-
-from pyface.qt import QtCore, QtGui, qt_api
+from pyface.qt import QtCore, QtGui
 
 from pyface.image_resource import ImageResource
 

--- a/pyface/ui/qt/workbench/split_tab_widget.py
+++ b/pyface/ui/qt/workbench/split_tab_widget.py
@@ -300,15 +300,6 @@ class SplitTabWidget(QtGui.QSplitter):
     def _focus_changed(self, old, new):
         """ Handle a change in focus that affects the current tab. """
 
-        # It is possible for the C++ layer of this object to be deleted between
-        # the time when the focus change signal is emitted and time when the
-        # slots are dispatched by the Qt event loop. This may be a bug in PyQt4.
-        if qt_api == "pyqt":
-            import sip
-
-            if sip.isdeleted(self):
-                return
-
         if self._repeat_focus_changes:
             self.focus_changed.emit(old, new)
 


### PR DESCRIPTION
In particular this includes:
- removing PyQt4 support (PySide is long-gone), but this means no more Qt4 (Fixes #510)
- `QtSvgWidgets`, and backwards compatibility imports in QtSvg on Qt6 platforms (Fixes #1235)
- `QtWidgets` is now available, and we should probably shift imports there instead of QtGui over time (but not in this PR) (work towards #1052)

