### PR TITLE
Import optional imports from relative module rather than toolkit

### DIFF
--- a/.github/actions/install-qt-support/action.yml
+++ b/.github/actions/install-qt-support/action.yml
@@ -20,6 +20,7 @@ runs:
       sudo apt-get install libxcb-render-util0
       sudo apt-get install libxcb-xinerama0
       sudo apt-get install libxcb-shape0
+      sudo apt-get install libxcb-cursor0
       sudo apt-get install pulseaudio
       sudo apt-get install libpulse-mainloop-glib0
       # Needed to work around https://bugreports.qt.io/browse/PYSIDE-1547

--- a/etstool.py
+++ b/etstool.py
@@ -95,7 +95,6 @@ dependencies = {
     "importlib_resources>=1.1.0",
     "traits" + TRAITS_VERSION_REQUIRES,
     "traitsui",
-    "numpy",
     "pygments",
     "coverage",
     "flake8",
@@ -112,8 +111,10 @@ if sys.platform == "darwin":
     )
     if b'AVX2' in result.stdout.split():
         dependencies.add('pillow_simd')
+        dependencies.add('numpy')
 else:
     dependencies.add('pillow_simd')
+    dependencies.add('numpy')
 
 
 source_dependencies = {

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -268,7 +268,8 @@ def __getattr__(name):
             msg=f"{name} is not available due to missing {dependency}.",
             logger=logging.getLogger(__name__),
         ):
-            result = toolkit_object(f"{source}:{name}")
+            module = import_module(f"pyface.{source}")
+            result = getattr(module, name)
 
     if result is not_found:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/pyface/api.py
+++ b/pyface/api.py
@@ -259,8 +259,8 @@ def __getattr__(name):
         result = toolkit_object(f"{source}:{name}")
 
     elif name in _optional_imports:
+        from importlib import import_module
         import logging
-        from pyface.toolkit import toolkit_object
         from pyface.util._optional_dependencies import optional_import
         dependency, source = _optional_imports[name]
         with optional_import(

--- a/pyface/tests/test_api.py
+++ b/pyface/tests/test_api.py
@@ -33,7 +33,7 @@ class TestApi(unittest.TestCase):
         attrs = [
             name
             for name in dir(api)
-            if not name.startswith('_') or name in api._optional_imports
+            if not (name.startswith('_') or name in api._optional_imports)
         ]
         for attr in attrs:
             with self.subTest(attr=attr):

--- a/pyface/tests/test_array_image.py
+++ b/pyface/tests/test_array_image.py
@@ -13,7 +13,8 @@ import unittest
 
 from traits.testing.optional_dependencies import numpy as np, requires_numpy
 
-from ..array_image import ArrayImage
+if np is not None:
+    from ..array_image import ArrayImage
 
 
 @requires_numpy


### PR DESCRIPTION
This fixes an issue seen in TraitsUI bleeding-edge tests.