### PR TITLE
Update the upload-artifact version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/test-docs-with-edm.yml
+++ b/.github/workflows/test-docs-with-edm.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build docs
         run: xvfb-run -a edm run -- python etstool.py docs --toolkit=${{ matrix.toolkit }}
       - name: Archive HTML docs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: html-doc-bundle
           path: docs/build/html


### PR DESCRIPTION
This PR updates the GitHub Actions upload-artifact action used in the documentation build workflow from v3 to v4. This should get the documentation build running again.

I've also added a dependabot config, to help us keep actions up to date where necessary.