### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = 'pyface'
 description = 'Traits-capable windowing framework'
 readme = 'README.rst'
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 authors = [{name='Enthought', email='info@enthought.com'}]
 keywords = ['gui', 'traits', 'traitsui', 'pyqt', 'pyside', 'wxpython']
 classifiers = [


### PR DESCRIPTION
This PR drops support for Python 3.7, which is increasingly beyond end-of-life (as-is Python 3.8), and increasingly hard to test on. Pyface now requires Python >= 3.8.