### PR TITLE
Skip PILImage tests on Qt5

### DIFF
--- a/pyface/tests/test_pil_image.py
+++ b/pyface/tests/test_pil_image.py
@@ -19,7 +19,14 @@ try:
 except ImportError:
     from importlib_resources import as_file, files
 
+from pyface.toolkit import toolkit
 from pyface.util._optional_dependencies import optional_import
+
+if toolkit.toolkit in {"qt", "qt4"}:
+    from pyface.qt import is_qt5
+else:
+    is_qt5 = False
+
 
 Image = None
 
@@ -35,6 +42,7 @@ image_source = files("pyface.tests") / "images" / "core.png"
 
 
 @unittest.skipIf(Image is None, "Pillow not available")
+@unittest.skipIf(is_qt5, "PIL.ImageQt does not support Qt 5")
 class TestPILImage(unittest.TestCase):
 
     def test_create_image(self):


### PR DESCRIPTION
PIL removed support for Qt 5 in https://github.com/python-pillow/Pillow/pull/8159. This PR skips the `TestPILImage` tests on Qt 5.

Related: https://github.com/enthought/pyface/issues/1255