### PR TITLE
Don't test with PySide2 and Apple Silicon

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,8 @@ jobs:
         exclude:
           - python-version: '3.11'
             qt-api: 'pyside2'
+          - os: macos-latest
+            qt-api: 'pyside2'
       fail-fast: false
 
     env:


### PR DESCRIPTION
The PySide2 wheels available on PyPI do not support Apple Silicon, so now that the `macos-latest` GitHub runner is Apple Silicon-based, we need to exclude the `macos-latest` / `pyside2` combination from our test workflow.