### PR TITLE
Update EDM version used in test workflows

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -36,7 +36,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v4
+        uses: enthought/setup-edm-action@v4.1
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment

--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  INSTALL_EDM_VERSION: 3.5.0
+  INSTALL_EDM_VERSION: 4.1.1
   QT_MAC_WANTS_LAYER: 1
 
 jobs:

--- a/.github/workflows/test-docs-with-edm.yml
+++ b/.github/workflows/test-docs-with-edm.yml
@@ -7,7 +7,7 @@ name: Build docs with EDM
 on: [pull_request, workflow_dispatch]
 
 env:
-  INSTALL_EDM_VERSION: 3.5.0
+  INSTALL_EDM_VERSION: 4.1.1
   QT_MAC_WANTS_LAYER: 1
 
 jobs:

--- a/.github/workflows/test-docs-with-edm.yml
+++ b/.github/workflows/test-docs-with-edm.yml
@@ -38,7 +38,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v4
+        uses: enthought/setup-edm-action@v4.1
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment
@@ -48,7 +48,7 @@ jobs:
       - name: Build docs
         run: xvfb-run -a edm run -- python etstool.py docs --toolkit=${{ matrix.toolkit }}
       - name: Archive HTML docs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.1
         with:
           name: html-doc-bundle
           path: docs/build/html

--- a/.github/workflows/test-docs-with-edm.yml
+++ b/.github/workflows/test-docs-with-edm.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build docs
         run: xvfb-run -a edm run -- python etstool.py docs --toolkit=${{ matrix.toolkit }}
       - name: Archive HTML docs
-        uses: actions/upload-artifact@v4.1
+        uses: actions/upload-artifact@v4
         with:
           name: html-doc-bundle
           path: docs/build/html

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -38,7 +38,7 @@ jobs:
           path: ~/.cache
           key: ${{ runner.os }}-${{ matrix.toolkit }}-${{ hashFiles('etstool.py') }}
       - name: Setup EDM
-        uses: enthought/setup-edm-action@v4
+        uses: enthought/setup-edm-action@v4.1
         with:
           edm-version: ${{ env.INSTALL_EDM_VERSION }}
       - name: Install click to the default EDM environment

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -7,7 +7,7 @@ name: Test with EDM
 on: pull_request
 
 env:
-  INSTALL_EDM_VERSION: 3.5.0
+  INSTALL_EDM_VERSION: 4.1.1
   QT_MAC_WANTS_LAYER: 1
 
 jobs:

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -16,9 +16,7 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        # Note: MacOS support is contingent on not hitting any issues with
-        # unsupported CPU features such as AVX2 and so may be unstable.
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         toolkit: ['pyside6']
       fail-fast: false
     timeout-minutes: 20  # should be plenty, it's usually < 5


### PR DESCRIPTION
This PR updates the EDM version used in test workflows to the most recent version, EDM 4.1.1.

It also updates the `setup-edm-action` to `v4.1`: the `v4` version doesn't know about the new URLs for recent EDMs.

Finally, we also remove `macos-latest` from the test matrix, since we don't currently have all the necessary EDM packages available on Apple Silicon (and the current workflow is only working with Python 3.8, where an Apple Silicon runtime won't be available).
