### PR TITLE
Remove macos-latest from ets-from-source workflow

### DIFF
--- a/.github/workflows/ets-from-source.yml
+++ b/.github/workflows/ets-from-source.yml
@@ -16,15 +16,11 @@ jobs:
   test-with-edm:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
         toolkit: ['pyside6']
+        runtime: ['3.8']
+    timeout-minutes: 20
     runs-on: ${{ matrix.os }}
-    env:
-      # Set root directory, mainly for Windows, so that the EDM Python
-      # environment lives in the same drive as the cloned source. Otherwise
-      # 'pip install' raises an error while trying to compute
-      # relative path between the site-packages and the source directory.
-      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
     steps:
       - uses: actions/checkout@v4
       - name: Install Qt dependencies
@@ -42,7 +38,7 @@ jobs:
       - name: Install click to the default EDM environment
         run: edm install -y wheel click coverage
       - name: Install test environment
-        run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }} --source
+        run: edm run -- python etstool.py install --toolkit=${{ matrix.toolkit }} --runtime=${{ matrix.runtime }} --source
       - name: Run tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: xvfb-run -a edm run -- python etstool.py test --toolkit=${{ matrix.toolkit }}

--- a/.github/workflows/run-style-checks.yml
+++ b/.github/workflows/run-style-checks.yml
@@ -1,7 +1,6 @@
 name: Style check
 
-on:
-  pull_request
+on: [pull_request, workflow_dispatch]
 
 jobs:
   style:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,6 @@ jobs:
             qt-api: 'pyside2'
           - os: macos-latest
             qt-api: 'pyside2'
-      fail-fast: false
 
     env:
       ETS_TOOLKIT: qt
@@ -53,7 +52,6 @@ jobs:
       matrix:
         os: [windows-latest]
         python-version: ['3.8', '3.10']
-      fail-fast: false
 
     env:
       ETS_TOOLKIT: wx

--- a/.github/workflows/test-docs-with-edm.yml
+++ b/.github/workflows/test-docs-with-edm.yml
@@ -18,15 +18,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         toolkit: ['pyside6']
-      fail-fast: false
     timeout-minutes: 20  # should be plenty, it's usually < 5
     runs-on: ${{ matrix.os }}
-    env:
-      # Set root directory, mainly for Windows, so that the EDM Python
-      # environment lives in the same drive as the cloned source. Otherwise
-      # 'pip install' raises an error while trying to compute
-      # relative path between the site-packages and the source directory.
-      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
     steps:
       - uses: actions/checkout@v4
       - name: Install Qt dependencies

--- a/.github/workflows/test-with-edm.yml
+++ b/.github/workflows/test-with-edm.yml
@@ -4,7 +4,7 @@
 
 name: Test with EDM
 
-on: pull_request
+on: [pull_request, workflow_dispatch]
 
 env:
   INSTALL_EDM_VERSION: 4.1.1
@@ -19,15 +19,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         toolkit: ['pyside6']
         runtime: ['3.8']
-      fail-fast: false
     timeout-minutes: 20  # should be plenty, it's usually < 5
     runs-on: ${{ matrix.os }}
-    env:
-      # Set root directory, mainly for Windows, so that the EDM Python
-      # environment lives in the same drive as the cloned source. Otherwise
-      # 'pip install' raises an error while trying to compute
-      # relative path between the site-packages and the source directory.
-      EDM_ROOT_DIRECTORY: ${{ github.workspace }}/.edm
     steps:
       - uses: actions/checkout@v4
       - name: Install Qt dependencies


### PR DESCRIPTION
Our `ets-from-source` workflow is currently failing, for the simple and shallow reason that we're not currently in a position to run EDM-based tests on macOS/ARM (missing runtime for Python 3.8; missing dependencies for Python 3.11). This PR removes `macos-latest` from the test matrix, and makes a couple of other drive-by cleanups.